### PR TITLE
Add open-ztd: file-first task board

### DIFF
--- a/Community/open-ztd/SKILL.md
+++ b/Community/open-ztd/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: open-ztd
+description: |
+  ZTD (Zo To Do) is a file-first task board for Zo Computer. Manage tasks via CLI, REST API, or a drag-and-drop Kanban web UI on zo.space. Cards are stored as markdown files with YAML frontmatter, backed by a SQLite index for fast queries. Supports assignees, priorities, types, tags, due dates, comments, attachments, and activity logs. Use this skill to create, update, query, or manage tasks.
+license: MIT
+compatibility: Created for Zo Computer
+metadata:
+  author: skeletorjs.zo.computer
+  category: Community
+  display-name: ZTD Task Board
+  emoji: "\u2705"
+---
+
+# ZTD (Zo To Do)
+
+File-first task board for Zo. Cards stored as markdown at `Data/ztd/`, indexed by SQLite.
+
+## Setup
+
+Set `ZTD_DATA_DIR` to customize where cards are stored (default: `Data/ztd` relative to your workspace root).
+
+## CLI
+
+Run via: `bun run Skills/open-ztd/scripts/ztd.ts <command> [options]`
+
+### Quick Reference
+
+| Command | What it does |
+|---|---|
+| `ztd add --title "..."` | Create a card (defaults: inbox, user, task, medium) |
+| `ztd list` | List all active cards |
+| `ztd list --status inbox --assignee user` | Filter cards |
+| `ztd move <id> in_progress` | Change status |
+| `ztd done <id>` | Mark complete |
+| `ztd comment <id> --content "..."` | Add a comment |
+| `ztd attach <id> --file "path"` | Attach a file reference |
+| `ztd link <id> --conversation con_xyz` | Link a conversation |
+| `ztd read <id>` | Print full card file |
+| `ztd stats` | Board summary |
+| `ztd inbox` | Unprocessed items |
+| `ztd review` | Items in review |
+| `ztd overdue` | Past-due items |
+| `ztd stale` | Items with no updates in 7+ days |
+| `ztd reindex` | Rebuild SQLite from files |
+
+### Card IDs
+
+Format: ZTD-N (e.g., ZTD-1, ZTD-42). Accept either `ZTD-1` or `1` in commands.
+
+### Statuses
+
+`inbox` -> `in_progress` -> `in_review` -> `done`
+
+### Types
+
+`task`, `question`, `request`, `blocker`, `idea`
+
+### Web UI
+
+Deploy the kanban page and API routes from `assets/routes/` to your zo.space for a drag-and-drop board UI. See `references/guide.md` for details.

--- a/Community/open-ztd/assets/routes/api-kanban-wildcard.ts
+++ b/Community/open-ztd/assets/routes/api-kanban-wildcard.ts
@@ -1,0 +1,234 @@
+/**
+ * ZTD API -- All other endpoints (detail, update, delete, comments, etc.)
+ *
+ * Deploy to zo.space at: /api/kanban/:path{.+} (route_type: api, public: true)
+ *
+ * IMPORTANT: Update LIB_PATH below to match your skill install location.
+ */
+
+import type { Context } from "hono";
+import { readFileSync, existsSync, readdirSync, unlinkSync } from "fs";
+import { join, basename } from "path";
+
+// Update this path to point to your installed ztd skill's lib.ts
+const LIB_PATH = "/home/workspace/Skills/open-ztd/scripts/lib.ts";
+
+export default async (c: Context) => {
+  const method = c.req.method;
+  const pathStr = c.req.param("path") || "";
+  const parts = pathStr.split("/");
+
+  try {
+    const lib = await import(LIB_PATH);
+
+    // -----------------------------------------------------------------------
+    // /api/kanban/stats
+    // -----------------------------------------------------------------------
+    if (parts[0] === "stats" && method === "GET") {
+      const db = lib.getDb();
+      const statuses = db.prepare("SELECT status, COUNT(*) as count FROM cards WHERE archived = 0 GROUP BY status").all();
+      const assignees = db.prepare("SELECT assignee, COUNT(*) as count FROM cards WHERE archived = 0 GROUP BY assignee").all();
+      const today = new Date().toISOString().split("T")[0];
+      const overdue = db.prepare("SELECT COUNT(*) as count FROM cards WHERE archived = 0 AND due_date IS NOT NULL AND due_date < ? AND status != 'done'").get(today) as { count: number };
+      const total = db.prepare("SELECT COUNT(*) as count FROM cards WHERE archived = 0").get() as { count: number };
+      db.close();
+      return c.json({ total: total.count, overdue: overdue.count, by_status: statuses, by_assignee: assignees });
+    }
+
+    // -----------------------------------------------------------------------
+    // /api/kanban/reindex
+    // -----------------------------------------------------------------------
+    if (parts[0] === "reindex" && method === "POST") {
+      const db = lib.getDb();
+      db.prepare("DELETE FROM cards").run();
+      let count = 0, errors = 0, maxId = 0;
+      for (const [dir, archived] of [[lib.DATA_DIR, 0], [lib.ARCHIVE_DIR, 1]] as const) {
+        for (const file of lib.listCardFiles(dir)) {
+          try {
+            const content = readFileSync(join(dir, file), "utf-8");
+            const card = lib.parseCardFile(content);
+            if (archived) {
+              const fm = card.frontmatter;
+              db.prepare(`INSERT OR REPLACE INTO cards (id,title,status,assignee,type,priority,tags,due_date,source,sort_order,created_at,updated_at,completed_at,archived) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,1)`).run(
+                fm.id, fm.title, fm.status, fm.assignee, fm.type, fm.priority, JSON.stringify(fm.tags), fm.due_date, fm.source, 0, fm.created_at, fm.updated_at, fm.completed_at);
+            } else {
+              lib.indexCard(db, card, count);
+            }
+            if (card.frontmatter.id > maxId) maxId = card.frontmatter.id;
+            count++;
+          } catch { errors++; }
+        }
+      }
+      db.prepare("INSERT OR REPLACE INTO metadata (key, value) VALUES ('next_id', ?)").run(String(maxId + 1));
+      db.close();
+      return c.json({ reindexed: count, errors, next_id: maxId + 1 });
+    }
+
+    // -----------------------------------------------------------------------
+    // /api/kanban/reorder
+    // -----------------------------------------------------------------------
+    if (parts[0] === "reorder" && method === "POST") {
+      const body = await c.req.json();
+      if (!Array.isArray(body.orders)) return c.json({ error: "orders array required" }, 400);
+      const db = lib.getDb();
+      const stmt = db.prepare("UPDATE cards SET sort_order = ? WHERE id = ?");
+      for (const o of body.orders) stmt.run(o.sort_order, o.id);
+      db.close();
+      return c.json({ updated: body.orders.length });
+    }
+
+    // -----------------------------------------------------------------------
+    // /api/kanban/archive
+    // -----------------------------------------------------------------------
+    if (parts[0] === "archive" && method === "GET") {
+      const db = lib.getDb();
+      const url = new URL(c.req.url);
+      const query = url.searchParams.get("query");
+      let sql = "SELECT * FROM cards WHERE archived = 1";
+      const params: any[] = [];
+      if (query) { sql += " AND title LIKE ?"; params.push(`%${query}%`); }
+      sql += " ORDER BY completed_at DESC LIMIT 50";
+      const rows = db.prepare(sql).all(...params);
+      db.close();
+      return c.json(rows);
+    }
+
+    // -----------------------------------------------------------------------
+    // /api/kanban/:id (numeric)
+    // -----------------------------------------------------------------------
+    const id = parseInt(parts[0], 10);
+    if (isNaN(id)) return c.json({ error: "Not found" }, 404);
+
+    const subRoute = parts[1];
+
+    // -----------------------------------------------------------------------
+    // /api/kanban/:id/comments
+    // -----------------------------------------------------------------------
+    if (subRoute === "comments" && method === "POST") {
+      const body = await c.req.json();
+      if (!body.content) return c.json({ error: "content required" }, 400);
+      const card = lib.readCard(id);
+      if (!card) return c.json({ error: "Card not found" }, 404);
+      const ts = lib.now();
+      const author = body.author || "user";
+      card.comments.push({ author, timestamp: ts, content: body.content });
+      card.activity.push(`${ts} | ${author} | commented`);
+      card.frontmatter.updated_at = ts;
+      lib.writeCard(card);
+      const db = lib.getDb();
+      lib.indexCard(db, card);
+      db.close();
+      return c.json({ ok: true, comment: { author, timestamp: ts, content: body.content } });
+    }
+
+    // -----------------------------------------------------------------------
+    // /api/kanban/:id/attachments
+    // -----------------------------------------------------------------------
+    if (subRoute === "attachments" && method === "POST") {
+      const body = await c.req.json();
+      if (!body.path) return c.json({ error: "path required" }, 400);
+      const card = lib.readCard(id);
+      if (!card) return c.json({ error: "Card not found" }, 404);
+      const ts = lib.now();
+      const author = body.added_by || "user";
+      card.frontmatter.attachments.push({
+        path: body.path, name: body.name || basename(body.path),
+        added_by: author, added_at: ts,
+      });
+      card.activity.push(`${ts} | ${author} | attached ${body.name || basename(body.path)}`);
+      card.frontmatter.updated_at = ts;
+      lib.writeCard(card);
+      const db = lib.getDb();
+      lib.indexCard(db, card);
+      db.close();
+      return c.json({ ok: true });
+    }
+
+    if (subRoute === "attachments" && method === "DELETE") {
+      const body = await c.req.json();
+      if (!body.path) return c.json({ error: "path required" }, 400);
+      const card = lib.readCard(id);
+      if (!card) return c.json({ error: "Card not found" }, 404);
+      card.frontmatter.attachments = card.frontmatter.attachments.filter((a: any) => a.path !== body.path);
+      card.frontmatter.updated_at = lib.now();
+      lib.writeCard(card);
+      const db = lib.getDb();
+      lib.indexCard(db, card);
+      db.close();
+      return c.json({ ok: true });
+    }
+
+    // -----------------------------------------------------------------------
+    // /api/kanban/:id/activity
+    // -----------------------------------------------------------------------
+    if (subRoute === "activity" && method === "GET") {
+      const card = lib.readCard(id);
+      if (!card) return c.json({ error: "Card not found" }, 404);
+      return c.json({ activity: card.activity });
+    }
+
+    // -----------------------------------------------------------------------
+    // /api/kanban/:id -- card detail / update / delete
+    // -----------------------------------------------------------------------
+    if (!subRoute) {
+      if (method === "GET") {
+        const card = lib.readCard(id);
+        if (!card) return c.json({ error: "Card not found" }, 404);
+        return c.json({
+          ...card.frontmatter,
+          display_id: `${lib.CARD_PREFIX}-${id}`,
+          description: card.description,
+          comments: card.comments,
+          activity: card.activity,
+        });
+      }
+
+      if (method === "PATCH") {
+        const body = await c.req.json();
+        const card = lib.readCard(id);
+        if (!card) return c.json({ error: "Card not found" }, 404);
+        const fm = card.frontmatter;
+        const changes: string[] = [];
+        const actor = body.actor || "user";
+        if (body.title !== undefined) { fm.title = body.title; changes.push(`title -> ${body.title}`); }
+        if (body.status !== undefined) {
+          const old = fm.status; fm.status = body.status;
+          changes.push(`status: ${old} -> ${body.status}`);
+          if (body.status === "done" && !fm.completed_at) fm.completed_at = lib.now();
+        }
+        if (body.assignee !== undefined) { fm.assignee = body.assignee; changes.push(`assignee -> ${body.assignee}`); }
+        if (body.priority !== undefined) { fm.priority = body.priority; changes.push(`priority -> ${body.priority}`); }
+        if (body.type !== undefined) { fm.type = body.type; changes.push(`type -> ${body.type}`); }
+        if (body.tags !== undefined) { fm.tags = body.tags; changes.push("tags updated"); }
+        if (body.due_date !== undefined) { fm.due_date = body.due_date; changes.push(`due_date -> ${body.due_date}`); }
+        if (body.description !== undefined) { card.description = body.description; changes.push("description updated"); }
+        if (body.conversation) {
+          if (!fm.conversations.includes(body.conversation)) fm.conversations.push(body.conversation);
+        }
+        fm.updated_at = lib.now();
+        for (const ch of changes) card.activity.push(`${fm.updated_at} | ${actor} | ${ch}`);
+        lib.writeCard(card);
+        const db = lib.getDb();
+        lib.indexCard(db, card);
+        db.close();
+        return c.json({ ok: true, changes, card: { ...fm, display_id: `${lib.CARD_PREFIX}-${id}` } });
+      }
+
+      if (method === "DELETE") {
+        const p1 = lib.cardPath(id);
+        const p2 = lib.cardPath(id, true);
+        if (existsSync(p1)) unlinkSync(p1);
+        else if (existsSync(p2)) unlinkSync(p2);
+        else return c.json({ error: "Card not found" }, 404);
+        const db = lib.getDb();
+        db.prepare("DELETE FROM cards WHERE id = ?").run(id);
+        db.close();
+        return c.json({ ok: true, deleted: id });
+      }
+    }
+
+    return c.json({ error: "Not found" }, 404);
+  } catch (e: any) {
+    return c.json({ error: e.message }, 500);
+  }
+};

