### PR TITLE
Add mcporter-setup skill for MCP server configuration

### DIFF
--- a/Community/mcporter-setup/SKILL.md
+++ b/Community/mcporter-setup/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: mcporter-setup
+description: >-
+  Install MCPorter and configure MCP servers from scratch. Use when setting up
+  MCP integration for the first time, adding new MCP servers, or troubleshooting
+  MCP connectivity. Handles installation, configuration, secrets management,
+  and connection testing.
+compatibility: Created for Zo Computer
+metadata:
+  author: curtastrophe
+  category: Community
+---
+
+# MCPorter Setup
+
+Install and configure MCP (Model Context Protocol) servers on Zo Computer. This skill handles the complete setup process from installation to working connection.
+
+## When to Use
+
+- User wants to use an MCP server but mcporter isn't installed
+- User wants to add a new MCP server to their configuration
+- User mentions a platform/service that might be available via MCP
+- Troubleshooting MCP connection issues
+- User asks "set up MCP" or "add MCP server"
+
+---
+
+## Setup Process
+
+Follow these steps in order:
+
+### Step 1: Check MCPorter Installation
+
+Run the installation check script:
+
+```bash
+bun Skills/mcporter-setup/scripts/check-install.ts
+```
+
+If not installed, the script will install mcporter automatically.
+
+### Step 2: Gather MCP Server Details
+
+Ask the user for the following information:
+
+| Required | Question | Example |
+|----------|----------|---------|
+| **Server URL** | "What is the MCP server URL?" | `https://mcp.example.com/mcp` |
+| **Server Name** | "What name would you like for this server?" | `myserver` |
+| **Description** | "What does this server provide?" | `My API integration` |
+
+### Step 3: Determine Authentication Method
+
+Check the server's auth requirements:
+
+```bash
+bun Skills/mcporter-setup/scripts/detect-auth.ts <server_url>
+```
+
+This will return one of:
+- `none` - No authentication required
+- `oauth` - Standard OAuth (browser-based)
+- `api-key` - API key in header
+- `bearer` - Bearer token
+- `custom` - Non-standard auth (requires manual setup)
+
+### Step 4: Handle Authentication
+
+Based on the auth type:
+
+#### No Auth
+Proceed directly to Step 5.
+
+#### OAuth
+Run the auth flow:
+```bash
+npx mcporter auth <server_url>
+```
+Tell the user: "A browser window will open for authentication. Please complete the login and return here."
+
+#### API Key / Bearer Token
+Ask the user:
+1. "What is the header name for the API key?" (e.g., `x-api-key`, `Authorization`)
+2. "What is your API key or token?"
+
+Then store the secret:
+```bash
+# Tell user to add secret in Settings > Advanced
+# Then reference it in config
+```
+
+**For API keys:** Direct the user to [Settings > Advanced](/?t=settings&s=advanced) to add the secret, then continue with the variable reference.
+
+### Step 5: Add Server Configuration
+
+Run the setup script with gathered information:
+
+```bash
+bun Skills/mcporter-setup/scripts/add-server.ts \
+  --name "<server_name>" \
+  --url "<server_url>" \
+  --description "<description>" \
+  --auth-type "<auth_type>" \
+  --header-name "<header_name>" \
+  --secret-var "<SECRET_VAR_NAME>"
+```
+
+### Step 6: Test Connection
+
+Verify the setup works:
+
+```bash
+bun Skills/mcporter-setup/scripts/test-server.ts <server_name>
+```
+
+If successful, show the available tools:
+```bash
+npx mcporter list <server_name> --all-parameters
+```
+
+---
+
+## Common MCP Servers
+
+Use these pre-configured setups for popular services:
+
+### Linear
+
+```
+URL: https://mcp.linear.app/mcp
+Auth: Bearer token (LINEAR_API_KEY)
+Header: Authorization: Bearer ${LINEAR_API_KEY}
+```
+
+Setup:
+1. Get API key from Linear Settings > API
+2. Store as `LINEAR_API_KEY` in Zo Secrets
+3. Run: `npx mcporter config add linear https://mcp.linear.app/mcp --header "Authorization: Bearer ${LINEAR_API_KEY}" --scope home`
+
+### Context7 (No Auth)
+
+```
+URL: https://mcp.context7.com/mcp
+Auth: None
+```
+
+Setup:
+```bash
+npx mcporter config add context7 https://mcp.context7.com/mcp --description "Documentation search" --scope home
+```
+
+### GitHub MCP (STDIO)
+
+```
+Command: npx -y @github/mcp-server
+Auth: GITHUB_TOKEN environment variable
+```
+
+Setup:
+1. Create GitHub Personal Access Token
+2. Store as `GITHUB_TOKEN` in Zo Secrets
+3. Run: `npx mcporter config add github --command "npx" --arg "-y" --arg "@github/mcp-server" --env "GITHUB_TOKEN=${GITHUB_TOKEN}" --scope home`
+
+### Firecrawl
+
+```
+URL: https://mcp.firecrawl.dev/mcp
+Auth: Bearer token (FIRECRAWL_API_KEY)
+Header: Authorization: Bearer ${FIRECRAWL_API_KEY}
+```
+
+Setup:
+1. Get API key from Firecrawl dashboard
+2. Store as `FIRECRAWL_API_KEY` in Zo Secrets
+3. Run: `npx mcporter config add firecrawl https://mcp.firecrawl.dev/mcp --header "Authorization: Bearer ${FIRECRAWL_API_KEY}" --scope home`
+
+---
+
+## Troubleshooting
+
+### SSE Error / Invalid Content Type
+
+The server may use a different transport or require custom auth:
+1. Check server documentation
+2. Try `--http-url` flag instead of SSE
+3. May need manual token configuration
+
+### Authentication Required (401/403)
+
+Secret may not be loaded:
+1. Verify secret exists in Zo Secrets
+2. Check the environment variable name matches exactly
+3. Test with: `curl -H "Authorization: Bearer $SECRET" <url>`
+
+### Tools Unavailable
+
+Server may be offline or auth failed:
+1. Test connectivity: `curl -v <server_url>`
+2. Re-run auth: `npx mcporter auth <server_url>`
+3. Check server status page if available
+
+---
+
+## Scripts
+
+### `check-install.ts`
+Checks if mcporter is installed and installs if needed.
+
+### `detect-auth.ts <url>`
+Analyzes server auth requirements.
+
+### `add-server.ts`
+Adds server configuration with proper auth setup.
+
+### `test-server.ts <name>`
+Tests server connectivity and lists available tools.
+
+---
+
+## After Setup
+
+Once configured, use the `mcporter` skill for quick command reference:
+
+```bash
+npx mcporter list <server>
+npx mcporter call <server>.<tool> param=value
+```
+
+## References
+
+- [MCPorter Documentation](https://github.com/steipete/mcporter)
+- [MCP Server Registry](https://github.com/modelcontextprotocol/servers)
+- [Zo Secrets](/?t=settings&s=advanced)

--- a/Community/mcporter-setup/references/mcporter-cli-reference.md
+++ b/Community/mcporter-setup/references/mcporter-cli-reference.md
@@ -1,0 +1,66 @@
+---
+summary: 'Quick reference for mcporter subcommands, their arguments, and shared global flags.'
+read\_when:
+- 'Need a refresher on available CLI commands'
+---
+# mcporter CLI Reference
+A quick reference for the primary `mcporter` subcommands. Each command inherits
+`--config ` and `--root ` to override where servers are loaded from.
+## `mcporter list [server]`
+- Without arguments, lists every configured server (with live discovery + brief
+status).
+- With a server name, prints TypeScript-style signatures for each tool, doc
+comments, and optional summaries.
+- Hidden alias: `list-tools` (kept for muscle memory; not advertised in help output).
+- Hidden ad-hoc flag aliases: `--sse` for `--http-url`, `--insecure` for `--allow-http` (for plain HTTP testing).
+- Flags:
+- `--all-parameters` – include every optional parameter in the signature.
+- `--schema` – pretty-print the JSON schema for each tool.
+- `--timeout ` – per-server timeout when enumerating all servers.
+## `mcporter call `
+- Invokes a tool once and prints the response; supports positional arguments via
+pseudo-TS syntax and `--arg` flags.
+- Useful flags:
+- `--server`, `--tool` – alternate way to target a tool.
+- `--timeout ` – override call timeout (defaults to `CALL\_TIMEOUT\_MS`).
+- `--output text|markdown|json|raw` – choose how to render the `CallResult`.
+- `--tail-log` – stream tail output when the tool returns log handles.
+## `mcporter generate-cli`
+- Produces a standalone CLI for a single MCP server (optionally bundling or
+compiling with Bun).
+- Key flags:
+- `--server ` (or inline JSON) – choose the server definition.
+- `--command ` – point at an ad-hoc HTTP endpoint (include `https://` or use `host/path.tool`) or a stdio command (anything with spaces, e.g., `"npx -y chrome-devtools-mcp@latest"`). If you omit `--command`, the first positional argument is inspected: whitespace → stdio, otherwise the parser probes for HTTP/HTTPS and falls back to config names.
+- `--output ` – where to write the TypeScript template.
+- `--bundle ` – emit a bundle (Node/Bun) ready for `bun x`.
+- `--bundler rolldown|bun` – pick the bundler implementation (defaults to Rolldown unless the runtime resolves to Bun, in which case Bun’s bundler is used automatically; still requires a local Bun install).
+- `--compile ` – compile with Bun (implies `--runtime bun`).
+- `--include-tools ` – only generate subcommands for the specified tools (exact MCP tool names). It is an error if any requested tool is missing.
+- `--exclude-tools ` – generate subcommands for every tool except the ones listed. Unknown tool names are ignored. If all tools are excluded, generation fails.
+- `--include-tools` and `--exclude-tools` are mutually exclusive.
+- `--timeout ` / `--runtime node|bun` – shared via the generator flag
+parser so defaults stay consistent.
+- `--from ` – reuse metadata from an existing CLI artifact (legacy
+`regenerate-cli` behavior, must point at an existing CLI).
+- `--dry-run` – print the resolved `mcporter generate-cli ...` command without
+executing (requires `--from`).
+- Positional shorthand: `npx mcporter generate-cli linear` uses the configured
+`linear` definition; `npx mcporter generate-cli https://example.com/mcp`
+treats the URL as an ad-hoc server definition.
+## `mcporter emit-ts `
+- Emits TypeScript definitions (and optionally a ready-to-use client) describing
+a server’s tools. This reuses the same formatter as `mcporter list` so doc
+comments, signatures, and examples stay in sync.
+- Modes:
+- `--mode types --out ` (default) – export an interface whose
+methods return `Promise`, with doc comments and optional
+summaries.
+- `--mode client --out ` – emit both the interface (`.d.ts`)
+and a factory that wraps `createServerProxy`, returning objects whose
+methods resolve to `CallResult`.
+- Other flags:
+- `--include-optional` (alias `--all-parameters`) – show every optional field.
+- `--types-out ` – override where the `.d.ts` sits when using client
+mode.
+For more detail (behavioral nuances, OAuth flows, etc.), see `docs/spec.md` and
+command-specific docs under `docs/`.

--- a/Community/mcporter-setup/references/mcporter-config.md
+++ b/Community/mcporter-setup/references/mcporter-config.md
@@ -1,0 +1,149 @@
+---
+summary: 'How mcporter discovers, merges, and mutates configuration files (project + home + imports), including OAuth and persistence.'
+read\_when:
+- 'Working on config resolution, imports, or mcporter config subcommands'
+---
+# CLI Help Menu Snapshot
+```
+mcporter config
+Usage: mcporter config [options] 
+Manage configured MCP servers, imports, and ad-hoc discoveries.
+Commands:
+list [options] [filter] Show merged servers (local + imports + ad-hoc cache)
+get  Inspect a single server with resolved source info
+add [options]  [target] Persist a server definition (URL or stdio command)
+remove [options]  Delete a local entry or copy from an import
+import  [options] Copy entries from cursor/claude/codex/etc. into config
+login  Complete OAuth/auth flows for a server
+logout  Clear cached credentials for a server
+doctor [options] Validate config files and report common mistakes
+help [command] Show CLI or subcommand help
+Global Options:
+--config  Use an explicit config file (default: config/mcporter.json)
+--root  Set project root for import discovery (default: cwd)
+--json Emit machine-readable output when supported
+-h, --help Display help for mcporter config
+Run `mcporter config help add` to see transport flags, ad-hoc persistence tips, and schema docs.
+See https://github.com/sweetistics/mcporter/blob/main/docs/config.md for config anatomy, import precedence, and troubleshooting guidance.
+```
+# Configuration Guide
+## Overview
+mcporter keeps three configuration buckets in sync: repository-scoped JSON (`config/mcporter.json`), imported editor configs (Cursor, Claude, Codex, Windsurf, OpenCode, VS Code), and ad-hoc definitions supplied on the CLI. This guide explains how those sources merge, how to mutate them with `mcporter config ...`, and the safety rails around OAuth, env interpolation, and persistence.
+## Quick Start
+1. Create `config/mcporter.json` at the repo root:
+```jsonc
+{
+"mcpServers": {
+"linear": {
+"description": "Linear issues",
+"baseUrl": "https://mcp.linear.app/mcp",
+"headers": { "Authorization": "Bearer ${LINEAR\_API\_KEY}" }
+}
+},
+"imports": ["cursor", "claude-code", "claude-desktop", "codex", "windsurf", "opencode", "vscode"]
+}
+```
+2. Run `mcporter list linear` (or `mcporter config list linear`) to make sure the runtime can reach it.
+3. Use `mcporter config add shadcn https://www.shadcn.io/api/mcp` to persist another server without editing JSON.
+4. Authenticate any OAuth-backed server with either `mcporter auth ` or `mcporter config login `; tokens land under `~/.mcporter//` unless you override `tokenCacheDir`.
+## Config Resolution Order
+mcporter now merges home and project config files by default so global servers stay available inside repos. The order depends on how you invoke the CLI:
+1. If you pass `--config ` (or set `--config` programmatically), only that file is used—no merging.
+2. If `MCPORTER\_CONFIG` is set, only that file is used—no merging.
+3. Otherwise, mcporter loads both of these layers (when present):
+- `~/.mcporter/mcporter.json` or `~/.mcporter/mcporter.jsonc`
+- `/config/mcporter.json`
+Entries from the project file override entries with the same name from the home file. Each layer still pulls in its own imports before merging.
+All `mcporter config …` mutations still write back to a single file: the explicit path when provided; otherwise the project config path (`/config/mcporter.json`). To edit the home file explicitly, run commands like `mcporter config --config ~/.mcporter/mcporter.json add  …` or set `MCPORTER\_CONFIG` in your shell profile.
+## Discovery & Precedence
+mcporter builds a merged view of all known servers before executing any command. The sources load in this order:
+| Priority | Source | Notes |
+| --- | --- | --- |
+| 1 | Explicit `--http-url`, `--stdio`, or bare URL passed to commands | Highest priority, never cached unless `--persist` is supplied. Requires `--allow-http` for plain HTTP URLs. |
+| 2 | `config/mcporter.json` (or the file passed via `--config`) | Default path is `/config/mcporter.json`; missing file returns an empty config so commands continue to work. |
+| 3 | Imports listed in `"imports"` | When you omit `imports`, mcporter loads `['cursor','claude-code','claude-desktop','codex','windsurf','opencode','vscode']`. When you specify a non-empty array, mcporter appends any omitted defaults after your list so shared presets remain available. |
+Rules:
+- Later sources never override earlier ones. Local config always wins over imports; ad-hoc descriptors override both for the duration of a command.
+- Each merged server tracks its origin (local path vs. import path), so `mcporter config get ` can show you the path before you edit or remove the local copy with `mcporter config remove `.
+- Imports remain read-only until you explicitly copy an entry via `mcporter config import  --copy` or run `mcporter config add --copy-from claude-code:linear` (feature planned alongside the CLI work).
+## CLI Workflows
+`mcporter config` is the entry point for reading and writing configuration files. Use the existing ad-hoc flags on `mcporter list|call|auth` when you want ephemeral definitions; once you’re ready to persist them, switch back to `mcporter config add`.
+Use `--scope home|project` with `mcporter config add` to pick the write target explicitly. `project` is always the default (creating `config/mcporter.json` if needed); `home` writes to `~/.mcporter/mcporter.json` even when a project config is present. `--persist ` still takes precedence when you need a custom file.
+### `mcporter config list [filter]`
+- Shows \*\*local\*\* entries by default. Pass `--source import` to list imported editor configs, or `--json` for machine output.
+- Always appends a summary of other config files (paths, counts, sample names) so you know where imported entries live.
+- `filter` accepts a name, glob fragment, or `source:cursor` selector.
+- Adds informational notes when we auto-correct names (same machinery as `mcporter list`).
+### `mcporter config get `
+- Prints the resolved definition for a single server, including the on-disk path, inherited headers/env, and transport details.
+- Near-miss names are auto-corrected with the same heuristics as `mcporter list`/`call`, and you’ll see suggestions whenever ambiguity remains.
+- Supports ad-hoc descriptors so you can inspect a URL before persisting it.
+### `mcporter config add  [target]`
+- Persists a server into the writable config file. Accepts both positional shortcuts (`mcporter config add sentry https://mcp.sentry.dev/mcp`) and flag-driven definitions:
+- `--transport http|sse|stdio`
+- `--url` or `--command`/`--stdio`
+- `--env`, `--header`, `--token-cache-dir`, `--description`, `--tag`, `--client-name`, `--oauth-redirect-url`
+- `--copy-from importKind:name` to clone settings from an imported entry before editing.
+- `--dry-run` shows the JSON diff without writing, while `--persist ` overrides the destination file.
+### `mcporter config remove `
+- Removes the local definition. Names sourced exclusively from imports remain untouched until you copy them locally.
+### `mcporter config import `
+- Displays (and optionally copies) entries from editor-specific configs:
+- `cursor`: `.cursor/mcp.json` in the repo, falling back to `~/.config/Cursor/User/mcp.json` (or `%APPDATA%/Cursor/User` on Windows).
+- `claude-code`: `/.claude/settings.local.json`, `/.claude/settings.json`, `/.claude/mcp.json`, then `~/.claude/settings.json`, `~/.claude/mcp.json`, `~/.claude.json`. `settings.local.json` is meant for untracked per-developer overrides, while `settings.json` is the shared project config.
+- `claude-desktop`: platform-specific `Claude/claude\_desktop\_config.json` paths.
+- `codex`: `/.codex/config.toml`, then `~/.codex/config.toml`.
+- `windsurf`: Codeium’s Windsurf config under `%APPDATA%/Codeium/windsurf/mcp\_config.json` or `~/.codeium/windsurf/mcp\_config.json`.
+- `opencode`: Honors `OPENCODE\_CONFIG` when set, then `/opencode.json(c)`, `OPENCODE\_CONFIG\_DIR/opencode.json(c)`, and finally `${XDG\_CONFIG\_HOME:-~/.config}/opencode/opencode.json(c)` (or `%APPDATA%/opencode/opencode.json(c)` on Windows). Both `.json` and `.jsonc` extensions are supported.
+- `vscode`: `Code/User/mcp.json` (stable + Insiders) inside the OS-appropriate config directory.
+- `--copy` writes selected entries into your local config; `--filter ` narrows the import list; `--path ` lets you point at bespoke locations.
+### `mcporter config login ` / `logout`
+- Mirrors `mcporter auth`. `login` completes OAuth (or token provisioning) for either a named server or an ad-hoc URL. When a hosted MCP returns 401/403, mcporter automatically promotes that target to OAuth and re-runs the flow, matching the behavior documented in `docs/adhoc.md`.
+- `--browser none` suppresses automatic browser launch (useful for copying the URL into a remote browser).
+- `logout` wipes token caches under `~/.mcporter//` (or the custom `tokenCacheDir`). Pass `--all` to clear everything.
+### `mcporter config doctor`
+- Early validator that checks for simple issues (e.g., OAuth entries missing cache paths). Future iterations will add fixes for Accept headers, duplicate imports, and more.
+## Ad-hoc & Persistence
+- `--http-url` and `--stdio` flags live on `mcporter list|call|auth`, keeping `mcporter config` focused on persistent config files.
+- Names default to slugified hostnames or executable/script combos. Supply `--name` to improve reuse; mcporter uses that slug for OAuth caches even before persistence.
+- `--allow-http` is mandatory for cleartext endpoints so we never downgrade transport silently.
+- Add `--persist ` (defaulting to `config/mcporter.json` when omitted) to copy the ad-hoc definition into config. We reuse the same serializer as the import pipeline, so copying from Cursor → local config produces identical structure and preserves custom env/header fields.
+- `--env KEY=VAL` entries merge with existing `env` dictionaries if you later persist the same server; nothing is lost when you alternate between CLI flags and JSON edits.
+## Schema Reference
+Top-level structure:
+| Key | Type | Description |
+| --- | --- | --- |
+| `mcpServers` | object | Map of server names → definitions. Required even if empty. |
+| `imports` | string[] | Optional list of import kinds. Empty array disables imports entirely; omitting the key falls back to the default list. |
+Server definition fields (subset of what `RawEntrySchema` accepts):
+| Field | Description |
+| --- | --- |
+| `description` | Free-form summary printed by `mcporter list`/`config list`. |
+| `baseUrl` / `url` / `serverUrl` | HTTPS or HTTP endpoint. `http://` requires `--allow-http` in ad-hoc mode but works in config if you explicitly set it. |
+| `command` / `args` | Stdio executable definition (string or array). Arrays are preferred because they avoid shell quoting issues. |
+| `env` | Key/value pairs applied when launching stdio commands. Supports `${VAR}` interpolation and `${VAR:-fallback}` defaults. Existing process env values win over fallbacks. |
+| `headers` | Request headers for HTTP/SSE transports. Values can reference `$env:VAR` or `${VAR}` placeholders, which must be set at runtime or mcporter aborts with a helpful error.
+| `auth` | Currently only `oauth` is recognized. Any other string is ignored (treated as undefined) to avoid stale state from other clients. |
+| `tokenCacheDir` | Directory for OAuth tokens; still honored, but mcporter now keeps a centralized vault in `~/.mcporter/credentials.json` (legacy per-server caches are auto-migrated). Supports `~` expansion. |
+| `clientName` | Optional identifier some servers use for telemetry/audience segmentation. |
+| `oauthRedirectUrl` | Override the default localhost callback. Useful when tunneling OAuth through Codespaces or remote dev boxes. |
+| `oauthCommand.args` | For STDIO servers that ship a custom auth subcommand (e.g., Gmail MCP). mcporter will spawn the stdio command with these args when you run `mcporter auth `, so you don’t need to call `npx ... auth` manually. |
+mcporter normalizes headers to include `Accept: application/json, text/event-stream` automatically, matching the runtime’s streaming expectations.
+## Imports & Conflict Resolution
+- `pathsForImport(kind, rootDir)` determines every candidate path. mcporter searches the repo first, then user-level directories, and stops at the first file that parses.
+- Entries pulled from imports are treated as read-only snapshots. The merge process keeps the first definition for each name; later sources with the same name are skipped until you override locally.
+- To copy an imported entry, either run `mcporter config import  --copy --filter name` or use `mcporter config add name --copy-from kind:name`. The copy operation writes through the same JSON normalization stack, so the resulting file matches our schema even if the source format was TOML (Codex) or legacy JSON shapes (`servers` vs `mcpServers`).
+## Project vs. Machine Layers
+- Keep `config/mcporter.json` under version control. Encourage contributors to add sensitive data via env vars (`${LINEAR\_API\_KEY}`) rather than inline secrets.
+- Machine-specific additions can live in `~/.mcporter/local.json`; point `mcporter config --config ~/.mcporter/local.json add ...` there when you prefer not to touch the repo. Since the runtime only watches one config at a time, CI jobs should always pass `--config config/mcporter.json` (or run from the repo root) for deterministic behavior.
+- OAuth tokens, cached server metadata, and generated CLIs should remain outside the repo (`~/.mcporter//`, `dist/`).
+## Validation & Troubleshooting
+- `mcporter list --http-url ...` refuses to auto-run OAuth to keep listing commands quick; use `mcporter config login ...` or `mcporter auth ...` to finish credential setup.
+- When env placeholders are missing, commands fail fast with the exact variable name. Add the variable or wrap it in `${VAR:-fallback}` to provide defaults.
+- Use `mcporter config get  --show-source` (planned flag) to confirm whether a server came from an import. If a teammate’s Cursor config keeps overriding your local entry, reorder the `imports` array to move Cursor later or set it to `[]` to disable imports entirely.
+- `docs/adhoc.md` covers deeper debugging, including tmux workflows and OAuth promotion logs.
+## Outstanding Coverage Items
+- Describe how `--persist` writes through the same import merge pipeline (especially once `mcporter config add --copy-from` ships) so users know exactly which file changes.
+- Call out that `--allow-http` remains required for cleartext URLs even in config mutations, and reiterate that `--env KEY=VAL` merges with on-disk env blocks rather than replacing them entirely.
+- Clarify and illustrate the automatic OAuth promotion path for ad-hoc HTTP entries in both this doc and future `mcporter config login` help output.
+- Flesh out `mcporter config doctor` once the validator is implemented so we can show real output samples and suggested fixes.

--- a/Community/mcporter-setup/scripts/add-server.ts
+++ b/Community/mcporter-setup/scripts/add-server.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env bun
+/**
+ * Add MCP Server Configuration
+ * Handles server setup with proper authentication
+ */
+
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const RED = "\x1b[31m";
+const NC = "\x1b[0m";
+
+interface ServerConfig {
+  name: string;
+  url: string;
+  description?: string;
+  authType: "none" | "oauth" | "api-key" | "bearer" | "custom";
+  headerName?: string;
+  secretVar?: string;
+  scope: "home" | "project";
+}
+
+function parseArgs(): ServerConfig | null {
+  const args = process.argv.slice(2);
+  const config: Partial<ServerConfig> = {
+    scope: "home",
+    authType: "none",
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case "--name":
+        config.name = args[++i];
+        break;
+      case "--url":
+        config.url = args[++i];
+        break;
+      case "--description":
+        config.description = args[++i];
+        break;
+      case "--auth-type":
+        config.authType = args[++i] as ServerConfig["authType"];
+        break;
+      case "--header-name":
+        config.headerName = args[++i];
+        break;
+      case "--secret-var":
+        config.secretVar = args[++i];
+        break;
+      case "--scope":
+        config.scope = args[++i] as "home" | "project";
+        break;
+      case "--help":
+        console.log(`
+Add MCP Server Configuration
+
+Usage: bun add-server.ts [options]
+
+Options:
+  --name <name>           Server name (required)
+  --url <url>             Server URL (required)
+  --description <desc>    Server description
+  --auth-type <type>      Auth type: none, oauth, api-key, bearer, custom
+  --header-name <name>    Header name for API key (e.g., "x-api-key")
+  --secret-var <var>      Environment variable name for secret
+  --scope <scope>         Config scope: home (default) or project
+  --help                  Show this help
+`);
+        process.exit(0);
+    }
+  }
+
+  if (!config.name || !config.url) {
+    console.log(`${RED}Error: --name and --url are required${NC}`);
+    return null;
+  }
+
+  return config as ServerConfig;
+}
+
+async function addServer(config: ServerConfig): Promise<boolean> {
+  const args = ["mcporter", "config", "add", config.name, config.url];
+
+  // Add description
+  if (config.description) {
+    args.push("--description", config.description);
+  }
+
+  // Add auth header if needed
+  if (config.authType === "api-key" || config.authType === "bearer") {
+    if (config.headerName && config.secretVar) {
+      const headerValue =
+        config.authType === "bearer"
+          ? `Bearer \${${config.secretVar}}`
+          : `\${${config.secretVar}}`;
+      args.push("--header", `${config.headerName}: ${headerValue}`);
+    } else {
+      console.log(
+        `${YELLOW}Warning: API key auth requires --header-name and --secret-var${NC}`
+      );
+    }
+  }
+
+  args.push("--scope", config.scope);
+
+  console.log(`${YELLOW}Adding server configuration...${NC}`);
+  console.log(`  Name: ${config.name}`);
+  console.log(`  URL: ${config.url}`);
+  if (config.description) console.log(`  Description: ${config.description}`);
+  if (config.secretVar)
+    console.log(`  Secret: ${config.secretVar} (from Zo Secrets)`);
+  console.log("");
+
+  const result = Bun.spawnSync(["npx", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  if (result.exitCode === 0) {
+    console.log(`${GREEN}✓ Server '${config.name}' added successfully${NC}`);
+
+    if (config.secretVar) {
+      console.log(
+        `\n${YELLOW}Important: Make sure '${config.secretVar}' is set in Zo Secrets${NC}`
+      );
+      console.log("  Go to: Settings > Advanced > Secrets\n");
+    }
+
+    return true;
+  }
+
+  console.log(`${RED}Failed to add server${NC}`);
+  console.log(result.stderr.toString());
+  return false;
+}
+
+async function main() {
+  const config = parseArgs();
+
+  if (!config) {
+    console.log("\nRun with --help for usage information");
+    process.exit(1);
+  }
+
+  console.log("╔════════════════════════════════════════╗");
+  console.log("║     Add MCP Server Configuration       ║");
+  console.log("╚════════════════════════════════════════╝\n");
+
+  const success = await addServer(config);
+
+  if (success) {
+    console.log(`\n${GREEN}Next steps:${NC}`);
+    console.log(`  Test connection: npx mcporter list ${config.name}`);
+    console.log(`  View tools: npx mcporter list ${config.name} --all-parameters`);
+  }
+
+  process.exit(success ? 0 : 1);
+}
+
+main();

--- a/Community/mcporter-setup/scripts/check-install.ts
+++ b/Community/mcporter-setup/scripts/check-install.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env bun
+/**
+ * Check MCPorter Installation
+ * Verifies mcporter is installed and installs if needed
+ */
+
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const RED = "\x1b[31m";
+const NC = "\x1b[0m";
+
+async function checkInstallation(): Promise<{
+  installed: boolean;
+  version?: string;
+  error?: string;
+}> {
+  try {
+    const result = Bun.spawnSync(["npx", "mcporter", "--version"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    if (result.exitCode === 0) {
+      const version = result.stdout.toString().trim();
+      return { installed: true, version };
+    }
+
+    // Try to parse error - might just be "not installed yet"
+    const stderr = result.stderr.toString();
+    if (stderr.includes("installed") || result.exitCode !== 0) {
+      // npx will auto-install on first use, so this is actually fine
+      return { installed: true, version: "will install on first use" };
+    }
+
+    return { installed: false, error: stderr };
+  } catch (error) {
+    return { installed: false, error: String(error) };
+  }
+}
+
+async function installMcporter(): Promise<boolean> {
+  console.log(`${YELLOW}Installing mcporter globally...${NC}`);
+
+  try {
+    // Install globally with npm
+    const result = Bun.spawnSync(
+      ["npm", "install", "-g", "mcporter", "--silent"],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+      }
+    );
+
+    if (result.exitCode === 0) {
+      console.log(`${GREEN}✓ mcporter installed globally${NC}`);
+      return true;
+    }
+
+    // Try with pnpm as fallback
+    console.log(`${YELLOW}Trying pnpm...${NC}`);
+    const pnpmResult = Bun.spawnSync(
+      ["pnpm", "add", "-g", "mcporter"],
+      { stdout: "pipe", stderr: "pipe" }
+    );
+
+    if (pnpmResult.exitCode === 0) {
+      console.log(`${GREEN}✓ mcporter installed globally via pnpm${NC}`);
+      return true;
+    }
+
+    console.log(
+      `${YELLOW}Note: mcporter can run via npx without global install${NC}`
+    );
+    return true; // npx handles this
+  } catch (error) {
+    console.log(`${RED}Install error: ${error}${NC}`);
+    return false;
+  }
+}
+
+async function main() {
+  console.log("╔════════════════════════════════════════╗");
+  console.log("║     MCPorter Installation Check        ║");
+  console.log("╚════════════════════════════════════════╝\n");
+
+  // Check prerequisites
+  const nodeCheck = Bun.spawnSync(["node", "--version"], {
+    stdout: "pipe",
+  });
+  if (nodeCheck.exitCode !== 0) {
+    console.log(`${RED}✗ Node.js is not installed${NC}`);
+    console.log("  Please install Node.js first.");
+    process.exit(1);
+  }
+  console.log(`${GREEN}✓ Node.js ${nodeCheck.stdout.toString().trim()}${NC}`);
+
+  // Check mcporter
+  const status = await checkInstallation();
+
+  if (status.installed) {
+    console.log(`${GREEN}✓ MCPorter available${NC}`);
+    if (status.version && status.version !== "will install on first use") {
+      console.log(`  Version: ${status.version}`);
+    } else {
+      console.log(`  Will install on first use via npx`);
+    }
+    process.exit(0);
+  }
+
+  // Need to install
+  console.log(`${YELLOW}MCPorter not found${NC}`);
+  const success = await installMcporter();
+
+  if (success) {
+    console.log(`\n${GREEN}MCPorter is ready to use!${NC}`);
+    console.log("  Run: npx mcporter list");
+    process.exit(0);
+  } else {
+    console.log(`\n${RED}Installation failed${NC}`);
+    console.log("  You can still use: npx mcporter <command>");
+    process.exit(1);
+  }
+}
+
+main();

--- a/Community/mcporter-setup/scripts/detect-auth.ts
+++ b/Community/mcporter-setup/scripts/detect-auth.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env bun
+/**
+ * Detect MCP Server Authentication Requirements
+ * Analyzes server endpoint to determine auth method
+ */
+
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const RED = "\x1b[31m";
+const BLUE = "\x1b[34m";
+const NC = "\x1b[0m";
+
+interface AuthDetection {
+  url: string;
+  authType: "none" | "oauth" | "api-key" | "bearer" | "custom";
+  details: string;
+  suggestedSetup: string;
+}
+
+async function detectAuth(url: string): Promise<AuthDetection> {
+  // Normalize URL
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    url = "https://" + url;
+  }
+
+  // Try to fetch server info
+  try {
+    // First try a simple GET to see if it responds
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Accept: "application/json, text/event-stream",
+      },
+    });
+
+    // Check response headers and status
+    if (response.status === 401 || response.status === 403) {
+      // Check for OAuth headers
+      const wwwAuth = response.headers.get("WWW-Authenticate") || "";
+
+      if (wwwAuth.toLowerCase().includes("bearer")) {
+        return {
+          url,
+          authType: "bearer",
+          details: "Server requires Bearer token authentication",
+          suggestedSetup:
+            "Store your API token as a secret (e.g., MY_API_TOKEN) and use: --header 'Authorization: Bearer ${MY_API_TOKEN}'",
+        };
+      }
+
+      if (wwwAuth.toLowerCase().includes("oauth")) {
+        return {
+          url,
+          authType: "oauth",
+          details: "Server requires OAuth authentication",
+          suggestedSetup: "Run: npx mcporter auth " + url,
+        };
+      }
+
+      // Generic auth required
+      return {
+        url,
+        authType: "api-key",
+        details: "Server requires authentication (API key or token)",
+        suggestedSetup:
+          "Check server documentation for required headers. Common patterns:\n" +
+          "  --header 'x-api-key: ${MY_API_KEY}' or\n" +
+          "  --header 'Authorization: Bearer ${MY_API_KEY}'",
+      };
+    }
+
+    // Check for SSE/streamable HTTP support
+    const contentType = response.headers.get("Content-Type") || "";
+
+    if (response.ok && contentType.includes("application/json")) {
+      // Try to get server info
+      const text = await response.text();
+      if (text.includes("server") || text.includes("mcp") || text.includes("protocol")) {
+        return {
+          url,
+          authType: "none",
+          details: "Server appears to be publicly accessible",
+          suggestedSetup:
+            "Run: npx mcporter config add <name> " + url + " --scope home",
+        };
+      }
+    }
+
+    if (response.ok && contentType.includes("text/event-stream")) {
+      return {
+        url,
+        authType: "none",
+        details: "Server supports SSE transport",
+        suggestedSetup:
+          "Run: npx mcporter config add <name> " + url + " --scope home",
+      };
+    }
+
+    // Try POST to initialize MCP connection
+    const initResponse = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "mcporter-setup", version: "1.0.0" },
+        },
+      }),
+    });
+
+    if (initResponse.status === 401 || initResponse.status === 403) {
+      return {
+        url,
+        authType: "api-key",
+        details: "Server requires authentication for MCP operations",
+        suggestedSetup:
+          "Check server documentation for authentication requirements",
+      };
+    }
+
+    if (initResponse.ok) {
+      const data = await initResponse.json();
+      if (data.result) {
+        return {
+          url,
+          authType: "none",
+          details:
+            "Server responds to MCP protocol without authentication",
+          suggestedSetup:
+            "Run: npx mcporter config add <name> " + url + " --scope home",
+        };
+      }
+    }
+
+    return {
+      url,
+      authType: "custom",
+      details:
+        "Could not determine auth method. Server may require custom setup.",
+      suggestedSetup:
+        "Check server documentation or try: npx mcporter auth " + url,
+    };
+  } catch (error) {
+    return {
+      url,
+      authType: "custom",
+      details: `Error connecting to server: ${error}`,
+      suggestedSetup:
+        "Verify the URL is correct and the server is accessible",
+    };
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const url = args[0];
+
+  if (!url) {
+    console.log("Usage: bun detect-auth.ts <server_url>");
+    console.log("Example: bun detect-auth.ts https://mcp.example.com/mcp");
+    process.exit(1);
+  }
+
+  console.log("╔════════════════════════════════════════╗");
+  console.log("║     MCP Auth Detection                 ║");
+  console.log("╚════════════════════════════════════════╝\n");
+
+  console.log(`${BLUE}Analyzing: ${url}${NC}\n`);
+
+  const result = await detectAuth(url);
+
+  console.log(`${GREEN}Auth Type: ${result.authType.toUpperCase()}${NC}`);
+  console.log(`Details: ${result.details}\n`);
+  console.log(`${YELLOW}Suggested Setup:${NC}`);
+  console.log(result.suggestedSetup);
+
+  // Output JSON for programmatic use
+  console.log("\n---JSON---");
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main();

--- a/Community/mcporter-setup/scripts/test-server.ts
+++ b/Community/mcporter-setup/scripts/test-server.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env bun
+/**
+ * Test MCP Server Connection
+ * Verifies server connectivity and lists available tools
+ */
+
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const RED = "\x1b[31m";
+const BLUE = "\x1b[34m";
+const NC = "\x1b[0m";
+
+interface TestResult {
+  serverName: string;
+  status: "success" | "error" | "auth-required" | "timeout";
+  toolCount?: number;
+  tools?: Array<{ name: string; description: string }>;
+  latency?: number;
+  error?: string;
+}
+
+async function testServer(serverName: string): Promise<TestResult> {
+  const startTime = Date.now();
+
+  try {
+    // Run mcporter list with JSON output
+    const result = Bun.spawnSync(
+      ["npx", "mcporter", "list", serverName, "--json"],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 60000,
+      }
+    );
+
+    const latency = Date.now() - startTime;
+
+    if (result.exitCode !== 0) {
+      const stderr = result.stderr.toString();
+
+      if (
+        stderr.includes("401") ||
+        stderr.includes("403") ||
+        stderr.includes("Authentication required")
+      ) {
+        return {
+          serverName,
+          status: "auth-required",
+          latency,
+          error: "Authentication required. Check your API key or run: npx mcporter auth " + serverName,
+        };
+      }
+
+      if (stderr.includes("timeout") || stderr.includes("timed out")) {
+        return {
+          serverName,
+          status: "timeout",
+          latency,
+          error: "Connection timed out. Server may be offline or unreachable.",
+        };
+      }
+
+      return {
+        serverName,
+        status: "error",
+        latency,
+        error: stderr || "Unknown error",
+      };
+    }
+
+    // Parse JSON output
+    const output = result.stdout.toString();
+    const data = JSON.parse(output);
+
+    // Extract tool info
+    const tools = (data.tools || []).map(
+      (t: { name: string; description?: string }) => ({
+        name: t.name,
+        description: t.description || "No description",
+      })
+    );
+
+    return {
+      serverName,
+      status: "success",
+      toolCount: tools.length,
+      tools,
+      latency,
+    };
+  } catch (error) {
+    return {
+      serverName,
+      status: "error",
+      latency: Date.now() - startTime,
+      error: String(error),
+    };
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const serverName = args[0];
+
+  if (!serverName) {
+    console.log("Usage: bun test-server.ts <server_name>");
+    console.log("Example: bun test-server.ts linear");
+    process.exit(1);
+  }
+
+  console.log("╔════════════════════════════════════════╗");
+  console.log("║     MCP Server Connection Test         ║");
+  console.log("╚════════════════════════════════════════╝\n");
+
+  console.log(`${BLUE}Testing: ${serverName}${NC}\n`);
+
+  const result = await testServer(serverName);
+
+  // Display results
+  switch (result.status) {
+    case "success":
+      console.log(`${GREEN}✓ Connection successful${NC}`);
+      console.log(`  Tools available: ${result.toolCount}`);
+      console.log(`  Latency: ${result.latency}ms\n`);
+
+      if (result.tools && result.tools.length > 0) {
+        console.log(`${YELLOW}Available Tools:${NC}`);
+        result.tools.forEach((tool) => {
+          console.log(`  • ${tool.name}`);
+          if (tool.description) {
+            console.log(`    ${tool.description.slice(0, 60)}${tool.description.length > 60 ? "..." : ""}`);
+          }
+        });
+
+        console.log(`\n${GREEN}To use a tool:${NC}`);
+        console.log(`  npx mcporter call ${serverName}.${result.tools[0].name}`);
+        console.log(`\n${GREEN}To see all parameters:${NC}`);
+        console.log(`  npx mcporter list ${serverName} --all-parameters`);
+      }
+      break;
+
+    case "auth-required":
+      console.log(`${RED}✗ Authentication required${NC}`);
+      console.log(`  ${result.error}\n`);
+      console.log(`${YELLOW}To fix:${NC}`);
+      console.log("  1. Check your API key is set in Zo Secrets");
+      console.log("  2. Or run: npx mcporter auth " + serverName);
+      break;
+
+    case "timeout":
+      console.log(`${RED}✗ Connection timed out${NC}`);
+      console.log(`  ${result.error}\n`);
+      console.log(`${YELLOW}Possible causes:${NC}`);
+      console.log("  • Server is offline");
+      console.log("  • Network connectivity issues");
+      console.log("  • Server URL is incorrect");
+      break;
+
+    case "error":
+      console.log(`${RED}✗ Connection failed${NC}`);
+      console.log(`  Error: ${result.error}\n`);
+      console.log(`${YELLOW}Troubleshooting:${NC}`);
+      console.log("  • Verify the server URL in your config");
+      console.log("  • Check if authentication is required");
+      console.log("  • Try: npx mcporter list --verbose");
+      break;
+  }
+
+  // Output JSON for programmatic use
+  console.log("\n---JSON---");
+  console.log(JSON.stringify(result, null, 2));
+
+  process.exit(result.status === "success" ? 0 : 1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds a new skill for installing and configuring MCP (Model Context Protocol) servers on Zo Computer.

## Features

- **Installation check** - Verifies mcporter is installed, installs if missing
- **Auth detection** - Automatically determines authentication requirements (OAuth, API key, bearer token, or custom)
- **Server configuration** - Adds MCP servers to mcporter config with proper auth setup
- **Connection testing** - Validates server connectivity and lists available tools
- **Common servers** - Pre-configured setups for Linear, Context7, GitHub, and Firecrawl

## Scripts Included

- `check-install.ts` - Verify/install mcporter
- `detect-auth.ts` - Analyze server auth requirements  
- `add-server.ts` - Add server configuration
- `test-server.ts` - Test server connectivity

## Usage

After installation, Zo can guide users through the complete MCP setup process:

1. Check mcporter installation
2. Gather server details (URL, name, description)
3. Detect authentication requirements
4. Configure authentication (OAuth browser flow or API key via Zo Secrets)
5. Add server configuration
6. Test connection

## Test Plan

- [ ] Install mcporter if not present
- [ ] Add a public MCP server (Context7 - no auth)
- [ ] Add an API key-based server (e.g., Linear, Firecrawl)
- [ ] Test connection and list tools

## Related

- Complements the existing `mcporter` skill (quick reference for calling tools)
- Works with the `mcp-builder` skill (for building custom MCP servers)