### PR TITLE
ci: auto-regenerate manifest.json on main branch pushes

### DIFF
--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -1,0 +1,49 @@
+name: Update Manifest
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  update-manifest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      
+      - name: Install dependencies
+        run: bun install
+      
+      - name: Validate skills
+        run: bun validate
+      
+      - name: Regenerate manifest
+        run: bun manifest
+      
+      - name: Check for changes
+        id: check
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Commit and push changes
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add manifest.json
+          git commit -m "chore: regenerate manifest.json [skip ci]"
+          git push


### PR DESCRIPTION
## What this does

Adds a GitHub Actions workflow that automatically regenerates 

manifest.json whenever changes are pushed to the main branch.

## Why

Contributors running 

bun manifest

 from their forks get 

tarball_url

 and 

archive_root

 pointing to their fork, not the upstream repo. This workflow ensures the manifest always uses the correct zocomputer/skills URLs.

## How it works

1. Runs on every push to 

main

 (or manual trigger)
2. Validates all skills with 

bun validate

3. Regenerates manifest with 

bun manifest

4. Auto-commits and pushes changes if the manifest changed

## Future contributor workflow

Contributors should:
- Add their skill folder and 

SKILL.md

- NOT commit 

manifest.json

 changes (or CI will fix it anyway)

The workflow handles the manifest generation post-merge.