--- a/Community/open-ztd/assets/routes/api-kanban.ts
+++ b/Community/open-ztd/assets/routes/api-kanban.ts
@@ -1,0 +1,73 @@
+/**
+ * ZTD API -- List and create cards
+ *
+ * Deploy to zo.space at: /api/kanban (route_type: api, public: true)
+ *
+ * IMPORTANT: Update LIB_PATH below to match your skill install location.
+ */
+
+import type { Context } from "hono";
+
+// Update this path to point to your installed ztd skill's lib.ts
+const LIB_PATH = "/home/workspace/Skills/open-ztd/scripts/lib.ts";
+
+export default async (c: Context) => {
+  const method = c.req.method;
+  try {
+    const lib = await import(LIB_PATH);
+    const url = new URL(c.req.url);
+
+    // GET /api/kanban -- list cards
+    if (method === "GET") {
+      const db = lib.getDb();
+      let sql = "SELECT * FROM cards WHERE archived = 0";
+      const params: any[] = [];
+      const status = url.searchParams.get("status");
+      const assignee = url.searchParams.get("assignee");
+      const type = url.searchParams.get("type");
+      const tag = url.searchParams.get("tag");
+      if (status) { sql += " AND status = ?"; params.push(status); }
+      if (assignee) { sql += " AND assignee = ?"; params.push(assignee); }
+      if (type) { sql += " AND type = ?"; params.push(type); }
+      if (tag) { sql += " AND tags LIKE ?"; params.push(`%"${tag}"%`); }
+      sql += " ORDER BY sort_order ASC, id ASC";
+      const rows = db.prepare(sql).all(...params) as any[];
+      db.close();
+      return c.json(rows.map((r: any) => ({
+        ...r,
+        display_id: `${lib.CARD_PREFIX}-${r.id}`,
+        tags: r.tags ? JSON.parse(r.tags) : [],
+      })));
+    }
+
+    // POST /api/kanban -- create card
+    if (method === "POST") {
+      const body = await c.req.json();
+      if (!body.title) return c.json({ error: "title required" }, 400);
+      const db = lib.getDb();
+      const id = lib.getNextId(db);
+      const ts = lib.now();
+      const fm = {
+        id, title: body.title, status: body.status || "inbox",
+        assignee: body.assignee || "user", type: body.type || "task",
+        priority: body.priority || "medium", tags: body.tags || [],
+        due_date: body.due_date || null, source: body.source || "manual",
+        created_at: ts, updated_at: ts, completed_at: null,
+        conversations: body.conversation ? [body.conversation] : [],
+        attachments: [],
+      };
+      const card = {
+        frontmatter: fm, description: body.description || "",
+        comments: [], activity: [`${ts} | ${fm.assignee} | created`],
+      };
+      lib.writeCard(card);
+      lib.indexCard(db, card);
+      db.close();
+      return c.json({ ok: true, id, display_id: `${lib.CARD_PREFIX}-${id}`, title: fm.title }, 201);
+    }
+
+    return c.json({ error: "Method not allowed" }, 405);
+  } catch (e: any) {
+    return c.json({ error: e.message }, 500);
+  }
+};

