### PR TITLE
Add zo-ladder skill to Community

### DIFF
--- a/Community/zo-ladder/SKILL.md
+++ b/Community/zo-ladder/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: zo-ladder
+description: Send an article URL and get a clean, paywall-free version saved as a markdown document. Works with major news sites and publications by using text extraction services and browser automation.
+compatibility: Created for Zo Computer
+metadata:
+  author: mxgrauer.zo.computer
+  category: Community
+  display-name: Zo Ladder
+  emoji: 🪜
+allowed-tools: read_webpage web_search
+---
+# Unlock Article
+
+This skill fetches articles from paywalled websites and saves them as clean markdown documents.
+
+## Quick Start
+
+To unlock an article, simply provide a URL:
+
+```
+https://www.nytimes.com/2024/01/15/technology/example-article.html
+```
+
+Or ask me to:
+- "Unlock this article: <URL>"
+- "Remove the paywall from <URL>"
+- "Get me the full text of <URL>"
+- "Save this article: <URL>"
+
+## How it Works
+
+The skill tries multiple methods to retrieve the full article:
+
+1. **Text extraction services** - Uses jina.ai and other services to extract article text directly, preserving structure.
+2. **Browser automation** - Falls back to agent-browser to render pages and extract content, preserving structure.
+3. **Content cleaning** - Removes ads, navigation, and formatting to produce clean markdown.
+4. **Media normalization** - Normalizes media (images, videos) and captions in markdown.
+
+## Supported Sites
+
+This works with most publications including:
+- New York Times
+- Washington Post
+- Wall Street Journal
+- The Atlantic
+- Wired
+- Medium (member-only stories)
+- Substack
+- Bloomberg
+- Financial Times (partial)
+- And many more
+
+## Output Location
+
+Articles are saved to `Articles/<domain>/<article-title>.md`
+
+Each file includes:
+- Original URL for reference
+- Date saved
+- Clean article text
+- Source attribution
+- Subheadings
+- Article images
+- Image captions
+
+## Limitations
+
+- Some hard paywalls (especially those requiring login) cannot be bypassed
+- Content may be truncated if the site uses JavaScript-heavy paywalls
+- Image/caption availability depends on source extraction quality
+
+## Extraction Requirements
+
+- preserve heading hierarchy (H1/H2/H3)
+- include inline markdown images when source URLs are available
+- include captions directly beneath images when available
+- do not drop subheadings even if body text is partially missing
+
+## Manual Usage
+
+You can also run the script directly:
+
+```bash
+bun run /home/workspace/Skills/zo-ladder/scripts/unlock.ts <url>
+```
+
+Optional: specify output directory:
+```bash
+bun run /home/workspace/Skills/zo-ladder/scripts/unlock.ts <url> /custom/output/path
+```

--- a/Community/zo-ladder/scripts/.gitignore
+++ b/Community/zo-ladder/scripts/.gitignore
@@ -1,0 +1,34 @@
+# dependencies (bun install)
+node_modules
+
+# output
+out
+dist
+*.tgz
+
+# code coverage
+coverage
+*.lcov
+
+# logs
+logs
+_.log
+report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# caches
+.eslintcache
+.cache
+*.tsbuildinfo
+
+# IntelliJ based IDEs
+.idea
+
+# Finder (MacOS) folder config
+.DS_Store

