### PR TITLE
Add revealjs-presentation and zopack community skills

### DIFF
--- a/Community/revealjs-presentation/SKILL.md
+++ b/Community/revealjs-presentation/SKILL.md
@@ -1,0 +1,611 @@
+---
+name: revealjs-presentation
+description: |
+  Build interactive HTML slide presentations using Reveal.js + Chart.js. Use when asked to create a slide deck, pitch deck, presentation, or slideshow. Creates a single self-contained .html file with animations, charts, and polished UI. Can also publish presentations directly to zo.space as live page routes.
+compatibility: Created for Zo Computer
+metadata:
+  author: skeletorjs.zo.computer
+  version: 1.0
+---
+# Reveal.js Presentation Skill
+
+Build self-contained HTML slide decks using Reveal.js 5 + Chart.js 4. Every output is a single `.html` file that opens in any browser. Optionally publish to zo.space as a live page route.
+
+## Two Output Modes
+
+### 1. Local HTML File (default)
+Creates a single `.html` file saved to the user's workspace. No build step, no dependencies. Open in any browser.
+
+### 2. zo.space Page Route (on request)
+Publishes the presentation as a live page on `skeletorjs.zo.space`. Uses the pre-installed `reveal.js` package + inline styles. Use when the user says "publish", "put it on zo.space", "make it live", or "share it online".
+
+The publish script at `scripts/publish.ts` handles the conversion from local HTML to a zo.space-compatible React page route. Run it via:
+```bash
+bun /home/workspace/Skills/revealjs-presentation/scripts/publish.ts --file <path-to-html> --route <path> [--public]
+```
+
+When publishing to zo.space:
+- Reveal.js is imported from the pre-installed package (`import Reveal from "reveal.js"`)
+- Chart.js is loaded from CDN via dynamic script injection in useEffect
+- All CSS is inlined in the component
+- The route defaults to private unless `--public` is passed
+- After publishing, check `get_space_errors()` for build issues
+
+---
+
+## Core Stack (Local HTML)
+
+| Library | CDN | Purpose |
+|---------|-----|---------|
+| Reveal.js 5.1 | `cdn.jsdelivr.net/npm/reveal.js@5.1.0` | Slide engine |
+| Chart.js 4.4 | `cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js` | Charts |
+| Google Fonts | `fonts.googleapis.com` | Typography |
+
+---
+
+## Approved Extension Libraries
+
+Reach for these when the core stack can't cover the requirement. All are CDN-loadable and UMD-compatible.
+
+### Data Visualization
+
+| Need | Library | CDN |
+|------|---------|-----|
+| Custom charts | D3.js v7 | `cdn.jsdelivr.net/npm/d3@7` |
+| Animated counters | CountUp.js | `cdn.jsdelivr.net/npm/countup.js@2` |
+| Geographic maps | Leaflet.js | `cdn.jsdelivr.net/npm/leaflet@1.9` |
+| Flow diagrams | Mermaid.js | `cdn.jsdelivr.net/npm/mermaid@10` |
+
+### Animation & Motion
+
+| Need | Library | CDN |
+|------|---------|-----|
+| Complex sequences | GSAP | `cdn.jsdelivr.net/npm/gsap@3` |
+| Particle backgrounds | tsParticles | `cdn.jsdelivr.net/npm/tsparticles@2` |
+| Typewriter effect | Typed.js | `cdn.jsdelivr.net/npm/typed.js@2` |
+| Lottie animations | lottie-web | `cdn.jsdelivr.net/npm/lottie-web@5` |
+
+### Content & Code
+
+| Need | Library | CDN |
+|------|---------|-----|
+| Code highlighting | Prism.js | `cdn.jsdelivr.net/npm/prismjs@1` |
+| Math / LaTeX | MathJax 3 | `cdn.jsdelivr.net/npm/mathjax@3` |
+| Icons | Lucide | `unpkg.com/lucide@latest/dist/umd/lucide.js` |
+
+---
+
+## Compatibility Checks for New Libraries
+
+Before adding any library not listed above:
+
+1. **Can CSS or existing stack handle it?** Many effects don't need a library.
+2. **UMD build on CDN?** Must work via `<script src="...">` tag. ES module-only packages won't work.
+3. **No conflict with Reveal.js?** Watch for global keyboard/scroll listeners, body transform manipulation.
+4. **Init after slide visible?** Use `slidechanged` event handler, not DOMContentLoaded.
+5. **< 200KB gzipped?** Check bundlephobia.com before adding.
+
+---
+
+## File Structure (Local HTML)
+
+Always output a **single `.html` file**:
+
+```
+<head>
+  fonts → reveal.css → theme → chart.js → <style>
+</head>
+<body>
+  SVG symbol defs (logos, icons)
+  <div class="reveal">
+    <div class="slides">
+      <section> x N slides
+    </div>
+  </div>
+  reveal.js script → init script → chart build functions
+</body>
+```
+
+---
+
+## Boilerplate Shell
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>PRESENTATION TITLE</title>
+<link href="https://fonts.googleapis.com/css2?family=YOUR+FONTS&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/dist/reveal.css"/>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/dist/theme/white.css"/>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<style>
+:root {
+  --bg:    #FAFAF8;
+  --dk:    #111111;
+  --dk2:   #333333;
+  --gray:  #888888;
+  --accent:#YOUR_COLOR;
+  --border:#E5E5E5;
+  --f-sans:'YOUR_FONT', system-ui, sans-serif;
+  --f-mono:'YOUR_MONO', 'SF Mono', monospace;
+}
+
+.reveal { font-family: var(--f-sans); }
+.reveal .slides section {
+  text-align: left;
+  height: 100%;
+  padding: 0;
+}
+
+.S {
+  position: relative;
+  width: 100%; height: 100%;
+  display: flex; flex-direction: column;
+  padding: 32px 52px 24px;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--dk);
+  box-sizing: border-box;
+}
+.S > * { position: relative; z-index: 1; }
+
+.pre { opacity: 0; }
+.al  { animation: fromLeft  .5s ease forwards; }
+.ar  { animation: fromRight .5s ease forwards; }
+.ab  { animation: fromBelow .5s ease forwards; }
+.af  { animation: fadeUp    .55s ease forwards; }
+.ap  { animation: pop       .4s ease forwards; }
+
+.d1 { animation-delay:.08s }
+.d2 { animation-delay:.18s }
+.d3 { animation-delay:.28s }
+.d4 { animation-delay:.38s }
+.d5 { animation-delay:.48s }
+.d6 { animation-delay:.58s }
+
+@keyframes fromLeft  { from{opacity:0;transform:translateX(-22px)} to{opacity:1;transform:none} }
+@keyframes fromRight { from{opacity:0;transform:translateX(22px)}  to{opacity:1;transform:none} }
+@keyframes fromBelow { from{opacity:0;transform:translateY(18px)}  to{opacity:1;transform:none} }
+@keyframes fadeUp    { from{opacity:0}                             to{opacity:1} }
+@keyframes pop       { from{opacity:0;transform:scale(.93)}        to{opacity:1;transform:scale(1)} }
+
+.cw {
+  position: relative;
+  width: 100%;
+  min-height: 200px;
+  flex-shrink: 0;
+}
+.cw canvas {
+  position: absolute;
+  inset: 0;
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.h1 { font-size:52px; font-weight:800; line-height:1.05; }
+.h2 { font-size:38px; font-weight:700; line-height:1.1;  }
+.h3 { font-size:28px; font-weight:700; line-height:1.15; }
+.stag {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: .25em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 10px;
+}
+.mono { font-family: var(--f-mono); }
+
+.row { display:flex; flex-direction:row; gap:24px; }
+.col { display:flex; flex-direction:column; gap:12px; }
+.g2  { display:grid; grid-template-columns:1fr 1fr;         gap:12px; }
+.g3  { display:grid; grid-template-columns:1fr 1fr 1fr;     gap:12px; }
+.g4  { display:grid; grid-template-columns:1fr 1fr 1fr 1fr; gap:12px; }
+
+.card {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 18px 20px;
+}
+.card.accent {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+}
+
+.pill {
+  display:inline-flex; align-items:center;
+  padding:3px 10px; border-radius:99px;
+  font-size:11px; font-weight:600; letter-spacing:.03em;
+  background: rgba(0,0,0,.07);
+}
+</style>
+</head>
+<body>
+
+<div class="reveal">
+<div class="slides">
+
+  <!-- SLIDES GO HERE -->
+
+</div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/dist/reveal.js"></script>
+<script>
+const chartMap = {};
+const built = new Set();
+
+Reveal.initialize({
+  hash: true,
+  transition: 'fade',
+  transitionSpeed: 'fast',
+  controls: true,
+  progress: true,
+  width: 1280,
+  height: 720,
+  margin: 0,
+});
+
+function animateSlide(slide) {
+  slide.querySelectorAll('.pre').forEach(el => el.classList.remove('pre'));
+}
+
+Reveal.on('slidechanged', ({ indexh }) => {
+  const slide = Reveal.getSlide(indexh);
+  if (slide) animateSlide(slide);
+  if (chartMap[indexh] && !built.has(indexh)) {
+    built.add(indexh);
+    chartMap[indexh]();
+  }
+});
+
+Reveal.on('ready', () => {
+  const slide = Reveal.getSlide(0);
+  if (slide) animateSlide(slide);
+  if (chartMap[0] && !built.has(0)) {
+    built.add(0);
+    chartMap[0]();
+  }
+});
+</script>
+</body>
+</html>
+```
+
+---
+
+## Slide Anatomy
+
+Every slide follows this pattern:
+
+```html
+<section>
+<div class="S">
+  <div class="stag pre af d1">Category</div>
+  <div class="h2 pre al d2">Headline with <span style="color:var(--accent)">accent</span></div>
+  <div class="pre af d3" style="color:var(--gray);font-size:16px;margin-bottom:20px;">
+    Supporting text.
+  </div>
+  <div class="g2 pre af d4" style="flex:1;min-height:0;">
+    <!-- content -->
+  </div>
+</div>
+</section>
+```
+
+---
+
+## Layout Patterns
+
+### 2-Column Split
+```html
+<div class="row" style="flex:1;gap:32px;">
+  <div class="col" style="flex:1;"><!-- left --></div>
+  <div class="col" style="flex:1.2;"><!-- right --></div>
+</div>
+```
+
+### Card Grid (3-up)
+```html
+<div class="g3" style="flex:1;min-height:0;">
+  <div class="card pre ap d3">...</div>
+  <div class="card pre ap d4">...</div>
+  <div class="card pre ap d5">...</div>
+</div>
+```
+
+### Hero Stat
+```html
+<div style="display:flex;align-items:baseline;gap:8px;margin-bottom:4px;">
+  <div style="font-size:64px;font-weight:900;color:var(--accent);">$5.2B</div>
+  <div style="font-size:18px;color:var(--gray);">market</div>
+</div>
+```
+
+### CSS Treemap
+```html
+<div style="display:flex;flex-direction:column;gap:4px;flex:1;">
+  <div style="display:flex;gap:4px;flex:34;">
+    <div style="flex:1;background:#COLOR;border-radius:6px;padding:10px;color:#fff;">
+      <div style="font-size:11px;opacity:.7;">Category</div>
+      <div style="font-weight:700;">34%</div>
+    </div>
+  </div>
+</div>
+```
+
+### Numbered Steps / Timeline
+```html
+<div style="display:flex;gap:0;flex:1;position:relative;">
+  <div style="position:absolute;top:28px;left:28px;right:28px;height:2px;background:var(--border);z-index:0;"></div>
+  <div style="flex:1;display:flex;flex-direction:column;align-items:center;text-align:center;position:relative;z-index:1;">
+    <div style="width:56px;height:56px;border-radius:50%;background:var(--accent);color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:18px;flex-shrink:0;">1</div>
+    <div style="font-weight:600;margin-top:10px;font-size:14px;">Step Title</div>
+    <div style="font-size:12px;color:var(--gray);margin-top:4px;">Description</div>
+  </div>
+</div>
+```
+
+### Comparison Table (CSS grid)
+```html
+<div style="display:grid;grid-template-columns:2fr 1fr 1fr;gap:1px;background:var(--border);border-radius:10px;overflow:hidden;">
+  <div style="background:var(--dk);color:#fff;padding:10px 14px;font-size:12px;font-weight:700;">Feature</div>
+  <div style="background:var(--dk);color:#fff;padding:10px 14px;font-size:12px;font-weight:700;text-align:center;">Option A</div>
+  <div style="background:var(--dk);color:var(--accent);padding:10px 14px;font-size:12px;font-weight:700;text-align:center;">Option B</div>
+  <div style="background:#fff;padding:9px 14px;font-size:13px;">Feature name</div>
+  <div style="background:#fff;padding:9px 14px;font-size:13px;text-align:center;color:var(--gray);">No</div>
+  <div style="background:#fff;padding:9px 14px;font-size:13px;text-align:center;color:var(--accent);font-weight:600;">Yes</div>
+</div>
+```
+
+---
+
+## Chart.js Recipes
+
+### Bar Chart
+```js
+function buildBarChart() {
+  const ctx = document.getElementById('barChart').getContext('2d');
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+      datasets: [{
+        label: 'Revenue',
+        data: [42, 68, 55, 89, 104, 127],
+        backgroundColor: 'YOUR_COLOR',
+        borderRadius: 6,
+        borderSkipped: false,
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { grid: { display: false }, border: { display: false } },
+        y: { grid: { color: '#f0f0f0' }, border: { display: false } }
+      }
+    }
+  });
+}
+```
+
+### Line Chart
+```js
+function buildLineChart() {
+  const ctx = document.getElementById('lineChart').getContext('2d');
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: ['Q1', 'Q2', 'Q3', 'Q4'],
+      datasets: [{
+        label: 'Series A',
+        data: [30, 55, 80, 120],
+        borderColor: 'YOUR_COLOR_1',
+        backgroundColor: 'YOUR_COLOR_1_20',
+        borderWidth: 2.5,
+        pointRadius: 4,
+        tension: 0.35,
+        fill: true,
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: { grid: { display: false } },
+        y: { grid: { color: '#f0f0f0' } }
+      }
+    }
+  });
+}
+```
+
+### Doughnut
+```js
+function buildDoughnut() {
+  const ctx = document.getElementById('doughnutChart').getContext('2d');
+  new Chart(ctx, {
+    type: 'doughnut',
+    data: {
+      labels: ['A', 'B', 'C'],
+      datasets: [{
+        data: [40, 30, 30],
+        backgroundColor: ['#C1','#C2','#C3'],
+        borderWidth: 0,
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      cutout: '65%',
+    }
+  });
+}
+```
+
+**Canvas HTML:**
+```html
+<div class="cw" style="min-height:220px;">
+  <canvas id="UNIQUE_CHART_ID"></canvas>
+</div>
+```
+
+Register in chartMap:
+```js
+const chartMap = { 3: buildFunnelChart, 7: buildLineChart };
+```
+
+---
+
+## Animation Rules
+
+1. Add `.pre` to any element to start invisible
+2. Add direction: `.al` (left), `.ar` (right), `.ab` (below), `.af` (fade), `.ap` (pop)
+3. Add delay: `.d1` through `.d6`
+4. Init script removes `.pre` when slide becomes active
+
+---
+
+## Critical Gotchas
+
+- **Chart height must be explicit.** `.cw` wrappers need `min-height`. Chart.js reads container height; 0px = invisible.
+- **Dead functions = errors.** Every `chartMap` entry needs a matching `<canvas id>`.
+- **Don't reuse canvas IDs.** Each chart needs a unique ID.
+- **SVG logos: define once, use everywhere** with `<symbol>` and `<use href="#id">`.
+- **Reveal.js default is 960x700.** For widescreen: `width: 1280, height: 720`.
+
+---
+
+## Slide Type Catalog
+
+| Type | Best For |
+|------|----------|
+| Hero / Title | Opening, closing |
+| Stat Showcase | Key metrics |
+| Problem / Opportunity | Setting context |
+| Feature Grid | Capability overview |
+| Comparison | Competitive positioning |
+| Chart | Data storytelling |
+| Process / Steps | How it works |
+| Timeline | Roadmap |
+| Quote / Testimonial | Social proof |
+| Closing / CTA | Next steps |
+
+---
+
+## Publishing to zo.space
+
+When the user wants to publish a presentation to zo.space:
+
+1. First create the local HTML file as normal
+2. Run the publish script:
+   ```bash
+   bun /home/workspace/Skills/revealjs-presentation/scripts/publish.ts \
+     --file /home/workspace/Inbox/my-deck.html \
+     --route /presentations/my-deck \
+     --public
+   ```
+3. The script extracts slides HTML, CSS variables, custom styles, chart functions, and SVG symbols from the HTML file
+4. It generates a React page route component that:
+   - Imports Reveal.js from the pre-installed package
+   - Loads Chart.js from CDN dynamically if charts are present
+   - Inlines all custom CSS
+   - Initializes Reveal.js in a useEffect
+   - Handles animations and chart building
+5. The route is deployed via `update_space_route`
+6. Check `get_space_errors()` after publishing
+
+The published presentation will be live at `https://skeletorjs.zo.space<route>`.
+
+### Manual zo.space Publishing (without the script)
+
+If you need more control, you can manually create a page route. The pattern:
+
+```tsx
+import { useEffect, useRef } from "react";
+import Reveal from "reveal.js";
+
+export default function Presentation() {
+  const deckRef = useRef<HTMLDivElement>(null);
+  const revealRef = useRef<any>(null);
+
+  useEffect(() => {
+    // Load reveal.js CSS from CDN
+    const revealCss = document.createElement("link");
+    revealCss.rel = "stylesheet";
+    revealCss.href = "https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/dist/reveal.css";
+    document.head.appendChild(revealCss);
+
+    const themeCss = document.createElement("link");
+    themeCss.rel = "stylesheet";
+    themeCss.href = "https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/dist/theme/white.css";
+    document.head.appendChild(themeCss);
+
+    // Init Reveal after CSS loads
+    themeCss.onload = () => {
+      if (deckRef.current && !revealRef.current) {
+        const deck = new Reveal(deckRef.current, {
+          hash: true,
+          transition: "fade",
+          transitionSpeed: "fast",
+          controls: true,
+          progress: true,
+          width: 1280,
+          height: 720,
+          margin: 0,
+          embedded: false,
+        });
+        deck.initialize();
+        revealRef.current = deck;
+      }
+    };
+
+    return () => {
+      revealRef.current?.destroy();
+      revealCss.remove();
+      themeCss.remove();
+    };
+  }, []);
+
+  return (
+    <>
+      <style>{`
+        /* your custom CSS here */
+      `}</style>
+      <div ref={deckRef} className="reveal" style={{ width: "100vw", height: "100vh" }}>
+        <div className="slides">
+          {/* <section> slides here </section> */}
+        </div>
+      </div>
+    </>
+  );
+}
+```
+
+---
+
+## Quick-Start Checklist
+
+Before writing slides:
+- [ ] Define CSS variables: `--bg`, `--dk`, `--accent`, `--f-sans`, `--f-mono`
+- [ ] Choose font pair and add Google Fonts import
+- [ ] Plan slide count and sequence
+- [ ] Identify charts and assign unique canvas IDs
+- [ ] Identify logos/icons to SVG-symbolize
+
+When writing each slide:
+- [ ] Wrap in `<div class="S">`
+- [ ] Add `.pre` + animation class + delay to animated elements
+- [ ] Use explicit `min-height` on `.cw` chart wrappers
+
+After all slides:
+- [ ] Build `chartMap` with 0-based slide indices
+- [ ] One `buildXxx()` per chart
+- [ ] Every `chartMap` key has a matching `<canvas id>`
+- [ ] If publishing to zo.space, run publish script

--- a/Community/revealjs-presentation/SKILL.md
+++ b/Community/revealjs-presentation/SKILL.md
@@ -17,7 +17,7 @@ Build self-contained HTML slide decks using Reveal.js 5 + Chart.js 4. Every outp
 Creates a single `.html` file saved to the user's workspace. No build step, no dependencies. Open in any browser.
 
 ### 2. zo.space Page Route (on request)
-Publishes the presentation as a live page on `skeletorjs.zo.space`. Uses the pre-installed `reveal.js` package + inline styles. Use when the user says "publish", "put it on zo.space", "make it live", or "share it online".
+Publishes the presentation as a live page on the user's `<handle>.zo.space`. Uses the pre-installed `reveal.js` package + inline styles. Use when the user says "publish", "put it on zo.space", "make it live", or "share it online".
 
 The publish script at `scripts/publish.ts` handles the conversion from local HTML to a zo.space-compatible React page route. Run it via:
 ```bash
@@ -521,7 +521,7 @@ When the user wants to publish a presentation to zo.space:
 5. The route is deployed via `update_space_route`
 6. Check `get_space_errors()` after publishing
 
-The published presentation will be live at `https://skeletorjs.zo.space<route>`.
+The published presentation will be live at `https://<handle>.zo.space<route>`.
 
 ### Manual zo.space Publishing (without the script)
 

--- a/Community/revealjs-presentation/scripts/publish.ts
+++ b/Community/revealjs-presentation/scripts/publish.ts
@@ -1,0 +1,234 @@
+#!/usr/bin/env bun
+
+import { parseArgs } from "util";
+import { readFileSync } from "fs";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    file: { type: "string", short: "f" },
+    route: { type: "string", short: "r" },
+    public: { type: "boolean", default: false },
+    help: { type: "boolean", short: "h" },
+  },
+  strict: true,
+});
+
+if (values.help || !values.file || !values.route) {
+  console.log(`Usage: bun publish.ts --file <html-path> --route <zo-space-path> [--public]
+
+Converts a self-contained Reveal.js HTML presentation into a zo.space page route.
+
+Options:
+  --file, -f    Path to the HTML presentation file (required)
+  --route, -r   zo.space route path, e.g. /presentations/my-deck (required)
+  --public      Make the route publicly accessible (default: private)
+  --help, -h    Show this help
+
+Examples:
+  bun publish.ts --file /home/workspace/Inbox/pitch.html --route /pitch --public
+  bun publish.ts -f deck.html -r /presentations/q1-review`);
+  process.exit(values.help ? 0 : 1);
+}
+
+const html = readFileSync(values.file!, "utf-8");
+
+// Extract content between tags
+function extractBetween(content: string, startTag: string, endTag: string): string {
+  const startIdx = content.indexOf(startTag);
+  if (startIdx === -1) return "";
+  const afterStart = startIdx + startTag.length;
+  const endIdx = content.indexOf(endTag, afterStart);
+  if (endIdx === -1) return "";
+  return content.slice(afterStart, endIdx).trim();
+}
+
+// Extract all content between matching tags (multiple occurrences)
+function extractAllBetween(content: string, startTag: string, endTag: string): string[] {
+  const results: string[] = [];
+  let searchFrom = 0;
+  while (true) {
+    const startIdx = content.indexOf(startTag, searchFrom);
+    if (startIdx === -1) break;
+    const afterStart = startIdx + startTag.length;
+    const endIdx = content.indexOf(endTag, afterStart);
+    if (endIdx === -1) break;
+    results.push(content.slice(afterStart, endIdx).trim());
+    searchFrom = endIdx + endTag.length;
+  }
+  return results;
+}
+
+// 1. Extract custom CSS from <style> block
+const styleMatch = html.match(/<style>([\s\S]*?)<\/style>/);
+const customCss = styleMatch ? styleMatch[1].trim() : "";
+
+// 2. Extract SVG symbols block
+const svgSymbolsMatch = html.match(/<svg\s+style="display:none[^"]*">([\s\S]*?)<\/svg>/);
+const svgSymbols = svgSymbolsMatch ? svgSymbolsMatch[0] : "";
+
+// 3. Extract slides HTML
+const slidesHtml = extractBetween(html, '<div class="slides">', '</div>\n</div>');
+
+// 4. Extract chart builder functions and chartMap
+const scriptBlocks = extractAllBetween(html, "<script>", "</script>");
+let chartFunctions = "";
+let chartMapStr = "{}";
+
+for (const block of scriptBlocks) {
+  // Skip the reveal.js CDN script tag content (which would be empty anyway)
+  if (block.includes("Reveal.initialize") || block.includes("chartMap")) {
+    // Extract chartMap definition
+    const mapMatch = block.match(/const\s+chartMap\s*=\s*(\{[^}]*\})/);
+    if (mapMatch) chartMapStr = mapMatch[1];
+
+    // Extract all function definitions (chart builders)
+    const funcRegex = /function\s+\w+\s*\([^)]*\)\s*\{[\s\S]*?\n\}/g;
+    const funcs = block.match(funcRegex);
+    if (funcs) {
+      chartFunctions = funcs.join("\n\n");
+    }
+  }
+}
+
+const hasCharts = chartFunctions.length > 0 && chartMapStr !== "{}";
+
+// 5. Extract Google Fonts link
+const fontsMatch = html.match(/href="(https:\/\/fonts\.googleapis\.com\/css2[^"]*)"/);
+const fontsUrl = fontsMatch ? fontsMatch[1] : "";
+
+// 6. Extract title
+const titleMatch = html.match(/<title>(.*?)<\/title>/);
+const title = titleMatch ? titleMatch[1] : "Presentation";
+
+// Escape backticks and ${} in extracted HTML/CSS for template literal safety
+function escapeForTemplateLiteral(str: string): string {
+  return str.replace(/\\/g, "\\\\").replace(/`/g, "\\`").replace(/\$\{/g, "\\${");
+}
+
+// Build the React component
+const component = `import { useEffect, useRef } from "react";
+import Reveal from "reveal.js";
+
+export default function Presentation() {
+  const deckRef = useRef<HTMLDivElement>(null);
+  const revealRef = useRef<any>(null);
+
+  useEffect(() => {
+    const revealCss = document.createElement("link");
+    revealCss.rel = "stylesheet";
+    revealCss.href = "https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/dist/reveal.css";
+    document.head.appendChild(revealCss);
+
+    const themeCss = document.createElement("link");
+    themeCss.rel = "stylesheet";
+    themeCss.href = "https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/dist/theme/white.css";
+    document.head.appendChild(themeCss);
+${fontsUrl ? `
+    const fontLink = document.createElement("link");
+    fontLink.rel = "stylesheet";
+    fontLink.href = "${fontsUrl}";
+    document.head.appendChild(fontLink);
+` : ""}
+    document.title = ${JSON.stringify(title)};
+${hasCharts ? `
+    const chartScript = document.createElement("script");
+    chartScript.src = "https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js";
+    chartScript.onload = () => initDeck();
+    document.head.appendChild(chartScript);
+` : ""}
+    function initDeck() {
+      if (!deckRef.current || revealRef.current) return;
+
+      const deck = new Reveal(deckRef.current, {
+        hash: true,
+        transition: "fade",
+        transitionSpeed: "fast",
+        controls: true,
+        progress: true,
+        width: 1280,
+        height: 720,
+        margin: 0,
+        embedded: false,
+      });
+
+${hasCharts ? `
+      ${chartFunctions.replace(/\n/g, "\n      ")}
+
+      const chartMap: Record<number, () => void> = ${chartMapStr};
+      const built = new Set<number>();
+` : ""}
+
+      function animateSlide(slide: Element) {
+        slide.querySelectorAll(".pre").forEach(el => el.classList.remove("pre"));
+      }
+
+      deck.on("slidechanged", (event: any) => {
+        const slide = deck.getSlide(event.indexh);
+        if (slide) animateSlide(slide);
+${hasCharts ? `        if (chartMap[event.indexh] && !built.has(event.indexh)) {
+          built.add(event.indexh);
+          chartMap[event.indexh]();
+        }` : ""}
+      });
+
+      deck.on("ready", () => {
+        const slide = deck.getSlide(0);
+        if (slide) animateSlide(slide);
+${hasCharts ? `        if (chartMap[0] && !built.has(0)) {
+          built.add(0);
+          chartMap[0]();
+        }` : ""}
+      });
+
+      deck.initialize();
+      revealRef.current = deck;
+    }
+
+${!hasCharts ? `
+    themeCss.onload = () => initDeck();
+` : ""}
+
+    return () => {
+      revealRef.current?.destroy();
+      revealRef.current = null;
+      revealCss.remove();
+      themeCss.remove();
+${fontsUrl ? `      fontLink.remove();` : ""}
+    };
+  }, []);
+
+  return (
+    <>
+      <style dangerouslySetInnerHTML={{ __html: \`${escapeForTemplateLiteral(customCss)}\` }} />
+      <div style={{ width: "100vw", height: "100vh", overflow: "hidden" }}>
+${svgSymbols ? `        <div dangerouslySetInnerHTML={{ __html: \`${escapeForTemplateLiteral(svgSymbols)}\` }} />` : ""}
+        <div ref={deckRef} className="reveal">
+          <div className="slides" dangerouslySetInnerHTML={{ __html: \`${escapeForTemplateLiteral(slidesHtml)}\` }} />
+        </div>
+      </div>
+    </>
+  );
+}
+`;
+
+// Output the generated component to stdout for inspection
+console.log("Generated zo.space route component:");
+console.log("Route:", values.route);
+console.log("Public:", values.public);
+console.log("Has charts:", hasCharts);
+console.log("Has fonts:", !!fontsUrl);
+console.log("Has SVG symbols:", !!svgSymbols);
+console.log("Slides HTML length:", slidesHtml.length);
+console.log("Custom CSS length:", customCss.length);
+console.log("---");
+
+// Write the component to a temp file for the Zo tool to pick up
+const outPath = `/home/.z/workspaces/temp-route-${Date.now()}.tsx`;
+Bun.write(outPath, component);
+console.log("Component written to:", outPath);
+console.log("\nTo deploy, use update_space_route with:");
+console.log(`  path: ${values.route}`);
+console.log(`  route_type: page`);
+console.log(`  public: ${values.public}`);
+console.log(`  code: <contents of ${outPath}>`);

--- a/Community/zopack/SKILL.md
+++ b/Community/zopack/SKILL.md
@@ -55,14 +55,22 @@ To import a `.zopack.md` file and deploy its routes:
    ```
    Use `--preview` first to show the user what will be deployed.
 
-2. If the user confirms, run without `--preview` to get the full JSON plan:
+2. **Security scan:** Before deploying, review the route code in the plan for risks:
+   - `fetch()` or `http`/`https` calls to external URLs (data exfiltration)
+   - `process.env` access beyond expected secrets (credential harvesting)
+   - `eval()`, `Function()`, or dynamic `import()` (arbitrary code execution)
+   - Encoded/obfuscated strings (`atob`, `Buffer.from`) hiding malicious payloads
+   - Filesystem access outside `/home/workspace/` (path traversal)
+   If any suspicious patterns are found, flag them to the user and do not proceed without explicit approval.
+
+3. If the user confirms, run without `--preview` to get the full JSON plan:
    ```bash
    bun /home/workspace/Skills/zopack/scripts/import.ts \
      --file "/path/to/pack.zopack.md" \
      --handle "<user-handle>"
    ```
 
-3. Parse the JSON output and execute the deployment in order:
+4. Parse the JSON output and execute the deployment in order:
 
    **a. Install dependencies:**
    - npm packages: `cd /__substrate/space && bun add <package>` for each

--- a/Community/zopack/SKILL.md
+++ b/Community/zopack/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: zopack
+description: Export and import zo.space route setups as shareable .zopack.md files. Use when the user wants to package their zo.space routes for sharing, or when they receive a .zopack.md file to deploy. Triggers on "export my zo.space", "create a zopack", "import this zopack", or any mention of .zopack.md files.
+compatibility: Created for Zo Computer
+metadata:
+  author: skeletorjs.zo.computer
+---
+
+# zopack
+
+Package zo.space routes into a single shareable `.zopack.md` file that anyone can give to their Zo to deploy instantly.
+
+## Export
+
+To export routes from the user's zo.space into a `.zopack.md`:
+
+1. Ask the user which routes to export (or use "all"). List their current routes with `list_space_routes`.
+2. Fetch each route's code using `get_space_route(path)`.
+3. Build a JSON array of route objects:
+   ```json
+   [
+     { "path": "/api/foo", "route_type": "api", "public": true, "code": "..." },
+     { "path": "/bar", "route_type": "page", "public": false, "code": "..." }
+   ]
+   ```
+4. Pipe the JSON array to the export script:
+   ```bash
+   echo '<json array>' | bun /home/workspace/Skills/zopack/scripts/export.ts \
+     --name "pack-name" \
+     --description "What this does" \
+     --output "Inbox/pack-name.zopack.md"
+   ```
+5. The script outputs the file path. Show the user the generated file.
+
+The export script automatically:
+- Detects the user's handle and replaces it with `{{HANDLE}}`
+- Identifies npm dependencies not in the base zo.space install
+- Detects shadcn/AnimateUI component imports and maps to registry URLs
+- Finds filesystem paths referenced in code (directories, JSON files)
+- Identifies required environment variable secrets
+
+## Import
+
+To import a `.zopack.md` file and deploy its routes:
+
+1. Parse the pack file to get the deployment plan:
+   ```bash
+   bun /home/workspace/Skills/zopack/scripts/import.ts \
+     --file "/path/to/pack.zopack.md" \
+     --handle "<user-handle>" \
+     --preview
+   ```
+   Use `--preview` first to show the user what will be deployed.
+
+2. If the user confirms, run without `--preview` to get the full JSON plan:
+   ```bash
+   bun /home/workspace/Skills/zopack/scripts/import.ts \
+     --file "/path/to/pack.zopack.md" \
+     --handle "<user-handle>"
+   ```
+
+3. Parse the JSON output and execute the deployment in order:
+
+   **a. Install dependencies:**
+   - npm packages: `cd /__substrate/space && bun add <package>` for each
+   - shadcn components: `cd /__substrate/space && npx shadcn@latest add <url> --yes` for each
+   - For `shadcn:<name>` entries, use: `npx shadcn@latest add <name> --yes`
+
+   **b. Create filesystem structure:**
+   - Directories: `mkdir -p /home/workspace/<dir>` for each
+   - Files: write each file with the specified initial content
+
+   **c. Check for secret requirements:**
+   - If secrets are listed, warn the user to configure them in Settings > Advanced before the routes will work
+
+   **d. Deploy routes:**
+   - Use `update_space_route(path, route_type, code, public)` for each route in the plan
+   - Deploy API routes before page routes (pages may depend on APIs)
+
+   **e. Verify:**
+   - Run `get_space_errors()` to check for build/runtime errors
+   - Report success or any issues
+
+## Format Reference
+
+The `.zopack.md` format:
+
+```
+---
+format: zopack
+version: "1.0"
+name: pack-name
+description: "What this does"
+author: handle.zo.computer
+routes: 3
+exported: 2026-02-21
+---
+
+# pack-name
+
+Description text.
+
+## Routes
+
+### `/path` (api|page, public|private)
+
+\```typescript|tsx
+// route code here
+\```
+
+## Dependencies
+
+**npm packages** (not in default zo.space):
+- `package-name`
+
+**Components** (install via shadcn CLI):
+- `https://animate-ui.com/r/component-name.json`
+- `shadcn:component-name`
+
+## Setup
+
+**Directories to create:**
+- `Data/my-dir`
+
+**Files to initialize:**
+- `Data/state.json` with content: `[]`
+
+**Secrets required** (configure in Settings > Advanced):
+- `API_KEY_NAME`
+
+## Variables
+
+| Placeholder | Description |
+|---|---|
+| `{{HANDLE}}` | Your zo.space handle |
+```

--- a/Community/zopack/SKILL.md
+++ b/Community/zopack/SKILL.md
@@ -4,6 +4,7 @@ description: Export and import zo.space route setups as shareable .zopack.md fil
 compatibility: Created for Zo Computer
 metadata:
   author: skeletorjs.zo.computer
+  version: "1.0"
 ---
 
 # zopack
@@ -40,6 +41,8 @@ The export script automatically:
 - Identifies required environment variable secrets
 
 ## Import
+
+**Warning:** Always use `--preview` before importing packs from untrusted sources. A zopack can specify arbitrary npm packages, shadcn registry URLs, and route code that will run on your Zo.
 
 To import a `.zopack.md` file and deploy its routes:
 

--- a/Community/zopack/scripts/export.ts
+++ b/Community/zopack/scripts/export.ts
@@ -1,0 +1,290 @@
+#!/usr/bin/env bun
+
+import { parseArgs } from "util";
+
+const SPACE_BUILD = "/__substrate/space";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    name: { type: "string", short: "n" },
+    description: { type: "string", short: "d" },
+    author: { type: "string", short: "a" },
+    output: { type: "string", short: "o" },
+    help: { type: "boolean", short: "h" },
+  },
+});
+
+if (values.help) {
+  console.log(`zopack export -- Generate a .zopack.md from route data
+
+Usage:
+  echo '<routes json>' | bun export.ts --name <name> [options]
+
+Reads a JSON array of route objects from stdin. Each object:
+  { "path": "/api/foo", "route_type": "api", "public": true, "code": "..." }
+
+Options:
+  -n, --name         Pack name (required)
+  -d, --description  Short description
+  -a, --author       Author handle (default: auto-detected from code)
+  -o, --output       Output file path (default: Inbox/<name>.zopack.md)
+  -h, --help         Show this help
+
+Zo workflow: use get_space_route for each route, collect them into a JSON
+array, and pipe to this script.`);
+  process.exit(0);
+}
+
+if (!values.name) {
+  console.error("Error: --name is required. Use --help for usage.");
+  process.exit(1);
+}
+
+interface RouteInfo {
+  path: string;
+  route_type: "api" | "page";
+  public: boolean;
+  code: string;
+}
+
+// Read stdin
+const stdin = await Bun.stdin.text();
+let routes: RouteInfo[];
+try {
+  routes = JSON.parse(stdin);
+  if (!Array.isArray(routes)) throw new Error("Expected JSON array");
+} catch (e: any) {
+  console.error(`Error parsing stdin: ${e.message}`);
+  process.exit(1);
+}
+
+if (routes.length === 0) {
+  console.error("No routes provided. Pipe a JSON array of routes to stdin.");
+  process.exit(1);
+}
+
+function detectHandle(code: string): string | null {
+  const match = code.match(/https:\/\/(\w+)\.zo\.space/);
+  return match ? match[1] : null;
+}
+
+function templatizeCode(code: string, handle: string): string {
+  return code.replace(new RegExp(`https://${handle}\\.zo\\.space`, "g"), "https://{{HANDLE}}.zo.space");
+}
+
+function detectNpmImports(code: string): Set<string> {
+  const deps = new Set<string>();
+  const importRegex = /from\s+["']([^"'.@/][^"']*)["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = importRegex.exec(code)) !== null) {
+    const pkg = m[1].startsWith("@") ? m[1].split("/").slice(0, 2).join("/") : m[1].split("/")[0];
+    deps.add(pkg);
+  }
+  // Also catch @-scoped imports
+  const scopedRegex = /from\s+["'](@[^"'/]+\/[^"'/]+)/g;
+  while ((m = scopedRegex.exec(code)) !== null) {
+    deps.add(m[1]);
+  }
+  return deps;
+}
+
+function detectComponentImports(code: string): string[] {
+  const paths: string[] = [];
+  const regex = /from\s+["']@\/components\/(animate-ui\/[^"']+|ui\/[^"']+)["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(code)) !== null) {
+    paths.push(m[1]);
+  }
+  return paths;
+}
+
+function detectFilesystemPaths(code: string): { directories: string[]; files: Record<string, string> } {
+  const dirs = new Set<string>();
+  const files: Record<string, string> = {};
+  const pathRegex = /["']\/home\/workspace\/([^"']+)["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = pathRegex.exec(code)) !== null) {
+    const p = m[1];
+    if (p.endsWith(".json")) {
+      files[p] = "[]";
+      const dir = p.split("/").slice(0, -1).join("/");
+      if (dir) dirs.add(dir);
+    } else if (!p.includes(".")) {
+      dirs.add(p);
+    }
+  }
+  return { directories: [...dirs], files };
+}
+
+function detectSecrets(code: string): string[] {
+  const secrets = new Set<string>();
+  const regex = /process\.env\.(\w+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(code)) !== null) {
+    const name = m[1];
+    if (!["ZO_CLIENT_IDENTITY_TOKEN", "PORT", "NODE_ENV"].includes(name)) {
+      secrets.add(name);
+    }
+  }
+  return [...secrets];
+}
+
+function guessRegistryUrl(componentPath: string): string | null {
+  if (componentPath.startsWith("animate-ui/")) {
+    const rest = componentPath.replace("animate-ui/", "").replace(/\.\w+$/, "");
+    const slug = rest.replace(/\//g, "-");
+    return `https://animate-ui.com/r/${slug}.json`;
+  }
+  if (componentPath.startsWith("ui/")) {
+    const name = componentPath.replace("ui/", "").replace(/\.\w+$/, "");
+    return `shadcn:${name}`;
+  }
+  return null;
+}
+
+// Detect handle from all code
+let detectedHandle: string | null = null;
+for (const r of routes) {
+  detectedHandle = detectHandle(r.code);
+  if (detectedHandle) break;
+}
+const author = values.author || detectedHandle || "unknown";
+
+// Aggregate deps
+const allNpmDeps = new Set<string>();
+const allComponents = new Set<string>();
+const allDirs = new Set<string>();
+const allFiles: Record<string, string> = {};
+const allSecrets = new Set<string>();
+
+for (const r of routes) {
+  for (const dep of detectNpmImports(r.code)) allNpmDeps.add(dep);
+  for (const comp of detectComponentImports(r.code)) allComponents.add(comp);
+  const fs = detectFilesystemPaths(r.code);
+  for (const d of fs.directories) allDirs.add(d);
+  Object.assign(allFiles, fs.files);
+  for (const s of detectSecrets(r.code)) allSecrets.add(s);
+}
+
+// Filter against base zo.space deps
+let baseDeps = new Set<string>();
+try {
+  const raw = await Bun.file(`${SPACE_BUILD}/package.json`).text();
+  const pkg = JSON.parse(raw);
+  baseDeps = new Set([
+    ...Object.keys(pkg.dependencies || {}),
+    ...Object.keys(pkg.devDependencies || {}),
+  ]);
+} catch {}
+
+// Also filter out node built-ins and @/ alias imports
+const builtins = new Set([
+  "fs", "fs/promises", "path", "crypto", "util", "url", "os",
+  "http", "https", "stream", "buffer", "events", "child_process",
+  "net", "tls", "dns", "assert", "querystring", "string_decoder",
+]);
+
+const extraNpmDeps = [...allNpmDeps].filter(
+  (d) => !baseDeps.has(d) && !builtins.has(d) && !d.startsWith("@/") && !d.startsWith("node:")
+);
+
+// Map components to registry URLs
+const componentUrls: string[] = [];
+for (const comp of allComponents) {
+  const url = guessRegistryUrl(comp);
+  if (url) componentUrls.push(url);
+}
+
+// Templatize code
+const processedRoutes = routes.map((r) => ({
+  ...r,
+  code: detectedHandle ? templatizeCode(r.code, detectedHandle) : r.code,
+}));
+
+// Build the markdown
+let md = "";
+
+md += `---\n`;
+md += `format: zopack\n`;
+md += `version: "1.0"\n`;
+md += `name: ${values.name}\n`;
+if (values.description) md += `description: "${values.description}"\n`;
+md += `author: ${author}.zo.computer\n`;
+md += `routes: ${processedRoutes.length}\n`;
+md += `exported: ${new Date().toISOString().split("T")[0]}\n`;
+md += `---\n\n`;
+
+md += `# ${values.name}\n\n`;
+if (values.description) md += `${values.description}\n\n`;
+
+md += `## Routes\n\n`;
+for (const r of processedRoutes) {
+  const visibility = r.public ? "public" : "private";
+  const lang = r.route_type === "page" ? "tsx" : "typescript";
+  md += `### \`${r.path}\` (${r.route_type}, ${visibility})\n\n`;
+  md += `\`\`\`${lang}\n`;
+  md += r.code.trim();
+  md += `\n\`\`\`\n\n`;
+}
+
+if (extraNpmDeps.length > 0 || componentUrls.length > 0) {
+  md += `## Dependencies\n\n`;
+  if (extraNpmDeps.length > 0) {
+    md += `**npm packages** (not in default zo.space):\n`;
+    for (const dep of extraNpmDeps) md += `- \`${dep}\`\n`;
+    md += `\n`;
+  }
+  if (componentUrls.length > 0) {
+    md += `**Components** (install via shadcn CLI):\n`;
+    for (const url of componentUrls) md += `- \`${url}\`\n`;
+    md += `\n`;
+  }
+}
+
+const dirs = [...allDirs];
+const fileEntries = Object.entries(allFiles);
+const secrets = [...allSecrets];
+if (dirs.length > 0 || fileEntries.length > 0 || secrets.length > 0) {
+  md += `## Setup\n\n`;
+  if (dirs.length > 0) {
+    md += `**Directories to create:**\n`;
+    for (const d of dirs) md += `- \`${d}\`\n`;
+    md += `\n`;
+  }
+  if (fileEntries.length > 0) {
+    md += `**Files to initialize:**\n`;
+    for (const [path, content] of fileEntries) {
+      md += `- \`${path}\` with content: \`${content}\`\n`;
+    }
+    md += `\n`;
+  }
+  if (secrets.length > 0) {
+    md += `**Secrets required** (configure in [Settings > Advanced](/?t=settings&s=advanced)):\n`;
+    for (const s of secrets) md += `- \`${s}\`\n`;
+    md += `\n`;
+  }
+}
+
+if (detectedHandle) {
+  md += `## Variables\n\n`;
+  md += `| Placeholder | Description |\n`;
+  md += `|---|---|\n`;
+  md += `| \`{{HANDLE}}\` | Your zo.space handle (replaces \`${detectedHandle}\`) |\n`;
+  md += `\n`;
+}
+
+const outputPath = values.output
+  ? (values.output.startsWith("/") ? values.output : `/home/workspace/${values.output}`)
+  : `/home/workspace/Inbox/${values.name}.zopack.md`;
+
+await Bun.write(outputPath, md);
+
+console.error(`Exported ${processedRoutes.length} routes to ${outputPath}`);
+console.error(`  npm deps: ${extraNpmDeps.length > 0 ? extraNpmDeps.join(", ") : "none (all in base)"}`);
+console.error(`  components: ${componentUrls.length}`);
+console.error(`  secrets: ${secrets.length > 0 ? secrets.join(", ") : "none"}`);
+console.error(`  handle templatized: ${detectedHandle || "none found"}`);
+
+// Print the output path to stdout for Zo to reference
+console.log(outputPath);

--- a/Community/zopack/scripts/import.ts
+++ b/Community/zopack/scripts/import.ts
@@ -1,0 +1,268 @@
+#!/usr/bin/env bun
+
+import { parseArgs } from "util";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    file: { type: "string", short: "f" },
+    handle: { type: "string" },
+    preview: { type: "boolean", short: "p" },
+    help: { type: "boolean", short: "h" },
+  },
+});
+
+if (values.help) {
+  console.log(`zopack import -- Parse a .zopack.md file and output a deployment plan
+
+Usage:
+  bun import.ts --file <path> [options]
+
+Options:
+  -f, --file     Path to the .zopack.md file (required)
+  --handle       Your zo.space handle for variable replacement
+  -p, --preview  Preview the plan without outputting full code
+  -h, --help     Show this help
+
+The script outputs a JSON deployment plan. Zo reads this and deploys
+each route using update_space_route.`);
+  process.exit(0);
+}
+
+if (!values.file) {
+  console.error("Error: --file is required. Use --help for usage.");
+  process.exit(1);
+}
+
+interface ParsedRoute {
+  path: string;
+  route_type: "api" | "page";
+  public: boolean;
+  code: string;
+}
+
+interface ParsedPack {
+  meta: Record<string, string>;
+  routes: ParsedRoute[];
+  npm_deps: string[];
+  shadcn_components: string[];
+  directories: string[];
+  files: Array<{ path: string; content: string }>;
+  secrets: string[];
+  variables: Array<{ placeholder: string; description: string }>;
+}
+
+function parseFrontmatter(content: string): { meta: Record<string, string>; body: string } {
+  const meta: Record<string, string> = {};
+  if (!content.startsWith("---")) return { meta, body: content };
+
+  const endIdx = content.indexOf("---", 3);
+  if (endIdx === -1) return { meta, body: content };
+
+  const frontmatter = content.slice(3, endIdx).trim();
+  for (const line of frontmatter.split("\n")) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    let val = line.slice(colonIdx + 1).trim();
+    // Strip surrounding quotes
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    meta[key] = val;
+  }
+
+  const body = content.slice(endIdx + 3).trim();
+  return { meta, body };
+}
+
+function parseRoutes(body: string): ParsedRoute[] {
+  const routes: ParsedRoute[] = [];
+
+  // Match ### `path` (type, visibility)
+  const routeHeaderRegex = /^###\s+`([^`]+)`\s+\((\w+),\s*(\w+)\)/gm;
+  const headers: Array<{ path: string; type: string; visibility: string; index: number }> = [];
+
+  let match: RegExpExecArray | null;
+  while ((match = routeHeaderRegex.exec(body)) !== null) {
+    headers.push({
+      path: match[1],
+      type: match[2],
+      visibility: match[3],
+      index: match.index,
+    });
+  }
+
+  for (let i = 0; i < headers.length; i++) {
+    const header = headers[i];
+    const sectionStart = header.index;
+    const sectionEnd = i < headers.length - 1 ? headers[i + 1].index : body.length;
+    const section = body.slice(sectionStart, sectionEnd);
+
+    // Extract the fenced code block
+    const codeMatch = section.match(/```(?:typescript|tsx|ts)\n([\s\S]*?)```/);
+    if (!codeMatch) continue;
+
+    routes.push({
+      path: header.path,
+      route_type: header.type as "api" | "page",
+      public: header.visibility === "public",
+      code: codeMatch[1],
+    });
+  }
+
+  return routes;
+}
+
+function parseDependencies(body: string): { npm: string[]; shadcn: string[] } {
+  const npm: string[] = [];
+  const shadcn: string[] = [];
+
+  const depsSection = body.match(/## Dependencies\n\n([\s\S]*?)(?=\n## |\n---|\Z)/);
+  if (!depsSection) return { npm, shadcn };
+
+  const text = depsSection[1];
+
+  // npm packages
+  const npmMatch = text.match(/\*\*npm packages\*\*[^\n]*\n((?:- `[^`]+`\n?)*)/);
+  if (npmMatch) {
+    const lines = npmMatch[1].trim().split("\n");
+    for (const line of lines) {
+      const m = line.match(/- `([^`]+)`/);
+      if (m) npm.push(m[1]);
+    }
+  }
+
+  // shadcn/components
+  const compMatch = text.match(/\*\*Components\*\*[^\n]*\n((?:- `[^`]+`\n?)*)/);
+  if (compMatch) {
+    const lines = compMatch[1].trim().split("\n");
+    for (const line of lines) {
+      const m = line.match(/- `([^`]+)`/);
+      if (m) shadcn.push(m[1]);
+    }
+  }
+
+  return { npm, shadcn };
+}
+
+function parseSetup(body: string): { directories: string[]; files: Array<{ path: string; content: string }>; secrets: string[] } {
+  const directories: string[] = [];
+  const files: Array<{ path: string; content: string }> = [];
+  const secrets: string[] = [];
+
+  const setupSection = body.match(/## Setup\n\n([\s\S]*?)(?=\n## |\n---|\Z)/);
+  if (!setupSection) return { directories, files, secrets };
+
+  const text = setupSection[1];
+
+  // Directories
+  const dirMatch = text.match(/\*\*Directories to create:\*\*\n((?:- `[^`]+`\n?)*)/);
+  if (dirMatch) {
+    for (const line of dirMatch[1].trim().split("\n")) {
+      const m = line.match(/- `([^`]+)`/);
+      if (m) directories.push(m[1]);
+    }
+  }
+
+  // Files
+  const fileMatch = text.match(/\*\*Files to initialize:\*\*\n((?:- `[^`]+`[^\n]*\n?)*)/);
+  if (fileMatch) {
+    for (const line of fileMatch[1].trim().split("\n")) {
+      const m = line.match(/- `([^`]+)` with content: `([^`]*)`/);
+      if (m) files.push({ path: m[1], content: m[2] });
+    }
+  }
+
+  // Secrets
+  const secretMatch = text.match(/\*\*Secrets required\*\*[^\n]*\n((?:- `[^`]+`\n?)*)/);
+  if (secretMatch) {
+    for (const line of secretMatch[1].trim().split("\n")) {
+      const m = line.match(/- `([^`]+)`/);
+      if (m) secrets.push(m[1]);
+    }
+  }
+
+  return { directories, files, secrets };
+}
+
+function replaceVariables(code: string, handle?: string): string {
+  if (handle) {
+    code = code.replace(/\{\{HANDLE\}\}/g, handle);
+  }
+  return code;
+}
+
+async function main() {
+  const filePath = values.file!.startsWith("/") ? values.file! : `/home/workspace/${values.file}`;
+  const raw = await Bun.file(filePath).text();
+
+  const { meta, body } = parseFrontmatter(raw);
+
+  if (meta.format !== "zopack") {
+    console.error("Error: This file does not appear to be a .zopack.md (missing format: zopack in frontmatter)");
+    process.exit(1);
+  }
+
+  const routes = parseRoutes(body);
+  const { npm, shadcn } = parseDependencies(body);
+  const { directories, files, secrets } = parseSetup(body);
+
+  // Apply handle replacement if provided
+  const handle = values.handle;
+  const processedRoutes = routes.map((r) => ({
+    ...r,
+    code: replaceVariables(r.code, handle),
+  }));
+
+  const plan: ParsedPack = {
+    meta,
+    routes: processedRoutes,
+    npm_deps: npm,
+    shadcn_components: shadcn,
+    directories,
+    files,
+    secrets,
+    variables: [],
+  };
+
+  // Check for unreplaced variables
+  const unreplaced = new Set<string>();
+  for (const r of processedRoutes) {
+    const matches = r.code.match(/\{\{(\w+)\}\}/g);
+    if (matches) for (const m of matches) unreplaced.add(m);
+  }
+
+  if (values.preview) {
+    console.log(`Pack: ${meta.name || "unknown"}`);
+    console.log(`Author: ${meta.author || "unknown"}`);
+    console.log(`Description: ${meta.description || "none"}`);
+    console.log(`\nRoutes (${routes.length}):`);
+    for (const r of routes) {
+      console.log(`  ${r.path} (${r.route_type}, ${r.public ? "public" : "private"}) -- ${r.code.split("\n").length} lines`);
+    }
+    if (npm.length > 0) console.log(`\nnpm deps: ${npm.join(", ")}`);
+    if (shadcn.length > 0) console.log(`\nComponents: ${shadcn.join(", ")}`);
+    if (directories.length > 0) console.log(`\nDirectories: ${directories.join(", ")}`);
+    if (files.length > 0) console.log(`\nFiles: ${files.map((f) => f.path).join(", ")}`);
+    if (secrets.length > 0) console.log(`\nSecrets needed: ${secrets.join(", ")}`);
+    if (unreplaced.size > 0) console.log(`\nUnreplaced variables: ${[...unreplaced].join(", ")}`);
+    if (!handle && unreplaced.has("{{HANDLE}}")) {
+      console.log(`\nTip: Pass --handle <your-handle> to replace {{HANDLE}} automatically`);
+    }
+  } else {
+    // Output full JSON plan for Zo to consume
+    if (unreplaced.size > 0 && !handle) {
+      console.error(`Warning: Unreplaced variables found: ${[...unreplaced].join(", ")}`);
+      if (unreplaced.has("{{HANDLE}}")) {
+        console.error(`Pass --handle <your-handle> to replace {{HANDLE}}`);
+      }
+    }
+    console.log(JSON.stringify(plan, null, 2));
+  }
+}
+
+main().catch((e) => {
+  console.error("Import failed:", e.message);
+  process.exit(1);
+});

--- a/Community/zopack/scripts/import.ts
+++ b/Community/zopack/scripts/import.ts
@@ -118,7 +118,7 @@ function parseDependencies(body: string): { npm: string[]; shadcn: string[] } {
   const npm: string[] = [];
   const shadcn: string[] = [];
 
-  const depsSection = body.match(/## Dependencies\n\n([\s\S]*?)(?=\n## |\n---|\Z)/);
+  const depsSection = body.match(/## Dependencies\n\n([\s\S]*?)(?=\n## |\n---|$)/);
   if (!depsSection) return { npm, shadcn };
 
   const text = depsSection[1];
@@ -151,7 +151,7 @@ function parseSetup(body: string): { directories: string[]; files: Array<{ path:
   const files: Array<{ path: string; content: string }> = [];
   const secrets: string[] = [];
 
-  const setupSection = body.match(/## Setup\n\n([\s\S]*?)(?=\n## |\n---|\Z)/);
+  const setupSection = body.match(/## Setup\n\n([\s\S]*?)(?=\n## |\n---|$)/);
   if (!setupSection) return { directories, files, secrets };
 
   const text = setupSection[1];


### PR DESCRIPTION
## Summary

Two community skills from skeletorjs:

- **revealjs-presentation** -- Build self-contained HTML slide decks using Reveal.js 5 + Chart.js 4. Outputs single `.html` files that open in any browser, or publishes directly to zo.space as live page routes. Includes animation system, chart recipes, layout patterns, and a publish script for zo.space deployment.

- **zopack** -- Export and import zo.space route setups as shareable `.zopack.md` files. Packages routes, dependencies, component imports, filesystem requirements, and secrets into a single markdown file that anyone can hand to their Zo for instant deployment. Includes both export and import scripts.

## Validation

`bun validate` passes with zero warnings on these skills (all 14 existing warnings are on External/ skills).