--- a/Community/open-ztd/assets/routes/kanban.tsx
+++ b/Community/open-ztd/assets/routes/kanban.tsx
@@ -1,0 +1,648 @@
+/**
+ * ZTD Kanban Board -- zo.space page route
+ *
+ * Deploy to your zo.space as a private page at /kanban
+ * Requires the API routes to be deployed at /api/kanban
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  closestCorners,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragStartEvent,
+  type DragEndEvent,
+  type DragOverEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { useDroppable } from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+import { Loader2, Plus, X, MessageSquare, Paperclip, AlertTriangle, HelpCircle, Lightbulb, Send, ChevronDown } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Card {
+  id: number;
+  display_id: string;
+  title: string;
+  status: string;
+  assignee: string;
+  type: string;
+  priority: string;
+  tags: string[];
+  due_date: string | null;
+  description?: string;
+  comments?: Array<{ author: string; timestamp: string; content: string }>;
+  activity?: string[];
+  conversations?: string[];
+  attachments?: Array<{ path: string; name: string }>;
+  sort_order: number;
+}
+
+type Status = "inbox" | "in_progress" | "in_review" | "done";
+
+const STATUSES: { key: Status; label: string; color: string }[] = [
+  { key: "inbox", label: "Inbox", color: "bg-zinc-500" },
+  { key: "in_progress", label: "In Progress", color: "bg-blue-500" },
+  { key: "in_review", label: "In Review", color: "bg-amber-500" },
+  { key: "done", label: "Done", color: "bg-emerald-500" },
+];
+
+const PRIORITY_COLORS: Record<string, string> = {
+  urgent: "border-l-red-500",
+  high: "border-l-amber-500",
+  medium: "border-l-blue-500",
+  low: "border-l-zinc-400",
+};
+
+const TYPE_ICONS: Record<string, any> = {
+  question: HelpCircle,
+  blocker: AlertTriangle,
+  idea: Lightbulb,
+  request: Send,
+};
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+const API = "/api/kanban";
+
+async function fetchCards(): Promise<Card[]> {
+  const res = await fetch(API);
+  return res.json();
+}
+
+async function createCard(data: Partial<Card>): Promise<Card> {
+  const res = await fetch(API, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  return res.json();
+}
+
+async function updateCard(id: number, data: any): Promise<any> {
+  const res = await fetch(`${API}/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  return res.json();
+}
+
+async function fetchCardDetail(id: number): Promise<Card> {
+  const res = await fetch(`${API}/${id}`);
+  return res.json();
+}
+
+async function addComment(id: number, content: string, author: string): Promise<any> {
+  const res = await fetch(`${API}/${id}/comments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ content, author }),
+  });
+  return res.json();
+}
+
+async function saveReorder(orders: Array<{ id: number; sort_order: number }>): Promise<void> {
+  await fetch(`${API}/reorder`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ orders }),
+  });
+}
+
+async function deleteCard(id: number): Promise<void> {
+  await fetch(`${API}/${id}`, { method: "DELETE" });
+}
+
+// ---------------------------------------------------------------------------
+// Sortable Card Component
+// ---------------------------------------------------------------------------
+
+function SortableCard({ card, onClick }: { card: Card; onClick: () => void }) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: `card-${card.id}` });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  const TypeIcon = TYPE_ICONS[card.type];
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      onClick={(e) => { e.stopPropagation(); onClick(); }}
+      className={`group p-3 rounded-lg border border-border bg-card text-card-foreground cursor-grab active:cursor-grabbing hover:border-primary/30 transition-colors border-l-4 ${PRIORITY_COLORS[card.priority] || "border-l-transparent"}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5 mb-1">
+            <span className="text-[10px] font-mono text-muted-foreground">{card.display_id}</span>
+            {TypeIcon && <TypeIcon className="w-3 h-3 text-muted-foreground" />}
+          </div>
+          <p className="text-sm font-medium leading-tight">{card.title}</p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2 mt-2">
+        <span className="inline-block w-5 h-5 rounded-full text-[10px] font-bold flex items-center justify-center bg-primary/20 text-primary">
+          {card.assignee.charAt(0).toUpperCase()}
+        </span>
+        {card.tags && card.tags.length > 0 && (
+          <div className="flex gap-1 flex-wrap">
+            {card.tags.slice(0, 2).map((tag) => (
+              <span key={tag} className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">{tag}</span>
+            ))}
+            {card.tags.length > 2 && (
+              <span className="text-[10px] text-muted-foreground">+{card.tags.length - 2}</span>
+            )}
+          </div>
+        )}
+        {card.due_date && (
+          <span className={`text-[10px] ml-auto ${new Date(card.due_date) < new Date() ? "text-red-400" : "text-muted-foreground"}`}>
+            {new Date(card.due_date).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card Overlay (while dragging)
+// ---------------------------------------------------------------------------
+
+function CardOverlay({ card }: { card: Card }) {
+  return (
+    <div className={`p-3 rounded-lg border border-primary/50 bg-card text-card-foreground shadow-xl border-l-4 ${PRIORITY_COLORS[card.priority] || "border-l-transparent"} rotate-2`}>
+      <div className="flex items-center gap-1.5 mb-1">
+        <span className="text-[10px] font-mono text-muted-foreground">{card.display_id}</span>
+      </div>
+      <p className="text-sm font-medium">{card.title}</p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Column Component
+// ---------------------------------------------------------------------------
+
+function Column({
+  status,
+  cards,
+  onCardClick,
+  onAddCard,
+}: {
+  status: typeof STATUSES[number];
+  cards: Card[];
+  onCardClick: (card: Card) => void;
+  onAddCard: (status: Status) => void;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: `column-${status.key}` });
+  const sortableIds = cards.map((c) => `card-${c.id}`);
+
+  return (
+    <div className="flex flex-col min-w-[280px] w-[280px] flex-shrink-0">
+      <div className="flex items-center gap-2 mb-3 px-1">
+        <div className={`w-2 h-2 rounded-full ${status.color}`} />
+        <h2 className="text-sm font-semibold text-foreground">{status.label}</h2>
+        <span className="text-xs text-muted-foreground ml-auto">{cards.length}</span>
+      </div>
+      <div
+        ref={setNodeRef}
+        className={`flex-1 flex flex-col gap-2 p-2 rounded-xl transition-colors min-h-[200px] ${isOver ? "bg-primary/5 ring-1 ring-primary/20" : "bg-muted/30"}`}
+      >
+        <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+          {cards.map((card) => (
+            <SortableCard key={card.id} card={card} onClick={() => onCardClick(card)} />
+          ))}
+        </SortableContext>
+        <button
+          onClick={() => onAddCard(status.key)}
+          className="flex items-center gap-1.5 p-2 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+        >
+          <Plus className="w-3.5 h-3.5" />
+          <span>Add card</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card Detail Panel
+// ---------------------------------------------------------------------------
+
+function CardDetail({
+  card,
+  onClose,
+  onUpdate,
+}: {
+  card: Card;
+  onClose: () => void;
+  onUpdate: () => void;
+}) {
+  const [detail, setDetail] = useState<Card | null>(null);
+  const [commentText, setCommentText] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchCardDetail(card.id).then((d) => { setDetail(d); setLoading(false); });
+  }, [card.id]);
+
+  const handleStatusChange = async (newStatus: string) => {
+    await updateCard(card.id, { status: newStatus });
+    onUpdate();
+    const d = await fetchCardDetail(card.id);
+    setDetail(d);
+  };
+
+  const handleComment = async () => {
+    if (!commentText.trim()) return;
+    await addComment(card.id, commentText, "user");
+    setCommentText("");
+    const d = await fetchCardDetail(card.id);
+    setDetail(d);
+  };
+
+  const handleDelete = async () => {
+    await deleteCard(card.id);
+    onClose();
+    onUpdate();
+  };
+
+  if (loading || !detail) {
+    return (
+      <div className="fixed inset-y-0 right-0 w-[420px] bg-background border-l border-border shadow-2xl z-50 flex items-center justify-center">
+        <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-y-0 right-0 w-[420px] bg-background border-l border-border shadow-2xl z-50 flex flex-col overflow-hidden">
+      <div className="flex items-center justify-between p-4 border-b border-border">
+        <span className="text-sm font-mono text-muted-foreground">{detail.display_id}</span>
+        <button onClick={onClose} className="p-1 rounded hover:bg-muted"><X className="w-4 h-4" /></button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        <h2 className="text-lg font-semibold">{detail.title}</h2>
+
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <div>
+            <label className="text-muted-foreground text-xs">Status</label>
+            <select
+              value={detail.status}
+              onChange={(e) => handleStatusChange(e.target.value)}
+              className="w-full mt-1 p-1.5 rounded border border-border bg-background text-sm"
+            >
+              {STATUSES.map((s) => (
+                <option key={s.key} value={s.key}>{s.label}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="text-muted-foreground text-xs">Assignee</label>
+            <p className="mt-1 p-1.5 capitalize">{detail.assignee}</p>
+          </div>
+          <div>
+            <label className="text-muted-foreground text-xs">Priority</label>
+            <p className="mt-1 p-1.5 capitalize">{detail.priority}</p>
+          </div>
+          <div>
+            <label className="text-muted-foreground text-xs">Type</label>
+            <p className="mt-1 p-1.5 capitalize">{detail.type}</p>
+          </div>
+        </div>
+
+        {detail.tags && detail.tags.length > 0 && (
+          <div>
+            <label className="text-muted-foreground text-xs">Tags</label>
+            <div className="flex gap-1 mt-1 flex-wrap">
+              {detail.tags.map((tag) => (
+                <span key={tag} className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">{tag}</span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {detail.description && (
+          <div>
+            <label className="text-muted-foreground text-xs">Description</label>
+            <p className="mt-1 text-sm whitespace-pre-wrap">{detail.description}</p>
+          </div>
+        )}
+
+        {detail.attachments && detail.attachments.length > 0 && (
+          <div>
+            <label className="text-muted-foreground text-xs flex items-center gap-1"><Paperclip className="w-3 h-3" /> Attachments</label>
+            <div className="mt-1 space-y-1">
+              {detail.attachments.map((a, i) => (
+                <div key={i} className="text-xs text-blue-400 truncate">{a.name || a.path}</div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div>
+          <label className="text-muted-foreground text-xs flex items-center gap-1">
+            <MessageSquare className="w-3 h-3" /> Comments ({detail.comments?.length || 0})
+          </label>
+          <div className="mt-2 space-y-3">
+            {detail.comments?.map((c, i) => (
+              <div key={i} className="text-sm">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="font-medium text-xs text-primary">{c.author}</span>
+                  <span className="text-[10px] text-muted-foreground">
+                    {new Date(c.timestamp).toLocaleDateString("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}
+                  </span>
+                </div>
+                <p className="text-muted-foreground whitespace-pre-wrap">{c.content}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-3 flex gap-2">
+            <input
+              value={commentText}
+              onChange={(e) => setCommentText(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); handleComment(); } }}
+              placeholder="Add a comment..."
+              className="flex-1 text-sm p-2 rounded border border-border bg-background"
+            />
+            <button onClick={handleComment} className="px-3 py-2 rounded bg-primary text-primary-foreground text-sm hover:opacity-90">Send</button>
+          </div>
+        </div>
+
+        {detail.activity && detail.activity.length > 0 && (
+          <div>
+            <label className="text-muted-foreground text-xs">Activity</label>
+            <div className="mt-1 space-y-1">
+              {detail.activity.slice(-10).reverse().map((a, i) => {
+                const parts = a.split(" | ");
+                return (
+                  <div key={i} className="text-[11px] text-muted-foreground">
+                    <span className="opacity-60">{parts[0] ? new Date(parts[0]).toLocaleDateString("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }) : ""}</span>
+                    {" "}<span className="font-medium">{parts[1]}</span>{" "}{parts.slice(2).join(" | ")}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="p-3 border-t border-border">
+        <button onClick={handleDelete} className="text-xs text-red-400 hover:text-red-300">Delete card</button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Quick Add Form
+// ---------------------------------------------------------------------------
+
+function QuickAdd({ status, onSubmit, onCancel }: { status: Status; onSubmit: (title: string) => void; onCancel: () => void }) {
+  const [title, setTitle] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { inputRef.current?.focus(); }, []);
+
+  const handleSubmit = () => {
+    if (title.trim()) { onSubmit(title.trim()); setTitle(""); }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onCancel}>
+      <div className="bg-background border border-border rounded-xl p-4 w-[400px] shadow-2xl" onClick={(e) => e.stopPropagation()}>
+        <h3 className="text-sm font-semibold mb-3">New card in {STATUSES.find((s) => s.key === status)?.label}</h3>
+        <input
+          ref={inputRef}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") handleSubmit(); if (e.key === "Escape") onCancel(); }}
+          placeholder="Card title..."
+          className="w-full p-2.5 rounded-lg border border-border bg-background text-sm"
+        />
+        <div className="flex justify-end gap-2 mt-3">
+          <button onClick={onCancel} className="px-3 py-1.5 rounded text-sm text-muted-foreground hover:bg-muted">Cancel</button>
+          <button onClick={handleSubmit} className="px-3 py-1.5 rounded bg-primary text-primary-foreground text-sm hover:opacity-90">Create</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Board
+// ---------------------------------------------------------------------------
+
+export default function KanbanBoard() {
+  const [cards, setCards] = useState<Card[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeCard, setActiveCard] = useState<Card | null>(null);
+  const [selectedCard, setSelectedCard] = useState<Card | null>(null);
+  const [addingTo, setAddingTo] = useState<Status | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor),
+  );
+
+  const loadCards = useCallback(() => {
+    fetchCards()
+      .then((data) => { setCards(data); setError(null); })
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => { loadCards(); }, [loadCards]);
+
+  const getColumnCards = (status: Status) =>
+    cards.filter((c) => c.status === status).sort((a, b) => a.sort_order - b.sort_order);
+
+  const findCardById = (dragId: string): Card | undefined => {
+    const id = parseInt(dragId.replace("card-", ""), 10);
+    return cards.find((c) => c.id === id);
+  };
+
+  const handleDragStart = (event: DragStartEvent) => {
+    const card = findCardById(String(event.active.id));
+    if (card) setActiveCard(card);
+  };
+
+  const handleDragOver = (event: DragOverEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+
+    const activeId = String(active.id);
+    const overId = String(over.id);
+
+    const draggedCard = findCardById(activeId);
+    if (!draggedCard) return;
+
+    let targetStatus: Status | null = null;
+    if (overId.startsWith("column-")) {
+      targetStatus = overId.replace("column-", "") as Status;
+    } else if (overId.startsWith("card-")) {
+      const overCard = findCardById(overId);
+      if (overCard) targetStatus = overCard.status as Status;
+    }
+
+    if (targetStatus && draggedCard.status !== targetStatus) {
+      setCards((prev) =>
+        prev.map((c) => (c.id === draggedCard.id ? { ...c, status: targetStatus! } : c))
+      );
+    }
+  };
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+    setActiveCard(null);
+
+    if (!over) return;
+
+    const activeId = String(active.id);
+    const overId = String(over.id);
+    const draggedCard = findCardById(activeId);
+    if (!draggedCard) return;
+
+    let targetStatus: Status = draggedCard.status as Status;
+    if (overId.startsWith("column-")) {
+      targetStatus = overId.replace("column-", "") as Status;
+    } else if (overId.startsWith("card-")) {
+      const overCard = findCardById(overId);
+      if (overCard) targetStatus = overCard.status as Status;
+    }
+
+    const columnCards = cards
+      .filter((c) => c.status === targetStatus)
+      .sort((a, b) => a.sort_order - b.sort_order);
+
+    if (overId.startsWith("card-") && activeId !== overId) {
+      const oldIndex = columnCards.findIndex((c) => `card-${c.id}` === activeId);
+      const newIndex = columnCards.findIndex((c) => `card-${c.id}` === overId);
+      if (oldIndex !== -1 && newIndex !== -1) {
+        const reordered = arrayMove(columnCards, oldIndex, newIndex);
+        const orders = reordered.map((c, i) => ({ id: c.id, sort_order: i }));
+        await saveReorder(orders);
+      }
+    }
+
+    const originalCard = cards.find((c) => c.id === draggedCard.id);
+    if (originalCard && targetStatus !== (originalCard as any)._originalStatus) {
+      await updateCard(draggedCard.id, { status: targetStatus, actor: "user" });
+    }
+
+    loadCards();
+  };
+
+  const handleAddCard = async (title: string) => {
+    if (!addingTo) return;
+    await createCard({ title, status: addingTo, assignee: "user", source: "manual" });
+    setAddingTo(null);
+    loadCards();
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="border-b border-border px-6 py-4 flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold">ZTD</h1>
+          <p className="text-xs text-muted-foreground">Zo To Do</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-muted-foreground">{cards.length} cards</span>
+          <button
+            onClick={() => setAddingTo("inbox")}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-primary text-primary-foreground text-sm hover:opacity-90"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            New
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mx-6 mt-4 p-3 rounded-lg bg-destructive/10 text-destructive text-sm">{error}</div>
+      )}
+
+      <div className="p-6 overflow-x-auto">
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCorners}
+          onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
+          onDragEnd={handleDragEnd}
+        >
+          <div className="flex gap-4">
+            {STATUSES.map((status) => (
+              <Column
+                key={status.key}
+                status={status}
+                cards={getColumnCards(status.key)}
+                onCardClick={(card) => setSelectedCard(card)}
+                onAddCard={(s) => setAddingTo(s)}
+              />
+            ))}
+          </div>
+
+          <DragOverlay>
+            {activeCard ? <CardOverlay card={activeCard} /> : null}
+          </DragOverlay>
+        </DndContext>
+      </div>
+
+      {selectedCard && (
+        <CardDetail
+          card={selectedCard}
+          onClose={() => setSelectedCard(null)}
+          onUpdate={() => { loadCards(); }}
+        />
+      )}
+
+      {addingTo && (
+        <QuickAdd
+          status={addingTo}
+          onSubmit={handleAddCard}
+          onCancel={() => setAddingTo(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/Community/open-ztd/references/guide.md
+++ b/Community/open-ztd/references/guide.md
@@ -1,0 +1,334 @@
+# ZTD (Zo To Do) -- Complete Guide
+
+A file-first task board for Zo Computer. Manage tasks via CLI, REST API, or a drag-and-drop Kanban web UI.
+
+---
+
+## Quick Start
+
+**CLI:**
+```bash
+# Create a card
+bun run Skills/open-ztd/scripts/ztd.ts add --title "Fix the login bug" --assignee user --priority high
+
+# See what's on the board
+bun run Skills/open-ztd/scripts/ztd.ts list
+
+# Move a card
+bun run Skills/open-ztd/scripts/ztd.ts move 5 in_progress
+
+# Mark done
+bun run Skills/open-ztd/scripts/ztd.ts done 5
+```
+
+**API (after deploying routes to zo.space):**
+```
+GET    /api/kanban          -- List cards
+POST   /api/kanban          -- Create card
+PATCH  /api/kanban/:id      -- Update card
+DELETE /api/kanban/:id      -- Delete card
+```
+
+**Web UI:** Deploy the `/kanban` page route to your zo.space for a drag-and-drop board.
+
+---
+
+## How It Works
+
+### Storage: File-First with SQLite Index
+
+Each card is a markdown file at `Data/ztd/ZTD-N.md`. The file IS the card. A SQLite index at `Data/ztd/index.db` caches frontmatter for fast API queries but the files are the source of truth.
+
+```
+Data/ztd/
+  ZTD-1.md          -- Card file (source of truth)
+  ZTD-2.md
+  index.db          -- SQLite index (derived, rebuildable)
+  archive/          -- Done cards moved here after 14 days
+    ZTD-1.md
+```
+
+**In the file:** All card data -- frontmatter, description, comments, activity log. Everything needed to fully reconstruct the card.
+
+**Only in SQLite:** sort_order (drag-and-drop position), archived flag, next_id counter. These are ephemeral/derived.
+
+**If the index gets out of sync:** `ztd reindex` rebuilds it from the files.
+
+**Custom data directory:** Set the `ZTD_DATA_DIR` environment variable to store cards elsewhere.
+
+### Card File Format
+
+```markdown
+---
+id: 1
+title: Build the ZTD API
+status: in_progress
+assignee: user
+type: task
+priority: high
+tags: ["infrastructure"]
+due_date: 2026-03-01
+source: conversation
+created_at: 2026-02-22T09:00:00Z
+updated_at: 2026-02-22T15:30:00Z
+completed_at: null
+conversations:
+  - con_abc123
+attachments:
+  - path: docs/planning.md
+    name: Planning Doc
+    added_by: user
+    added_at: 2026-02-22T09:00:00Z
+---
+
+Build the zo.space API route for the task board.
+
+## Comments
+
+<!--- comment: user | 2026-02-22 09:15 --->
+Started working on the schema. Going with file-per-card approach.
+<!--- /comment --->
+
+<!--- comment: ai | 2026-02-22 10:00 --->
+Make sure we handle the reorder endpoint for drag-and-drop.
+<!--- /comment --->
+
+## Activity
+
+- 2026-02-22 09:00 | user | created
+- 2026-02-22 09:15 | user | status: inbox -> in_progress
+- 2026-02-22 10:00 | ai | commented
+```
+
+---
+
+## Card Fields
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `id` | integer | auto | Displayed as ZTD-1, ZTD-2, etc. |
+| `title` | string | required | Short description |
+| `status` | enum | `inbox` | `inbox`, `in_progress`, `in_review`, `done` |
+| `assignee` | string | `user` | Freeform. Use any names you want. |
+| `type` | enum | `task` | `task`, `question`, `request`, `blocker`, `idea` |
+| `priority` | enum | `medium` | `urgent`, `high`, `medium`, `low` |
+| `tags` | string[] | `[]` | Freeform. e.g. `["frontend", "urgent"]` |
+| `due_date` | date | null | ISO date string |
+| `source` | enum | `manual` | `manual`, `conversation`, `scheduled`, `boot` |
+| `created_at` | datetime | auto | When created |
+| `updated_at` | datetime | auto | Last modified |
+| `completed_at` | datetime | null | Set when moved to `done` |
+| `conversations` | string[] | `[]` | Zo conversation IDs linked to this card |
+| `attachments` | object[] | `[]` | File references: `{path, name, added_by, added_at}` |
+
+### Statuses
+
+| Status | What it means |
+|---|---|
+| **inbox** | New, unprocessed. |
+| **in_progress** | Actively being worked on. |
+| **in_review** | Done but needs someone to check/approve/respond. |
+| **done** | Complete. Auto-archived after 14 days. |
+
+### Types
+
+| Type | When to use |
+|---|---|
+| **task** | Work to be done |
+| **question** | Needs a response from the assignee |
+| **request** | Asking someone to do something |
+| **blocker** | Can't proceed until resolved |
+| **idea** | Not actionable yet, just captured |
+
+---
+
+## CLI Reference
+
+Run all commands via: `bun run Skills/open-ztd/scripts/ztd.ts <command> [options]`
+
+### Card Management
+
+```bash
+# Create a card
+ztd add --title "..." [--description "..."] [--assignee user] \
+  [--type task|question|request|blocker|idea] [--priority urgent|high|medium|low] \
+  [--tags "tag1,tag2"] [--due-date 2026-03-01] \
+  [--source manual|conversation|scheduled|boot] [--conversation con_abc123]
+
+# List cards (with optional filters)
+ztd list [--status inbox|in_progress|in_review|done] [--assignee user] \
+  [--tag ...] [--type ...]
+
+# Update card fields
+ztd update <id> [--title "..."] [--status ...] [--assignee ...] \
+  [--priority ...] [--tags ...] [--due-date ...] [--actor ...]
+
+# Move card to a new status
+ztd move <id> <status> [--actor ...]
+
+# Mark complete
+ztd done <id>
+
+# Delete a card
+ztd delete <id>
+
+# Read full card contents
+ztd read <id>
+```
+
+### Comments, Attachments, Conversations
+
+```bash
+# Add a comment
+ztd comment <id> --content "..." [--author user]
+
+# Attach a file reference
+ztd attach <id> --file "path/to/file" [--name "Display Name"] [--author user]
+
+# Link a conversation
+ztd link <id> --conversation <conversation_id>
+```
+
+### Board Views
+
+```bash
+# Board summary (counts by status)
+ztd stats
+
+# Unprocessed inbox items
+ztd inbox
+
+# Items in review (optionally filter by assignee)
+ztd review [--assignee user]
+
+# Past-due items
+ztd overdue
+
+# Items with no updates in 7+ days
+ztd stale
+```
+
+### Maintenance
+
+```bash
+# Rebuild SQLite index from card files
+ztd reindex
+
+# Search archived cards
+ztd archive [--query "..."]
+```
+
+### Card IDs
+
+Accept either `ZTD-1` or `1` in all commands. Both work.
+
+### Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `ZTD_DATA_DIR` | `~/workspace/Data/ztd` | Where card files and the SQLite index are stored |
+
+---
+
+## API Reference
+
+Deploy the routes from `routes/` to your zo.space. Base path: `/api/kanban`
+
+### Cards
+
+| Method | Path | Body | Description |
+|---|---|---|---|
+| `GET` | `/api/kanban` | -- | List active cards. Filters: `?status=`, `?assignee=`, `?type=`, `?tag=` |
+| `POST` | `/api/kanban` | `{title, assignee?, type?, priority?, tags?, due_date?, description?, source?}` | Create a card |
+| `GET` | `/api/kanban/:id` | -- | Get full card detail (description, comments, activity) |
+| `PATCH` | `/api/kanban/:id` | `{title?, status?, assignee?, priority?, tags?, due_date?, actor?}` | Update card fields |
+| `DELETE` | `/api/kanban/:id` | -- | Delete a card |
+
+### Comments & Attachments
+
+| Method | Path | Body | Description |
+|---|---|---|---|
+| `POST` | `/api/kanban/:id/comments` | `{content, author}` | Add a comment |
+| `POST` | `/api/kanban/:id/attachments` | `{path, name, added_by?}` | Add attachment reference |
+| `DELETE` | `/api/kanban/:id/attachments` | `{path}` | Remove attachment reference |
+
+### Board Operations
+
+| Method | Path | Body | Description |
+|---|---|---|---|
+| `GET` | `/api/kanban/stats` | -- | Board summary (counts by status, overdue, stale) |
+| `POST` | `/api/kanban/reorder` | `{orders: [{id, sort_order}]}` | Batch update sort positions |
+| `POST` | `/api/kanban/reindex` | -- | Rebuild SQLite index from files |
+| `GET` | `/api/kanban/archive` | -- | List archived cards |
+| `GET` | `/api/kanban/:id/activity` | -- | Get activity log for a card |
+
+---
+
+## Web UI
+
+Deploy the `/kanban` page route for a drag-and-drop Kanban board.
+
+**Features:**
+- Four columns: Inbox, In Progress, In Review, Done
+- Drag-and-drop cards between columns and reorder within columns
+- Click a card to open the detail panel (right side)
+- Detail panel shows: title, status (changeable), assignee, priority, type, tags, description, attachments, comments, activity log
+- Add comments from the detail panel
+- Quick-add button creates cards in any column
+- Priority shown as colored left border (red = urgent, amber = high, blue = medium, gray = low)
+- Type icons on cards (question mark, warning triangle, lightbulb, etc.)
+- Assignee badges with distinct colors
+- Due dates shown with red highlight if overdue
+
+**Stack:** React + @dnd-kit + Tailwind CSS
+
+---
+
+## Architecture
+
+```
+Skills/open-ztd/
+  SKILL.md                    -- Skill definition
+  scripts/
+    ztd.ts                    -- CLI tool (all commands)
+    lib.ts                    -- Shared library (parser, serializer, SQLite helpers)
+  references/
+    guide.md                  -- This file
+  assets/routes/
+    kanban.tsx                -- Board UI page route (deploy to zo.space)
+    api-kanban.ts             -- List/create cards API route
+    api-kanban-wildcard.ts    -- All other API endpoints (wildcard route)
+
+Data/ztd/                     -- Created automatically on first use
+  ZTD-N.md                   -- Card files (source of truth)
+  index.db                   -- SQLite index (derived cache)
+  archive/                   -- Auto-archived done cards (14+ days)
+```
+
+The API routes dynamically import `lib.ts` at runtime for shared logic. Changes to lib.ts are picked up immediately without redeploying routes.
+
+### Auto-Archive
+
+Cards in `done` status for 14+ days are moved to `Data/ztd/archive/ZTD-N.md`. Nothing is ever deleted. The `ztd archive` command queries archived cards.
+
+### Rebuilding the Index
+
+If the SQLite index gets out of sync with the card files (e.g., after direct file edits), run:
+```bash
+bun run Skills/open-ztd/scripts/ztd.ts reindex
+```
+This drops and rebuilds the index from all card files. Sort order resets to alphabetical on reindex.
+
+---
+
+## Deploying to zo.space
+
+The `assets/routes/` directory contains ready-to-deploy code for your zo.space:
+
+1. **`/kanban`** (page, private) -- The board UI
+2. **`/api/kanban`** (api) -- List and create cards
+3. **`/api/kanban/:path{.+}`** (api) -- All other endpoints (detail, update, delete, comments, reorder, etc.)
+
+To deploy, use `update_space_route` for each route, pasting the code from the corresponding file in `assets/routes/`. Set the kanban page to private (requires auth) and the API routes to public.
+
+**Important:** Update the `LIB_PATH` constant in the API route files to point to your installed skill location (e.g., `/home/workspace/Skills/open-ztd/scripts/lib.ts`).

--- a/Community/open-ztd/scripts/lib.ts
+++ b/Community/open-ztd/scripts/lib.ts
@@ -1,0 +1,471 @@
+/**
+ * ZTD shared library -- card file parser, serializer, SQLite helpers.
+ * Used by both the CLI (ztd.ts) and zo.space API routes (via dynamic import).
+ */
+
+import { Database } from "bun:sqlite";
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  readdirSync,
+  mkdirSync,
+  unlinkSync,
+} from "fs";
+import { join, basename } from "path";
+
+// ---------------------------------------------------------------------------
+// Config -- override with ZTD_DATA_DIR env var
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_ROOT = process.env.HOME
+  ? join(process.env.HOME, "workspace")
+  : "/home/workspace";
+
+export const DATA_DIR =
+  process.env.ZTD_DATA_DIR || join(WORKSPACE_ROOT, "Data", "ztd");
+export const ARCHIVE_DIR = join(DATA_DIR, "archive");
+export const DB_PATH = join(DATA_DIR, "index.db");
+export const CARD_PREFIX = "ZTD";
+export const STALE_DAYS = 7;
+export const ARCHIVE_DAYS = 14;
+
+// ---------------------------------------------------------------------------
+// Ensure dirs exist
+// ---------------------------------------------------------------------------
+
+if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
+if (!existsSync(ARCHIVE_DIR)) mkdirSync(ARCHIVE_DIR, { recursive: true });
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CardFrontmatter {
+  id: number;
+  title: string;
+  status: string;
+  assignee: string;
+  type: string;
+  priority: string;
+  tags: string[];
+  due_date: string | null;
+  source: string;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+  conversations: string[];
+  attachments: Array<{
+    path: string;
+    name: string;
+    added_by: string;
+    added_at: string;
+  }>;
+}
+
+export interface CardFile {
+  frontmatter: CardFrontmatter;
+  description: string;
+  comments: Array<{ author: string; timestamp: string; content: string }>;
+  activity: string[];
+}
+
+// ---------------------------------------------------------------------------
+// SQLite helpers
+// ---------------------------------------------------------------------------
+
+export function getDb(): Database {
+  const db = new Database(DB_PATH);
+  db.exec("PRAGMA journal_mode=WAL;");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cards (
+      id INTEGER PRIMARY KEY,
+      title TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'inbox',
+      assignee TEXT NOT NULL,
+      type TEXT DEFAULT 'task',
+      priority TEXT DEFAULT 'medium',
+      tags TEXT,
+      due_date TEXT,
+      source TEXT DEFAULT 'manual',
+      sort_order INTEGER DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      completed_at TEXT,
+      archived INTEGER DEFAULT 0
+    );
+    CREATE INDEX IF NOT EXISTS idx_status ON cards(status);
+    CREATE INDEX IF NOT EXISTS idx_assignee ON cards(assignee);
+    CREATE INDEX IF NOT EXISTS idx_type ON cards(type);
+    CREATE INDEX IF NOT EXISTS idx_priority ON cards(priority);
+    CREATE INDEX IF NOT EXISTS idx_due_date ON cards(due_date);
+    CREATE TABLE IF NOT EXISTS metadata (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+  `);
+  const row = db
+    .prepare("SELECT value FROM metadata WHERE key = 'next_id'")
+    .get() as { value: string } | null;
+  if (!row) {
+    db.prepare(
+      "INSERT INTO metadata (key, value) VALUES ('next_id', '1')"
+    ).run();
+  }
+  return db;
+}
+
+export function getNextId(db: Database): number {
+  const row = db
+    .prepare("SELECT value FROM metadata WHERE key = 'next_id'")
+    .get() as { value: string };
+  const id = parseInt(row.value, 10);
+  db.prepare("UPDATE metadata SET value = ? WHERE key = 'next_id'").run(
+    String(id + 1)
+  );
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// YAML Frontmatter parser / serializer
+// ---------------------------------------------------------------------------
+
+function parseYamlValue(val: string): any {
+  val = val.trim();
+  if (val === "null" || val === "") return null;
+  if (val === "true") return true;
+  if (val === "false") return false;
+  if (/^\d+$/.test(val)) return parseInt(val, 10);
+  if (/^\d+\.\d+$/.test(val)) return parseFloat(val);
+  if (val.startsWith("[") && val.endsWith("]")) {
+    try {
+      return JSON.parse(val);
+    } catch {
+      return val;
+    }
+  }
+  if (
+    (val.startsWith('"') && val.endsWith('"')) ||
+    (val.startsWith("'") && val.endsWith("'"))
+  ) {
+    return val.slice(1, -1);
+  }
+  return val;
+}
+
+function parseFrontmatter(raw: string): Record<string, any> {
+  const result: Record<string, any> = {};
+  const lines = raw.split("\n");
+  let currentKey = "";
+  let currentList: any[] | null = null;
+  let currentObj: Record<string, any> | null = null;
+  let objList: any[] | null = null;
+
+  for (const line of lines) {
+    if (/^  - /.test(line) && currentKey && !currentObj) {
+      const val = line.replace(/^  - /, "").trim();
+      if (val.includes(": ")) {
+        if (!objList) objList = [];
+        const [k, ...rest] = val.split(": ");
+        currentObj = { [k.trim()]: parseYamlValue(rest.join(": ")) };
+      } else {
+        if (!currentList) currentList = [];
+        currentList.push(parseYamlValue(val));
+      }
+      continue;
+    }
+
+    if (/^    /.test(line) && currentObj) {
+      const trimmed = line.trim();
+      if (trimmed.includes(": ")) {
+        const [k, ...rest] = trimmed.split(": ");
+        currentObj[k.trim()] = parseYamlValue(rest.join(": "));
+      }
+      continue;
+    }
+
+    if (/^[a-z_]+:/.test(line)) {
+      if (currentKey) {
+        if (objList && currentObj) {
+          objList.push(currentObj);
+          result[currentKey] = objList;
+        } else if (currentObj) {
+          result[currentKey] = [currentObj];
+        } else if (currentList) {
+          result[currentKey] = currentList;
+        }
+      }
+      currentList = null;
+      currentObj = null;
+      objList = null;
+      const colonIdx = line.indexOf(":");
+      const key = line.slice(0, colonIdx).trim();
+      const val = line.slice(colonIdx + 1).trim();
+      currentKey = key;
+      if (val) {
+        result[key] = parseYamlValue(val);
+        currentList = null;
+      }
+      continue;
+    }
+  }
+
+  if (currentKey) {
+    if (objList && currentObj) {
+      objList.push(currentObj);
+      result[currentKey] = objList;
+    } else if (currentObj) {
+      result[currentKey] = [currentObj];
+    } else if (currentList) {
+      result[currentKey] = currentList;
+    }
+  }
+  return result;
+}
+
+export function serializeFrontmatter(fm: CardFrontmatter): string {
+  const lines: string[] = ["---"];
+  lines.push(`id: ${fm.id}`);
+  lines.push(`title: ${fm.title}`);
+  lines.push(`status: ${fm.status}`);
+  lines.push(`assignee: ${fm.assignee}`);
+  lines.push(`type: ${fm.type}`);
+  lines.push(`priority: ${fm.priority}`);
+  lines.push(
+    fm.tags && fm.tags.length > 0 ? `tags: ${JSON.stringify(fm.tags)}` : "tags: []"
+  );
+  lines.push(`due_date: ${fm.due_date || "null"}`);
+  lines.push(`source: ${fm.source}`);
+  lines.push(`created_at: ${fm.created_at}`);
+  lines.push(`updated_at: ${fm.updated_at}`);
+  lines.push(`completed_at: ${fm.completed_at || "null"}`);
+  if (fm.conversations && fm.conversations.length > 0) {
+    lines.push("conversations:");
+    for (const c of fm.conversations) lines.push(`  - ${c}`);
+  } else {
+    lines.push("conversations: []");
+  }
+  if (fm.attachments && fm.attachments.length > 0) {
+    lines.push("attachments:");
+    for (const a of fm.attachments) {
+      lines.push(`  - path: ${a.path}`);
+      lines.push(`    name: ${a.name}`);
+      lines.push(`    added_by: ${a.added_by}`);
+      lines.push(`    added_at: ${a.added_at}`);
+    }
+  } else {
+    lines.push("attachments: []");
+  }
+  lines.push("---");
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Card file parser
+// ---------------------------------------------------------------------------
+
+export function parseCardFile(content: string): CardFile {
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) throw new Error("No frontmatter found");
+
+  const rawFm = parseFrontmatter(fmMatch[1]);
+  const fm: CardFrontmatter = {
+    id: rawFm.id ?? 0,
+    title: rawFm.title ?? "",
+    status: rawFm.status ?? "inbox",
+    assignee: rawFm.assignee ?? "user",
+    type: rawFm.type ?? "task",
+    priority: rawFm.priority ?? "medium",
+    tags: Array.isArray(rawFm.tags) ? rawFm.tags : [],
+    due_date: rawFm.due_date ?? null,
+    source: rawFm.source ?? "manual",
+    created_at: rawFm.created_at ?? new Date().toISOString(),
+    updated_at: rawFm.updated_at ?? new Date().toISOString(),
+    completed_at: rawFm.completed_at ?? null,
+    conversations: Array.isArray(rawFm.conversations) ? rawFm.conversations : [],
+    attachments: Array.isArray(rawFm.attachments) ? rawFm.attachments : [],
+  };
+
+  const body = content.slice(fmMatch[0].length).trim();
+  let description = "";
+  let commentsSection = "";
+  let activitySection = "";
+
+  const commentsSplit = body.split("## Comments");
+  if (commentsSplit.length > 1) {
+    description = commentsSplit[0].trim();
+    const rest = commentsSplit[1];
+    const activitySplit = rest.split("## Activity");
+    if (activitySplit.length > 1) {
+      commentsSection = activitySplit[0].trim();
+      activitySection = activitySplit[1].trim();
+    } else {
+      commentsSection = rest.trim();
+    }
+  } else {
+    const activitySplit = body.split("## Activity");
+    if (activitySplit.length > 1) {
+      description = activitySplit[0].trim();
+      activitySection = activitySplit[1].trim();
+    } else {
+      description = body;
+    }
+  }
+
+  const comments: Array<{
+    author: string;
+    timestamp: string;
+    content: string;
+  }> = [];
+  const commentRegex =
+    /<!--- comment: (.+?) \| (.+?) --->\n([\s\S]*?)<!--- \/comment --->/g;
+  let match;
+  while ((match = commentRegex.exec(commentsSection)) !== null) {
+    comments.push({
+      author: match[1].trim(),
+      timestamp: match[2].trim(),
+      content: match[3].trim(),
+    });
+  }
+
+  const activity: string[] = [];
+  if (activitySection) {
+    for (const line of activitySection.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("- ")) activity.push(trimmed.slice(2));
+    }
+  }
+
+  return { frontmatter: fm, description, comments, activity };
+}
+
+// ---------------------------------------------------------------------------
+// Card file writer
+// ---------------------------------------------------------------------------
+
+export function serializeCardFile(card: CardFile): string {
+  const parts: string[] = [];
+  parts.push(serializeFrontmatter(card.frontmatter));
+  parts.push("");
+  if (card.description) {
+    parts.push(card.description);
+    parts.push("");
+  }
+  parts.push("## Comments");
+  parts.push("");
+  for (const c of card.comments) {
+    parts.push(`<!--- comment: ${c.author} | ${c.timestamp} --->`);
+    parts.push(c.content);
+    parts.push("<!--- /comment --->");
+    parts.push("");
+  }
+  parts.push("## Activity");
+  parts.push("");
+  for (const a of card.activity) parts.push(`- ${a}`);
+  parts.push("");
+  return parts.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// File helpers
+// ---------------------------------------------------------------------------
+
+export function cardPath(id: number, archived = false): string {
+  const dir = archived ? ARCHIVE_DIR : DATA_DIR;
+  return join(dir, `${CARD_PREFIX}-${id}.md`);
+}
+
+export function readCard(id: number): CardFile | null {
+  let path = cardPath(id);
+  if (!existsSync(path)) {
+    path = cardPath(id, true);
+    if (!existsSync(path)) return null;
+  }
+  try {
+    return parseCardFile(readFileSync(path, "utf-8"));
+  } catch (e) {
+    console.error(`Warning: Failed to parse ${CARD_PREFIX}-${id}.md: ${e}`);
+    return null;
+  }
+}
+
+export function writeCard(card: CardFile): void {
+  const isArchived =
+    card.frontmatter.status === "done" &&
+    existsSync(cardPath(card.frontmatter.id, true));
+  const path = isArchived
+    ? cardPath(card.frontmatter.id, true)
+    : cardPath(card.frontmatter.id);
+  writeFileSync(path, serializeCardFile(card));
+}
+
+export function listCardFiles(dir: string = DATA_DIR): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter(
+    (f) => f.startsWith(`${CARD_PREFIX}-`) && f.endsWith(".md")
+  );
+}
+
+export function now(): string {
+  return new Date().toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Index helpers
+// ---------------------------------------------------------------------------
+
+export function indexCard(
+  db: Database,
+  card: CardFile,
+  sortOrder?: number
+): void {
+  const fm = card.frontmatter;
+  const existing = db
+    .prepare("SELECT id FROM cards WHERE id = ?")
+    .get(fm.id) as { id: number } | null;
+
+  if (existing) {
+    db.prepare(
+      `UPDATE cards SET title=?, status=?, assignee=?, type=?, priority=?, tags=?,
+      due_date=?, source=?, sort_order=COALESCE(?, sort_order), created_at=?, updated_at=?,
+      completed_at=?, archived=?
+      WHERE id=?`
+    ).run(
+      fm.title,
+      fm.status,
+      fm.assignee,
+      fm.type,
+      fm.priority,
+      JSON.stringify(fm.tags),
+      fm.due_date,
+      fm.source,
+      sortOrder ?? null,
+      fm.created_at,
+      fm.updated_at,
+      fm.completed_at,
+      0,
+      fm.id
+    );
+  } else {
+    db.prepare(
+      `INSERT INTO cards (id, title, status, assignee, type, priority, tags, due_date,
+      source, sort_order, created_at, updated_at, completed_at, archived)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      fm.id,
+      fm.title,
+      fm.status,
+      fm.assignee,
+      fm.type,
+      fm.priority,
+      JSON.stringify(fm.tags),
+      fm.due_date,
+      fm.source,
+      sortOrder ?? 0,
+      fm.created_at,
+      fm.updated_at,
+      fm.completed_at,
+      0
+    );
+  }
+}