--- a/Community/zo-ladder/scripts/CLAUDE.md
+++ b/Community/zo-ladder/scripts/CLAUDE.md
@@ -1,0 +1,106 @@
+
+Default to using Bun instead of Node.js.
+
+- Use `bun <file>` instead of `node <file>` or `ts-node <file>`
+- Use `bun test` instead of `jest` or `vitest`
+- Use `bun build <file.html|file.ts|file.css>` instead of `webpack` or `esbuild`
+- Use `bun install` instead of `npm install` or `yarn install` or `pnpm install`
+- Use `bun run <script>` instead of `npm run <script>` or `yarn run <script>` or `pnpm run <script>`
+- Bun automatically loads .env, so don't use dotenv.
+
+## APIs
+
+- `Bun.serve()` supports WebSockets, HTTPS, and routes. Don't use `express`.
+- `bun:sqlite` for SQLite. Don't use `better-sqlite3`.
+- `Bun.redis` for Redis. Don't use `ioredis`.
+- `Bun.sql` for Postgres. Don't use `pg` or `postgres.js`.
+- `WebSocket` is built-in. Don't use `ws`.
+- Prefer `Bun.file` over `node:fs`'s readFile/writeFile
+- Bun.$`ls` instead of execa.
+
+## Testing
+
+Use `bun test` to run tests.
+
+```ts#index.test.ts
+import { test, expect } from "bun:test";
+
+test("hello world", () => {
+  expect(1).toBe(1);
+});
+```
+
+## Frontend
+
+Use HTML imports with `Bun.serve()`. Don't use `vite`. HTML imports fully support React, CSS, Tailwind.
+
+Server:
+
+```ts#index.ts
+import index from "./index.html"
+
+Bun.serve({
+  routes: {
+    "/": index,
+    "/api/users/:id": {
+      GET: (req) => {
+        return new Response(JSON.stringify({ id: req.params.id }));
+      },
+    },
+  },
+  // optional websocket support
+  websocket: {
+    open: (ws) => {
+      ws.send("Hello, world!");
+    },
+    message: (ws, message) => {
+      ws.send(message);
+    },
+    close: (ws) => {
+      // handle close
+    }
+  },
+  development: {
+    hmr: true,
+    console: true,
+  }
+})
+```
+
+HTML files can import .tsx, .jsx or .js files directly and Bun's bundler will transpile & bundle automatically. `<link>` tags can point to stylesheets and Bun's CSS bundler will bundle.
+
+```html#index.html
+<html>
+  <body>
+    <h1>Hello, world!</h1>
+    <script type="module" src="./frontend.tsx"></script>
+  </body>
+</html>
+```
+
+With the following `frontend.tsx`:
+
+```tsx#frontend.tsx
+import React from "react";
+
+// import .css files directly and it works
+import './index.css';
+
+import { createRoot } from "react-dom/client";
+
+const root = createRoot(document.body);
+
+export default function Frontend() {
+  return <h1>Hello, world!</h1>;
+}
+
+root.render(<Frontend />);
+```
+
+Then, run index.ts
+
+```sh
+bun --hot ./index.ts
+```
+
+For more information, read the Bun API docs in `node_modules/bun-types/docs/**.md`.

--- a/Community/zo-ladder/scripts/README.md
+++ b/Community/zo-ladder/scripts/README.md
@@ -1,0 +1,15 @@
+# scripts
+
+To install dependencies:
+
+```bash
+bun install
+```
+
+To run:
+
+```bash
+bun run 
+```
+
+This project was created using `bun init` in bun v1.2.21. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.

--- a/Community/zo-ladder/scripts/bun.lock
+++ b/Community/zo-ladder/scripts/bun.lock
@@ -1,0 +1,25 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "scripts",
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
+    "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+  }
+}

--- a/Community/zo-ladder/scripts/package.json
+++ b/Community/zo-ladder/scripts/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "scripts",
+  "private": true,
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/Community/zo-ladder/scripts/tsconfig.json
+++ b/Community/zo-ladder/scripts/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}