--- a/Community/open-ztd/scripts/ztd.ts
+++ b/Community/open-ztd/scripts/ztd.ts
@@ -1,0 +1,1230 @@
+#!/usr/bin/env bun
+/**
+ * ZTD (Zo To Do) -- CLI tool for a file-first task board.
+ *
+ * Cards are markdown files in Data/ztd/ (source of truth).
+ * SQLite index at Data/ztd/index.db is a derived cache for fast queries.
+ *
+ * Usage: bun run Skills/open-ztd/scripts/ztd.ts <command> [options]
+ */
+
+import { Database } from "bun:sqlite";
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  readdirSync,
+  mkdirSync,
+  renameSync,
+  unlinkSync,
+} from "fs";
+import { join, basename } from "path";
+
+// ---------------------------------------------------------------------------
+// Config -- override with ZTD_DATA_DIR env var
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_ROOT = process.env.HOME
+  ? join(process.env.HOME, "workspace")
+  : "/home/workspace";
+
+const DATA_DIR =
+  process.env.ZTD_DATA_DIR || join(WORKSPACE_ROOT, "Data", "ztd");
+const ARCHIVE_DIR = join(DATA_DIR, "archive");
+const DB_PATH = join(DATA_DIR, "index.db");
+const CARD_PREFIX = "ZTD";
+const STALE_DAYS = 7;
+const ARCHIVE_DAYS = 14;
+
+// ---------------------------------------------------------------------------
+// Ensure dirs exist
+// ---------------------------------------------------------------------------
+
+if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
+if (!existsSync(ARCHIVE_DIR)) mkdirSync(ARCHIVE_DIR, { recursive: true });
+
+// ---------------------------------------------------------------------------
+// SQLite helpers
+// ---------------------------------------------------------------------------
+
+function getDb(): Database {
+  const db = new Database(DB_PATH);
+  db.exec("PRAGMA journal_mode=WAL;");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cards (
+      id INTEGER PRIMARY KEY,
+      title TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'inbox',
+      assignee TEXT NOT NULL,
+      type TEXT DEFAULT 'task',
+      priority TEXT DEFAULT 'medium',
+      tags TEXT,
+      due_date TEXT,
+      source TEXT DEFAULT 'manual',
+      sort_order INTEGER DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      completed_at TEXT,
+      archived INTEGER DEFAULT 0
+    );
+    CREATE INDEX IF NOT EXISTS idx_status ON cards(status);
+    CREATE INDEX IF NOT EXISTS idx_assignee ON cards(assignee);
+    CREATE INDEX IF NOT EXISTS idx_type ON cards(type);
+    CREATE INDEX IF NOT EXISTS idx_priority ON cards(priority);
+    CREATE INDEX IF NOT EXISTS idx_due_date ON cards(due_date);
+    CREATE TABLE IF NOT EXISTS metadata (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+  `);
+  const row = db
+    .prepare("SELECT value FROM metadata WHERE key = 'next_id'")
+    .get() as { value: string } | null;
+  if (!row) {
+    db.prepare(
+      "INSERT INTO metadata (key, value) VALUES ('next_id', '1')"
+    ).run();
+  }
+  return db;
+}
+
+function getNextId(db: Database): number {
+  const row = db
+    .prepare("SELECT value FROM metadata WHERE key = 'next_id'")
+    .get() as { value: string };
+  const id = parseInt(row.value, 10);
+  db.prepare("UPDATE metadata SET value = ? WHERE key = 'next_id'").run(
+    String(id + 1)
+  );
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// YAML Frontmatter parser / serializer (minimal, no deps)
+// ---------------------------------------------------------------------------
+
+interface CardFrontmatter {
+  id: number;
+  title: string;
+  status: string;
+  assignee: string;
+  type: string;
+  priority: string;
+  tags: string[];
+  due_date: string | null;
+  source: string;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+  conversations: string[];
+  attachments: Array<{
+    path: string;
+    name: string;
+    added_by: string;
+    added_at: string;
+  }>;
+}
+
+interface CardFile {
+  frontmatter: CardFrontmatter;
+  description: string;
+  comments: Array<{ author: string; timestamp: string; content: string }>;
+  activity: string[];
+}
+
+function parseYamlValue(val: string): any {
+  val = val.trim();
+  if (val === "null" || val === "") return null;
+  if (val === "true") return true;
+  if (val === "false") return false;
+  if (/^\d+$/.test(val)) return parseInt(val, 10);
+  if (/^\d+\.\d+$/.test(val)) return parseFloat(val);
+  if (val.startsWith("[") && val.endsWith("]")) {
+    try {
+      return JSON.parse(val);
+    } catch {
+      return val;
+    }
+  }
+  if (
+    (val.startsWith('"') && val.endsWith('"')) ||
+    (val.startsWith("'") && val.endsWith("'"))
+  ) {
+    return val.slice(1, -1);
+  }
+  return val;
+}
+
+function parseFrontmatter(raw: string): Record<string, any> {
+  const result: Record<string, any> = {};
+  const lines = raw.split("\n");
+  let currentKey = "";
+  let currentList: any[] | null = null;
+  let currentObj: Record<string, any> | null = null;
+  let objList: any[] | null = null;
+
+  for (const line of lines) {
+    if (/^  - /.test(line) && currentKey && !currentObj) {
+      const val = line.replace(/^  - /, "").trim();
+      if (val.includes(": ")) {
+        if (!objList) objList = [];
+        const [k, ...rest] = val.split(": ");
+        currentObj = { [k.trim()]: parseYamlValue(rest.join(": ")) };
+      } else {
+        if (!currentList) currentList = [];
+        currentList.push(parseYamlValue(val));
+      }
+      continue;
+    }
+
+    if (/^    /.test(line) && currentObj) {
+      const trimmed = line.trim();
+      if (trimmed.includes(": ")) {
+        const [k, ...rest] = trimmed.split(": ");
+        currentObj[k.trim()] = parseYamlValue(rest.join(": "));
+      }
+      continue;
+    }
+
+    if (/^[a-z_]+:/.test(line)) {
+      if (currentKey) {
+        if (objList && currentObj) {
+          objList.push(currentObj);
+          result[currentKey] = objList;
+        } else if (currentObj) {
+          result[currentKey] = [currentObj];
+        } else if (currentList) {
+          result[currentKey] = currentList;
+        }
+      }
+      currentList = null;
+      currentObj = null;
+      objList = null;
+
+      const colonIdx = line.indexOf(":");
+      const key = line.slice(0, colonIdx).trim();
+      const val = line.slice(colonIdx + 1).trim();
+      currentKey = key;
+      if (val) {
+        result[key] = parseYamlValue(val);
+        currentKey = key;
+        currentList = null;
+      }
+      continue;
+    }
+  }
+
+  if (currentKey) {
+    if (objList && currentObj) {
+      objList.push(currentObj);
+      result[currentKey] = objList;
+    } else if (currentObj) {
+      result[currentKey] = [currentObj];
+    } else if (currentList) {
+      result[currentKey] = currentList;
+    }
+  }
+
+  return result;
+}
+
+function serializeYamlValue(val: any): string {
+  if (val === null || val === undefined) return "null";
+  if (typeof val === "boolean") return String(val);
+  if (typeof val === "number") return String(val);
+  if (Array.isArray(val) && val.length === 0) return "[]";
+  return String(val);
+}
+
+function serializeFrontmatter(fm: CardFrontmatter): string {
+  const lines: string[] = ["---"];
+
+  lines.push(`id: ${fm.id}`);
+  lines.push(`title: ${fm.title}`);
+  lines.push(`status: ${fm.status}`);
+  lines.push(`assignee: ${fm.assignee}`);
+  lines.push(`type: ${fm.type}`);
+  lines.push(`priority: ${fm.priority}`);
+
+  if (fm.tags && fm.tags.length > 0) {
+    lines.push(`tags: ${JSON.stringify(fm.tags)}`);
+  } else {
+    lines.push("tags: []");
+  }
+
+  lines.push(`due_date: ${fm.due_date || "null"}`);
+  lines.push(`source: ${fm.source}`);
+  lines.push(`created_at: ${fm.created_at}`);
+  lines.push(`updated_at: ${fm.updated_at}`);
+  lines.push(`completed_at: ${fm.completed_at || "null"}`);
+
+  if (fm.conversations && fm.conversations.length > 0) {
+    lines.push("conversations:");
+    for (const c of fm.conversations) {
+      lines.push(`  - ${c}`);
+    }
+  } else {
+    lines.push("conversations: []");
+  }
+
+  if (fm.attachments && fm.attachments.length > 0) {
+    lines.push("attachments:");
+    for (const a of fm.attachments) {
+      lines.push(`  - path: ${a.path}`);
+      lines.push(`    name: ${a.name}`);
+      lines.push(`    added_by: ${a.added_by}`);
+      lines.push(`    added_at: ${a.added_at}`);
+    }
+  } else {
+    lines.push("attachments: []");
+  }
+
+  lines.push("---");
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Card file parser
+// ---------------------------------------------------------------------------
+
+function parseCardFile(content: string): CardFile {
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) throw new Error("No frontmatter found");
+
+  const rawFm = parseFrontmatter(fmMatch[1]);
+  const fm: CardFrontmatter = {
+    id: rawFm.id ?? 0,
+    title: rawFm.title ?? "",
+    status: rawFm.status ?? "inbox",
+    assignee: rawFm.assignee ?? "user",
+    type: rawFm.type ?? "task",
+    priority: rawFm.priority ?? "medium",
+    tags: Array.isArray(rawFm.tags) ? rawFm.tags : [],
+    due_date: rawFm.due_date ?? null,
+    source: rawFm.source ?? "manual",
+    created_at: rawFm.created_at ?? new Date().toISOString(),
+    updated_at: rawFm.updated_at ?? new Date().toISOString(),
+    completed_at: rawFm.completed_at ?? null,
+    conversations: Array.isArray(rawFm.conversations)
+      ? rawFm.conversations
+      : [],
+    attachments: Array.isArray(rawFm.attachments) ? rawFm.attachments : [],
+  };
+
+  const body = content.slice(fmMatch[0].length).trim();
+
+  let description = "";
+  let commentsSection = "";
+  let activitySection = "";
+
+  const commentsSplit = body.split("## Comments");
+  if (commentsSplit.length > 1) {
+    description = commentsSplit[0].trim();
+    const rest = commentsSplit[1];
+    const activitySplit = rest.split("## Activity");
+    if (activitySplit.length > 1) {
+      commentsSection = activitySplit[0].trim();
+      activitySection = activitySplit[1].trim();
+    } else {
+      commentsSection = rest.trim();
+    }
+  } else {
+    const activitySplit = body.split("## Activity");
+    if (activitySplit.length > 1) {
+      description = activitySplit[0].trim();
+      activitySection = activitySplit[1].trim();
+    } else {
+      description = body;
+    }
+  }
+
+  const comments: Array<{
+    author: string;
+    timestamp: string;
+    content: string;
+  }> = [];
+  const commentRegex =
+    /<!--- comment: (.+?) \| (.+?) --->\n([\s\S]*?)<!--- \/comment --->/g;
+  let match;
+  while ((match = commentRegex.exec(commentsSection)) !== null) {
+    comments.push({
+      author: match[1].trim(),
+      timestamp: match[2].trim(),
+      content: match[3].trim(),
+    });
+  }
+
+  const activity: string[] = [];
+  if (activitySection) {
+    for (const line of activitySection.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("- ")) {
+        activity.push(trimmed.slice(2));
+      }
+    }
+  }
+
+  return { frontmatter: fm, description, comments, activity };
+}
+
+// ---------------------------------------------------------------------------
+// Card file writer
+// ---------------------------------------------------------------------------
+
+function serializeCardFile(card: CardFile): string {
+  const parts: string[] = [];
+
+  parts.push(serializeFrontmatter(card.frontmatter));
+  parts.push("");
+
+  if (card.description) {
+    parts.push(card.description);
+    parts.push("");
+  }
+
+  parts.push("## Comments");
+  parts.push("");
+  for (const c of card.comments) {
+    parts.push(`<!--- comment: ${c.author} | ${c.timestamp} --->`);
+    parts.push(c.content);
+    parts.push("<!--- /comment --->");
+    parts.push("");
+  }
+
+  parts.push("## Activity");
+  parts.push("");
+  for (const a of card.activity) {
+    parts.push(`- ${a}`);
+  }
+  parts.push("");
+
+  return parts.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// File helpers
+// ---------------------------------------------------------------------------
+
+function cardPath(id: number, archived = false): string {
+  const dir = archived ? ARCHIVE_DIR : DATA_DIR;
+  return join(dir, `${CARD_PREFIX}-${id}.md`);
+}
+
+function readCard(id: number): CardFile | null {
+  let path = cardPath(id);
+  if (!existsSync(path)) {
+    path = cardPath(id, true);
+    if (!existsSync(path)) return null;
+  }
+  try {
+    return parseCardFile(readFileSync(path, "utf-8"));
+  } catch (e) {
+    console.error(`Warning: Failed to parse ${CARD_PREFIX}-${id}.md: ${e}`);
+    return null;
+  }
+}
+
+function writeCard(card: CardFile): void {
+  const isArchived =
+    card.frontmatter.status === "done" &&
+    existsSync(cardPath(card.frontmatter.id, true));
+  const path = isArchived
+    ? cardPath(card.frontmatter.id, true)
+    : cardPath(card.frontmatter.id);
+  writeFileSync(path, serializeCardFile(card));
+}
+
+function listCardFiles(dir: string = DATA_DIR): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter(
+    (f) => f.startsWith(`${CARD_PREFIX}-`) && f.endsWith(".md")
+  );
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Index helpers
+// ---------------------------------------------------------------------------
+
+function indexCard(db: Database, card: CardFile, sortOrder?: number): void {
+  const fm = card.frontmatter;
+  const existing = db
+    .prepare("SELECT id FROM cards WHERE id = ?")
+    .get(fm.id) as { id: number } | null;
+
+  if (existing) {
+    db.prepare(
+      `UPDATE cards SET title=?, status=?, assignee=?, type=?, priority=?, tags=?,
+      due_date=?, source=?, sort_order=COALESCE(?, sort_order), created_at=?, updated_at=?,
+      completed_at=?, archived=?
+      WHERE id=?`
+    ).run(
+      fm.title,
+      fm.status,
+      fm.assignee,
+      fm.type,
+      fm.priority,
+      JSON.stringify(fm.tags),
+      fm.due_date,
+      fm.source,
+      sortOrder ?? null,
+      fm.created_at,
+      fm.updated_at,
+      fm.completed_at,
+      0,
+      fm.id
+    );
+  } else {
+    db.prepare(
+      `INSERT INTO cards (id, title, status, assignee, type, priority, tags, due_date,
+      source, sort_order, created_at, updated_at, completed_at, archived)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      fm.id,
+      fm.title,
+      fm.status,
+      fm.assignee,
+      fm.type,
+      fm.priority,
+      JSON.stringify(fm.tags),
+      fm.due_date,
+      fm.source,
+      sortOrder ?? 0,
+      fm.created_at,
+      fm.updated_at,
+      fm.completed_at,
+      0
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI argument parser
+// ---------------------------------------------------------------------------
+
+function parseArgs(args: string[]): {
+  command: string;
+  positional: string[];
+  flags: Record<string, string>;
+} {
+  const command = args[0] || "help";
+  const positional: string[] = [];
+  const flags: Record<string, string> = {};
+
+  for (let i = 1; i < args.length; i++) {
+    if (args[i].startsWith("--")) {
+      const key = args[i].slice(2);
+      const next = args[i + 1];
+      if (next && !next.startsWith("--")) {
+        flags[key] = next;
+        i++;
+      } else {
+        flags[key] = "true";
+      }
+    } else {
+      positional.push(args[i]);
+    }
+  }
+
+  return { command, positional, flags };
+}
+
+function parseId(val: string): number {
+  const cleaned = val.replace(/^ZTD-/i, "");
+  const id = parseInt(cleaned, 10);
+  if (isNaN(id)) {
+    console.error(`Invalid ID: ${val}. Use a number or ZTD-N format.`);
+    process.exit(1);
+  }
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+function cmdAdd(flags: Record<string, string>): void {
+  if (!flags.title) {
+    console.error("Error: --title is required");
+    process.exit(1);
+  }
+
+  const db = getDb();
+  const id = getNextId(db);
+  const timestamp = now();
+
+  const fm: CardFrontmatter = {
+    id,
+    title: flags.title,
+    status: "inbox",
+    assignee: flags.assignee || "user",
+    type: flags.type || "task",
+    priority: flags.priority || "medium",
+    tags: flags.tags ? flags.tags.split(",").map((t) => t.trim()) : [],
+    due_date: flags["due-date"] || null,
+    source: flags.source || "manual",
+    created_at: timestamp,
+    updated_at: timestamp,
+    completed_at: null,
+    conversations: flags.conversation ? [flags.conversation] : [],
+    attachments: [],
+  };
+
+  const card: CardFile = {
+    frontmatter: fm,
+    description: flags.description || "",
+    comments: [],
+    activity: [`${timestamp} | ${fm.assignee} | created`],
+  };
+
+  writeCard(card);
+  indexCard(db, card);
+  db.close();
+
+  console.log(`Created ${CARD_PREFIX}-${id}: ${fm.title}`);
+}
+
+function cmdList(flags: Record<string, string>): void {
+  const db = getDb();
+  let query = "SELECT * FROM cards WHERE archived = 0";
+  const params: any[] = [];
+
+  if (flags.status) {
+    query += " AND status = ?";
+    params.push(flags.status);
+  }
+  if (flags.assignee) {
+    query += " AND assignee = ?";
+    params.push(flags.assignee);
+  }
+  if (flags.type) {
+    query += " AND type = ?";
+    params.push(flags.type);
+  }
+  if (flags.tag) {
+    query += " AND tags LIKE ?";
+    params.push(`%"${flags.tag}"%`);
+  }
+
+  query += " ORDER BY sort_order ASC, id ASC";
+
+  const rows = db.prepare(query).all(...params) as any[];
+  db.close();
+
+  if (rows.length === 0) {
+    console.log("No cards found.");
+    return;
+  }
+
+  const priorityColors: Record<string, string> = {
+    urgent: "\x1b[31m",
+    high: "\x1b[33m",
+    medium: "\x1b[0m",
+    low: "\x1b[2m",
+  };
+  const reset = "\x1b[0m";
+
+  for (const row of rows) {
+    const pColor = priorityColors[row.priority] || "";
+    const tags = row.tags ? JSON.parse(row.tags).join(", ") : "";
+    const tagStr = tags ? ` [${tags}]` : "";
+    const dueStr = row.due_date ? ` (due: ${row.due_date})` : "";
+    console.log(
+      `${pColor}${CARD_PREFIX}-${row.id}  ${row.status.padEnd(12)} ${row.assignee.padEnd(8)} ${row.type.padEnd(10)} ${row.priority.padEnd(8)} ${row.title}${tagStr}${dueStr}${reset}`
+    );
+  }
+}
+
+function cmdUpdate(
+  positional: string[],
+  flags: Record<string, string>
+): void {
+  if (positional.length === 0) {
+    console.error(
+      "Error: card ID required. Usage: ztd update <id> [--field value]"
+    );
+    process.exit(1);
+  }
+
+  const id = parseId(positional[0]);
+  const card = readCard(id);
+  if (!card) {
+    console.error(`Card ${CARD_PREFIX}-${id} not found.`);
+    process.exit(1);
+  }
+
+  const fm = card.frontmatter;
+  const oldStatus = fm.status;
+  const changes: string[] = [];
+  const actor = flags.actor || fm.assignee;
+
+  if (flags.title) {
+    fm.title = flags.title;
+    changes.push(`title -> ${flags.title}`);
+  }
+  if (flags.status) {
+    fm.status = flags.status;
+    changes.push(`status: ${oldStatus} -> ${flags.status}`);
+    if (flags.status === "done" && !fm.completed_at) {
+      fm.completed_at = now();
+    }
+  }
+  if (flags.assignee) {
+    fm.assignee = flags.assignee;
+    changes.push(`assignee -> ${flags.assignee}`);
+  }
+  if (flags.priority) {
+    fm.priority = flags.priority;
+    changes.push(`priority -> ${flags.priority}`);
+  }
+  if (flags.type) {
+    fm.type = flags.type;
+    changes.push(`type -> ${flags.type}`);
+  }
+  if (flags.tags) {
+    fm.tags = flags.tags.split(",").map((t) => t.trim());
+    changes.push(`tags -> ${flags.tags}`);
+  }
+  if (flags["due-date"]) {
+    fm.due_date = flags["due-date"];
+    changes.push(`due_date -> ${flags["due-date"]}`);
+  }
+
+  fm.updated_at = now();
+
+  for (const change of changes) {
+    card.activity.push(`${fm.updated_at} | ${actor} | ${change}`);
+  }
+
+  writeCard(card);
+  const db = getDb();
+  indexCard(db, card);
+  db.close();
+
+  console.log(`Updated ${CARD_PREFIX}-${id}: ${changes.join(", ")}`);
+}
+
+function cmdMove(positional: string[], flags: Record<string, string>): void {
+  if (positional.length < 2) {
+    console.error("Error: Usage: ztd move <id> <status>");
+    process.exit(1);
+  }
+
+  const id = parseId(positional[0]);
+  const newStatus = positional[1];
+  const validStatuses = ["inbox", "in_progress", "in_review", "done"];
+  if (!validStatuses.includes(newStatus)) {
+    console.error(
+      `Error: Invalid status "${newStatus}". Valid: ${validStatuses.join(", ")}`
+    );
+    process.exit(1);
+  }
+
+  const card = readCard(id);
+  if (!card) {
+    console.error(`Card ${CARD_PREFIX}-${id} not found.`);
+    process.exit(1);
+  }
+
+  const oldStatus = card.frontmatter.status;
+  const actor = flags.actor || card.frontmatter.assignee;
+  card.frontmatter.status = newStatus;
+  card.frontmatter.updated_at = now();
+  if (newStatus === "done" && !card.frontmatter.completed_at) {
+    card.frontmatter.completed_at = now();
+  }
+  card.activity.push(
+    `${card.frontmatter.updated_at} | ${actor} | status: ${oldStatus} -> ${newStatus}`
+  );
+
+  writeCard(card);
+  const db = getDb();
+  indexCard(db, card);
+  db.close();
+
+  console.log(`${CARD_PREFIX}-${id}: ${oldStatus} -> ${newStatus}`);
+}
+
+function cmdDone(positional: string[], flags: Record<string, string>): void {
+  if (positional.length === 0) {
+    console.error("Error: card ID required.");
+    process.exit(1);
+  }
+  cmdMove([positional[0], "done"], flags);
+}
+
+function cmdDelete(positional: string[]): void {
+  if (positional.length === 0) {
+    console.error("Error: card ID required.");
+    process.exit(1);
+  }
+
+  const id = parseId(positional[0]);
+  const path = cardPath(id);
+  const archivePath = cardPath(id, true);
+
+  if (existsSync(path)) {
+    unlinkSync(path);
+  } else if (existsSync(archivePath)) {
+    unlinkSync(archivePath);
+  } else {
+    console.error(`Card ${CARD_PREFIX}-${id} not found.`);
+    process.exit(1);
+  }
+
+  const db = getDb();
+  db.prepare("DELETE FROM cards WHERE id = ?").run(id);
+  db.close();
+
+  console.log(`Deleted ${CARD_PREFIX}-${id}`);
+}
+
+function cmdComment(
+  positional: string[],
+  flags: Record<string, string>
+): void {
+  if (positional.length === 0 || !flags.content) {
+    console.error(
+      "Error: Usage: ztd comment <id> --content '...' [--author user]"
+    );
+    process.exit(1);
+  }
+
+  const id = parseId(positional[0]);
+  const card = readCard(id);
+  if (!card) {
+    console.error(`Card ${CARD_PREFIX}-${id} not found.`);
+    process.exit(1);
+  }
+
+  const author = flags.author || "user";
+  const timestamp = now();
+
+  card.comments.push({ author, timestamp, content: flags.content });
+  card.activity.push(`${timestamp} | ${author} | commented`);
+  card.frontmatter.updated_at = timestamp;
+
+  writeCard(card);
+  const db = getDb();
+  indexCard(db, card);
+  db.close();
+
+  console.log(`Comment added to ${CARD_PREFIX}-${id}`);
+}
+
+function cmdAttach(
+  positional: string[],
+  flags: Record<string, string>
+): void {
+  if (positional.length === 0 || !flags.file) {
+    console.error(
+      "Error: Usage: ztd attach <id> --file 'path' [--name 'Name']"
+    );
+    process.exit(1);
+  }
+
+  const id = parseId(positional[0]);
+  const card = readCard(id);
+  if (!card) {
+    console.error(`Card ${CARD_PREFIX}-${id} not found.`);
+    process.exit(1);
+  }
+
+  const author = flags.author || "user";
+  const timestamp = now();
+  card.frontmatter.attachments.push({
+    path: flags.file,
+    name: flags.name || basename(flags.file),
+    added_by: author,
+    added_at: timestamp,
+  });
+  card.activity.push(
+    `${timestamp} | ${author} | attached ${flags.name || basename(flags.file)}`
+  );
+  card.frontmatter.updated_at = timestamp;
+
+  writeCard(card);
+  const db = getDb();
+  indexCard(db, card);
+  db.close();
+
+  console.log(`Attachment added to ${CARD_PREFIX}-${id}: ${flags.file}`);
+}
+
+function cmdLink(
+  positional: string[],
+  flags: Record<string, string>
+): void {
+  if (positional.length === 0 || !flags.conversation) {
+    console.error(
+      "Error: Usage: ztd link <id> --conversation <conversation_id>"
+    );
+    process.exit(1);
+  }
+
+  const id = parseId(positional[0]);
+  const card = readCard(id);
+  if (!card) {
+    console.error(`Card ${CARD_PREFIX}-${id} not found.`);
+    process.exit(1);
+  }
+
+  if (!card.frontmatter.conversations.includes(flags.conversation)) {
+    card.frontmatter.conversations.push(flags.conversation);
+    card.frontmatter.updated_at = now();
+    writeCard(card);
+  }
+
+  console.log(
+    `Linked conversation ${flags.conversation} to ${CARD_PREFIX}-${id}`
+  );
+}
+
+function cmdStats(): void {
+  const db = getDb();
+  const statuses = db
+    .prepare(
+      "SELECT status, COUNT(*) as count FROM cards WHERE archived = 0 GROUP BY status"
+    )
+    .all() as Array<{ status: string; count: number }>;
+
+  const assignees = db
+    .prepare(
+      "SELECT assignee, COUNT(*) as count FROM cards WHERE archived = 0 GROUP BY assignee"
+    )
+    .all() as Array<{ assignee: string; count: number }>;
+
+  const overdue = db
+    .prepare(
+      "SELECT COUNT(*) as count FROM cards WHERE archived = 0 AND due_date IS NOT NULL AND due_date < ? AND status != 'done'"
+    )
+    .get(new Date().toISOString().split("T")[0]) as { count: number };
+
+  const total = db
+    .prepare("SELECT COUNT(*) as count FROM cards WHERE archived = 0")
+    .get() as { count: number };
+
+  db.close();
+
+  console.log(`\nBoard Stats`);
+  console.log(`-----------`);
+  console.log(`Total active: ${total.count}`);
+  console.log(`Overdue: ${overdue.count}`);
+  console.log(`\nBy status:`);
+  for (const s of statuses) {
+    console.log(`  ${s.status.padEnd(14)} ${s.count}`);
+  }
+  console.log(`\nBy assignee:`);
+  for (const a of assignees) {
+    console.log(`  ${a.assignee.padEnd(14)} ${a.count}`);
+  }
+}
+
+function cmdReview(flags: Record<string, string>): void {
+  const db = getDb();
+  const assignee = flags.assignee || null;
+  let sql =
+    "SELECT * FROM cards WHERE archived = 0 AND status = 'in_review'";
+  const params: any[] = [];
+  if (assignee) {
+    sql += " AND assignee = ?";
+    params.push(assignee);
+  }
+  sql += " ORDER BY priority DESC, id ASC";
+  const rows = db.prepare(sql).all(...params) as any[];
+  db.close();
+
+  if (rows.length === 0) {
+    console.log("No items in review.");
+    return;
+  }
+
+  console.log(`\nIn Review: ${rows.length}`);
+  for (const row of rows) {
+    console.log(
+      `  ${CARD_PREFIX}-${row.id}  ${row.assignee.padEnd(8)} ${row.priority.padEnd(8)} ${row.title}`
+    );
+  }
+}
+
+function cmdOverdue(): void {
+  const db = getDb();
+  const today = new Date().toISOString().split("T")[0];
+  const rows = db
+    .prepare(
+      "SELECT * FROM cards WHERE archived = 0 AND due_date IS NOT NULL AND due_date < ? AND status != 'done' ORDER BY due_date ASC"
+    )
+    .all(today) as any[];
+  db.close();
+
+  if (rows.length === 0) {
+    console.log("No overdue items.");
+    return;
+  }
+
+  console.log(`\nOverdue: ${rows.length}`);
+  for (const row of rows) {
+    console.log(
+      `  ${CARD_PREFIX}-${row.id}  ${row.due_date}  ${row.assignee.padEnd(8)} ${row.title}`
+    );
+  }
+}
+
+function cmdInbox(): void {
+  const db = getDb();
+  const rows = db
+    .prepare(
+      "SELECT * FROM cards WHERE archived = 0 AND status = 'inbox' ORDER BY id DESC"
+    )
+    .all() as any[];
+  db.close();
+
+  if (rows.length === 0) {
+    console.log("Inbox is empty.");
+    return;
+  }
+
+  console.log(`\nInbox: ${rows.length}`);
+  for (const row of rows) {
+    const typeStr = row.type !== "task" ? ` (${row.type})` : "";
+    console.log(
+      `  ${CARD_PREFIX}-${row.id}  ${row.assignee.padEnd(8)} ${row.priority.padEnd(8)} ${row.title}${typeStr}`
+    );
+  }
+}
+
+function cmdStale(): void {
+  const db = getDb();
+  const cutoff = new Date(
+    Date.now() - STALE_DAYS * 24 * 60 * 60 * 1000
+  ).toISOString();
+  const rows = db
+    .prepare(
+      "SELECT * FROM cards WHERE archived = 0 AND status IN ('inbox', 'in_progress') AND updated_at < ? ORDER BY updated_at ASC"
+    )
+    .all(cutoff) as any[];
+  db.close();
+
+  if (rows.length === 0) {
+    console.log("No stale items.");
+    return;
+  }
+
+  console.log(`\nStale (no update in ${STALE_DAYS}+ days): ${rows.length}`);
+  for (const row of rows) {
+    const daysAgo = Math.floor(
+      (Date.now() - new Date(row.updated_at).getTime()) / (24 * 60 * 60 * 1000)
+    );
+    console.log(
+      `  ${CARD_PREFIX}-${row.id}  ${row.status.padEnd(14)} ${daysAgo}d ago  ${row.title}`
+    );
+  }
+}
+
+function cmdRead(positional: string[]): void {
+  if (positional.length === 0) {
+    console.error("Error: card ID required.");
+    process.exit(1);
+  }
+
+  const id = parseId(positional[0]);
+  let path = cardPath(id);
+  if (!existsSync(path)) {
+    path = cardPath(id, true);
+    if (!existsSync(path)) {
+      console.error(`Card ${CARD_PREFIX}-${id} not found.`);
+      process.exit(1);
+    }
+  }
+
+  console.log(readFileSync(path, "utf-8"));
+}
+
+function cmdReindex(): void {
+  const db = getDb();
+
+  db.prepare("DELETE FROM cards").run();
+
+  let count = 0;
+  let errors = 0;
+  let maxId = 0;
+
+  for (const file of listCardFiles(DATA_DIR)) {
+    try {
+      const content = readFileSync(join(DATA_DIR, file), "utf-8");
+      const card = parseCardFile(content);
+      indexCard(db, card, count);
+      if (card.frontmatter.id > maxId) maxId = card.frontmatter.id;
+      count++;
+    } catch (e) {
+      console.error(`Warning: Skipping ${file}: ${e}`);
+      errors++;
+    }
+  }
+
+  for (const file of listCardFiles(ARCHIVE_DIR)) {
+    try {
+      const content = readFileSync(join(ARCHIVE_DIR, file), "utf-8");
+      const card = parseCardFile(content);
+      const fm = card.frontmatter;
+      db.prepare(
+        `INSERT OR REPLACE INTO cards (id,title,status,assignee,type,priority,tags,due_date,
+        source,sort_order,created_at,updated_at,completed_at,archived)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,1)`
+      ).run(
+        fm.id,
+        fm.title,
+        fm.status,
+        fm.assignee,
+        fm.type,
+        fm.priority,
+        JSON.stringify(fm.tags),
+        fm.due_date,
+        fm.source,
+        0,
+        fm.created_at,
+        fm.updated_at,
+        fm.completed_at
+      );
+      if (fm.id > maxId) maxId = fm.id;
+      count++;
+    } catch (e) {
+      console.error(`Warning: Skipping archived ${file}: ${e}`);
+      errors++;
+    }
+  }
+
+  db.prepare(
+    "UPDATE metadata SET value = ? WHERE key = 'next_id'"
+  ).run(String(maxId + 1));
+
+  db.close();
+  console.log(
+    `Reindexed ${count} cards (${errors} errors). Next ID: ${maxId + 1}`
+  );
+}
+
+function cmdArchiveSearch(flags: Record<string, string>): void {
+  const db = getDb();
+  let query = "SELECT * FROM cards WHERE archived = 1";
+  const params: any[] = [];
+
+  if (flags.query) {
+    query += " AND title LIKE ?";
+    params.push(`%${flags.query}%`);
+  }
+
+  query += " ORDER BY completed_at DESC LIMIT 50";
+
+  const rows = db.prepare(query).all(...params) as any[];
+  db.close();
+
+  if (rows.length === 0) {
+    console.log("No archived cards found.");
+    return;
+  }
+
+  console.log(`\nArchived cards: ${rows.length}`);
+  for (const row of rows) {
+    console.log(
+      `  ${CARD_PREFIX}-${row.id}  ${row.completed_at?.split("T")[0] || "?"}  ${row.title}`
+    );
+  }
+}
+
+function cmdHelp(): void {
+  console.log(`
+ZTD (Zo To Do) -- File-first task board CLI
+
+Commands:
+  ztd add --title "..." [--assignee user] [--type ...] [--priority ...] [--tags ...] [--due-date ...] [--description ...] [--source ...] [--conversation ...]
+  ztd list [--status ...] [--assignee ...] [--type ...] [--tag ...]
+  ztd update <id> [--title ...] [--status ...] [--assignee ...] [--priority ...] [--type ...] [--tags ...] [--due-date ...] [--actor ...]
+  ztd move <id> <status> [--actor ...]
+  ztd done <id> [--actor ...]
+  ztd delete <id>
+  ztd comment <id> --content "..." [--author ...]
+  ztd attach <id> --file "..." [--name "..."] [--author ...]
+  ztd link <id> --conversation <id>
+  ztd read <id>
+  ztd stats
+  ztd review [--assignee ...]
+  ztd overdue
+  ztd inbox
+  ztd stale
+  ztd archive [--query "..."]
+  ztd reindex
+  ztd help
+
+Environment:
+  ZTD_DATA_DIR    Override default data directory (default: ~/workspace/Data/ztd)
+`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+const { command, positional, flags } = parseArgs(args);
+
+switch (command) {
+  case "add":
+    cmdAdd(flags);
+    break;
+  case "list":
+    cmdList(flags);
+    break;
+  case "update":
+    cmdUpdate(positional, flags);
+    break;
+  case "move":
+    cmdMove(positional, flags);
+    break;
+  case "done":
+    cmdDone(positional, flags);
+    break;
+  case "delete":
+    cmdDelete(positional);
+    break;
+  case "comment":
+    cmdComment(positional, flags);
+    break;
+  case "attach":
+    cmdAttach(positional, flags);
+    break;
+  case "link":
+    cmdLink(positional, flags);
+    break;
+  case "stats":
+    cmdStats();
+    break;
+  case "review":
+    cmdReview(flags);
+    break;
+  case "overdue":
+    cmdOverdue();
+    break;
+  case "inbox":
+    cmdInbox();
+    break;
+  case "stale":
+    cmdStale();
+    break;
+  case "read":
+    cmdRead(positional);
+    break;
+  case "archive":
+    cmdArchiveSearch(flags);
+    break;
+  case "reindex":
+    cmdReindex();
+    break;
+  case "help":
+  default:
+    cmdHelp();
+    break;
+}


### PR DESCRIPTION
## Summary

- Adds **open-ztd** to `Community/` -- a file-first task board for Zo Computer
- Cards stored as markdown files with YAML frontmatter, backed by SQLite index
- Includes CLI (`scripts/ztd.ts`), shared library (`scripts/lib.ts`), zo.space Kanban UI and API routes (`assets/routes/`)
- Supports assignees, priorities, types, tags, due dates, comments, attachments, activity logs, drag-and-drop reordering, and auto-archiving

## What's included

```
Community/open-ztd/
  SKILL.md              -- Skill definition and quick reference
  scripts/
    ztd.ts              -- CLI tool
    lib.ts              -- Shared library (parser, serializer, SQLite)
  references/
    guide.md            -- Full documentation (CLI, API, card fields, architecture)
  assets/routes/
    kanban.tsx           -- Drag-and-drop Kanban board (React + @dnd-kit)
    api-kanban.ts        -- List/create cards API
    api-kanban-wildcard.ts -- Detail, update, delete, comments, reorder API
```

## Validation

`bun run validate` passes with no issues for this skill (all warnings are pre-existing External/ issues).

Built by [@skeletor-js](https://github.com/skeletor-js) on [Zo Computer](https://zocomputer.com).