--- a/Community/zo-ladder/scripts/unlock.py
+++ b/Community/zo-ladder/scripts/unlock.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+Unlock Article - Paywall Bypass Tool
+Fetches articles from paywalled sites and saves clean markdown.
+"""
+
+import argparse
+import os
+import re
+import sys
+import time
+import urllib.parse
+from pathlib import Path
+from urllib.parse import urlparse
+
+import requests
+from readability import Document
+
+
+def extract_domain(url):
+    """Extract clean domain name from URL."""
+    parsed = urlparse(url)
+    domain = parsed.netloc.replace("www.", "").replace(".", "-")
+    return domain
+
+
+def extract_title_from_url(url):
+    """Create a filename-friendly title from URL."""
+    parsed = urlparse(url)
+    path = parsed.path.strip("/")
+    if path:
+        # Get the last meaningful part of the path
+        parts = [p for p in path.split("/") if p and not p.isdigit()]
+        if parts:
+            # Limit length and clean up
+            title = parts[-1].replace("-", " ").replace("_", " ")[:50]
+            return re.sub(r'[^\w\s-]', '', title).strip()
+    return "article"
+
+
+def try_archive_today(url):
+    """Try to get article via archive.today."""
+    try:
+        encoded_url = urllib.parse.quote(url, safe="")
+        submit_url = f"https://archive.today/submit/?url={encoded_url}"
+        
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+        }
+        
+        # Submit URL to archive.today
+        resp = requests.get(submit_url, headers=headers, allow_redirects=True, timeout=30)
+        
+        if resp.status_code == 200:
+            # Return the archived page URL
+            return resp.url
+        return None
+    except Exception as e:
+        print(f"Archive.today error: {e}", file=sys.stderr)
+        return None
+
+
+def try_archive_org(url):
+    """Try to get article via archive.org Wayback Machine."""
+    try:
+        # First check if there's a snapshot
+        check_url = f"https://archive.org/wayback/available?url={urllib.parse.quote(url)}"
+        resp = requests.get(check_url, timeout=10)
+        
+        if resp.status_code == 200:
+            data = resp.json()
+            if data.get("archived_snapshots"):
+                snapshot = data["archived_snapshots"].get("closest")
+                if snapshot and snapshot.get("available"):
+                    return snapshot.get("url")
+        
+        # If no snapshot, try to save it
+        save_url = f"https://web.archive.org/save/{url}"
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+        }
+        resp = requests.get(save_url, headers=headers, allow_redirects=True, timeout=60)
+        
+        if resp.status_code == 200:
+            return resp.url
+        return None
+    except Exception as e:
+        print(f"Archive.org error: {e}", file=sys.stderr)
+        return None
+
+
+def try_textise_dot_iitty(url):
+    """Try textise dot iitty service."""
+    try:
+        api_url = f"https://r.jina.ai/http://r.jina.ai/http://cc.bingj.com/cache.aspx?d=503-3904-1769&u={urllib.parse.quote(url)}"
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+        }
+        
+        resp = requests.get(api_url, headers=headers, timeout=30)
+        if resp.status_code == 200 and len(resp.text) > 500:
+            return resp.text
+        return None
+    except Exception as e:
+        print(f"Textise error: {e}", file=sys.stderr)
+        return None
+
+
+def try_12ft_ladder(url):
+    """Try 12ft.io ladder service."""
+    try:
+        ladder_url = f"https://12ft.io/{url}"
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+        }
+        
+        resp = requests.get(ladder_url, headers=headers, timeout=30)
+        if resp.status_code == 200 and len(resp.text) > 500:
+            return resp.text
+        return None
+    except Exception as e:
+        print(f"12ft.io error: {e}", file=sys.stderr)
+        return None
+
+
+def extract_article_content(html, url):
+    """Extract readable article content from HTML."""
+    try:
+        doc = Document(html)
+        title = doc.title()
+        content = doc.summary()
+        
+        # Clean up the content
+        # Remove script and style tags
+        import re
+        content = re.sub(r'<script[^>]*>.*?</script>', '', content, flags=re.DOTALL)
+        content = re.sub(r'<style[^>]*>.*?</style>', '', content, flags=re.DOTALL)
+        
+        # Convert to markdown-like format
+        content = re.sub(r'<h1[^>]*>(.*?)</h1>', r'\n# \1\n', content, flags=re.DOTALL)
+        content = re.sub(r'<h2[^>]*>(.*?)</h2>', r'\n## \1\n', content, flags=re.DOTALL)
+        content = re.sub(r'<h3[^>]*>(.*?)</h3>', r'\n### \1\n', content, flags=re.DOTALL)
+        content = re.sub(r'<p[^>]*>(.*?)</p>', r'\n\1\n', content, flags=re.DOTALL)
+        content = re.sub(r'<li[^>]*>(.*?)</li>', r'- \1\n', content, flags=re.DOTALL)
+        content = re.sub(r'<br\s*/?>', '\n', content)
+        content = re.sub(r'<[^>]+>', '', content)
+        
+        # Clean up whitespace
+        content = re.sub(r'\n{3,}', '\n\n', content)
+        
+        return title, content.strip()
+    except Exception as e:
+        print(f"Content extraction error: {e}", file=sys.stderr)
+        return None, None
+
+
+def save_article(title, content, url, output_dir):
+    """Save article as markdown file."""
+    domain = extract_domain(url)
+    safe_title = re.sub(r'[^\w\s-]', '', title)[:60] if title else extract_title_from_url(url)
+    safe_title = re.sub(r'\s+', '_', safe_title)
+    
+    # Create output directory
+    article_dir = Path(output_dir) / domain
+    article_dir.mkdir(parents=True, exist_ok=True)
+    
+    # Generate filename with timestamp to avoid collisions
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    filename = f"{safe_title}_{timestamp}.md"
+    filepath = article_dir / filename
+    
+    # Create markdown content
+    markdown = f"""---
+title: {title or 'Untitled Article'}
+source_url: {url}
+date_saved: {time.strftime("%Y-%m-%d %H:%M:%S")}
+---
+
+# {title or 'Untitled Article'}
+
+*Source: [{url}]({url})*
+
+---
+
+{content}
+"""
+    
+    with open(filepath, 'w', encoding='utf-8') as f:
+        f.write(markdown)
+    
+    return filepath
+
+
+def unlock_article(url, output_dir="/home/workspace/Articles"):
+    """Main function to unlock and save an article."""
+    print(f"Unlocking: {url}")
+    
+    html = None
+    source = None
+    
+    # Try multiple methods
+    methods = [
+        ("12ft.io", try_12ft_ladder),
+        ("archive.today", try_archive_today),
+        ("archive.org", try_archive_org),
+        ("textise service", try_textise_dot_iitty),
+    ]
+    
+    for method_name, method_func in methods:
+        print(f"  Trying {method_name}...")
+        try:
+            result = method_func(url)
+            if result:
+                if result.startswith("http"):
+                    # It's a URL, fetch the content
+                    headers = {"User-Agent": "Mozilla/5.0"}
+                    resp = requests.get(result, headers=headers, timeout=30)
+                    if resp.status_code == 200:
+                        html = resp.text
+                        source = method_name
+                        break
+                else:
+                    # It's already HTML content
+                    html = result
+                    source = method_name
+                    break
+        except Exception as e:
+            print(f"    {method_name} failed: {e}")
+            continue
+    
+    if not html:
+        print("ERROR: Could not bypass paywall with available methods.")
+        print("This article may have a hard paywall or require authentication.")
+        return None
+    
+    print(f"  Success! Retrieved via {source}")
+    
+    # Extract article content
+    title, content = extract_article_content(html, url)
+    
+    if not content or len(content) < 200:
+        print("WARNING: Extracted content is very short. The article may be truncated.")
+    
+    # Save the article
+    filepath = save_article(title, content, url, output_dir)
+    print(f"\nSaved to: {filepath}")
+    print(f"Title: {title or 'Untitled'}")
+    print(f"Content length: {len(content)} characters")
+    
+    return filepath
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Unlock paywalled articles and save as markdown"
+    )
+    parser.add_argument("url", help="Article URL to unlock")
+    parser.add_argument(
+        "--output", "-o",
+        default="/home/workspace/Articles",
+        help="Output directory (default: /home/workspace/Articles)"
+    )
+    
+    args = parser.parse_args()
+    
+    result = unlock_article(args.url, args.output)
+    sys.exit(0 if result else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Community/zo-ladder/scripts/unlock.ts
+++ b/Community/zo-ladder/scripts/unlock.ts
@@ -1,0 +1,267 @@
+#!/usr/bin/env bun
+/**
+ * Unlock Article - Paywall Bypass Tool
+ * Uses agent-browser for better paywall bypass capabilities
+ */
+
+import { $ } from "bun";
+
+interface ArticleResult {
+  success: boolean;
+  filepath?: string;
+  title?: string;
+  error?: string;
+}
+
+function extractDomain(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.replace(/^www\./, "").replace(/\./g, "-");
+  } catch {
+    return "unknown";
+  }
+}
+
+function sanitizeFilename(title: string): string {
+  return title
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "_")
+    .slice(0, 60);
+}
+
+async function tryArchiveServices(url: string): Promise<string | null> {
+  const services = [
+    `https://r.jina.ai/http://${url}`,
+    `https://r.jina.ai/http://cc.bingj.com/cache.aspx?d=503-3904-1769&u=${encodeURIComponent(url)}`,
+  ];
+
+  for (const serviceUrl of services) {
+    try {
+      const response = await fetch(serviceUrl, {
+        headers: {
+          "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+        },
+      });
+
+      if (response.ok) {
+        const text = await response.text();
+        if (text.length > 500) {
+          return text;
+        }
+      }
+    } catch (e) {
+      // Continue to next service
+    }
+  }
+
+  return null;
+}
+
+async function tryAgentBrowser(url: string): Promise<string | null> {
+  try {
+    // Use agent-browser to render the page fully
+    const result = await $`agent-browser page ${url} --format markdown --wait 3000`.text();
+    
+    if (result.includes("security verification") || result.includes("CAPTCHA") || result.includes("bot")) {
+      return null;
+    }
+    
+    return result.length > 500 ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+async function tryZoReadWebpage(url: string): Promise<string | null> {
+  try {
+    // Try using read_webpage via Zo API
+    const response = await fetch("https://api.zo.computer/zo/ask", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${process.env.ZO_CLIENT_IDENTITY_TOKEN || ""}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        input: `Read and extract the full article content from this URL: ${url}\n\nReturn the article title and full text content as markdown. If there's a paywall, try to bypass it using archive services or any available method.`,
+      }),
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      return data.output;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function extractWithReadability(html: string, url: string): Promise<{ title: string; content: string } | null> {
+  try {
+    // Use Mozilla's Readability via a simple extraction
+    const titleMatch = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+    const title = titleMatch?.[1]?.trim() || "Untitled Article";
+
+    // Basic content extraction - look for article content
+    let content = html;
+
+    // Remove script and style tags
+    content = content.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "");
+    content = content.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "");
+
+    // Look for article or main content
+    const articleMatch = content.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
+    const mainMatch = content.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
+    const contentMatch = content.match(/<div[^>]*class=["'][^"']*(?:content|article|post)[^"']*["'][^>]*>([\s\S]*?)<\/div>/i);
+
+    let extractedContent = articleMatch?.[1] || mainMatch?.[1] || contentMatch?.[1] || content;
+
+    // Convert to markdown
+    extractedContent = extractedContent
+      .replace(/<h1[^>]*>([\s\S]*?)<\/h1>/gi, "\n# $1\n")
+      .replace(/<h2[^>]*>([\s\S]*?)<\/h2>/gi, "\n## $1\n")
+      .replace(/<h3[^>]*>([\s\S]*?)<\/h3>/gi, "\n### $1\n")
+      .replace(/<p[^>]*>([\s\S]*?)<\/p>/gi, "\n$1\n")
+      .replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, "- $1\n")
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<[^>]+>/g, "");
+
+    // Clean up
+    extractedContent = extractedContent
+      .replace(/&nbsp;/g, " ")
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim();
+
+    return { title, content: extractedContent };
+  } catch {
+    return null;
+  }
+}
+
+async function saveArticle(
+  title: string,
+  content: string,
+  url: string,
+  outputDir: string
+): Promise<string> {
+  const domain = extractDomain(url);
+  const safeTitle = sanitizeFilename(title);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  const filename = `${safeTitle}_${timestamp}.md`;
+
+  const articleDir = `${outputDir}/${domain}`;
+  await $`mkdir -p ${articleDir}`;
+
+  const filepath = `${articleDir}/${filename}`;
+
+  const markdown = `---
+title: ${title}
+source_url: ${url}
+date_saved: ${new Date().toISOString()}
+---
+
+# ${title}
+
+*Source: [${url}](${url})*
+
+---
+
+${content}
+`;
+
+  await Bun.write(filepath, markdown);
+  return filepath;
+}
+
+async function unlockArticle(url: string, outputDir: string): Promise<ArticleResult> {
+  console.log(`Unlocking: ${url}`);
+
+  let content: string | null = null;
+  let source = "";
+
+  // Try text extraction services first (fastest)
+  console.log("  Trying text extraction services...");
+  content = await tryArchiveServices(url);
+  if (content) source = "extraction service";
+
+  // Try agent-browser with wait
+  if (!content) {
+    console.log("  Trying browser automation...");
+    content = await tryAgentBrowser(url);
+    if (content) source = "browser";
+  }
+
+  // Try Zo API as last resort
+  if (!content) {
+    console.log("  Trying Zo webpage reader...");
+    content = await tryZoReadWebpage(url);
+    if (content) source = "Zo reader";
+  }
+
+  if (!content) {
+    return {
+      success: false,
+      error: "Could not bypass paywall. This article may require authentication, have a hard paywall, or use strong bot protection.",
+    };
+  }
+
+  console.log(`  Content retrieved via ${source}`);
+
+  // Check if we got clean markdown directly
+  let title: string;
+  let articleContent: string;
+
+  if (content.includes("#") && content.length > 1000) {
+    // Looks like markdown already
+    const titleMatch = content.match(/^#\s+(.+)$/m);
+    title = titleMatch?.[1] || "Article";
+    articleContent = content;
+  } else {
+    // Need to extract
+    const extracted = await extractWithReadability(content, url);
+    if (!extracted || extracted.content.length < 100) {
+      return {
+        success: false,
+        error: "Could not extract readable article content from the retrieved page.",
+      };
+    }
+    title = extracted.title;
+    articleContent = extracted.content;
+  }
+
+  const filepath = await saveArticle(title, articleContent, url, outputDir);
+
+  console.log(`\n✓ Article saved to: ${filepath}`);
+  console.log(`  Title: ${title}`);
+  console.log(`  Length: ${articleContent.length} characters`);
+
+  return {
+    success: true,
+    filepath,
+    title,
+  };
+}
+
+// CLI
+const url = process.argv[2];
+const outputDir = process.argv[3] || "/home/workspace/Articles";
+
+if (!url) {
+  console.log("Usage: bun run unlock.ts <article-url> [output-directory]");
+  process.exit(1);
+}
+
+if (!url.startsWith("http")) {
+  console.log("Error: URL must start with http:// or https://");
+  process.exit(1);
+}
+
+const result = await unlockArticle(url, outputDir);
+
+if (!result.success) {
+  console.error(`\n✗ ${result.error}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add new `Community/zo-ladder` skill
- include scripts and supporting files for article extraction
- normalize `SKILL.md` frontmatter for registry compliance (`name: zo-ladder`, Community metadata)
- fix manual usage paths to point to `Skills/zo-ladder/scripts/unlock.ts`

## Validation
- ran `bun validate`
- validation passes for this addition; remaining warnings are pre-existing in unrelated `External/*` skills
