### PR TITLE
Add blitzit and skill-publishing skills

### DIFF
--- a/Community/blitzit/SKILL.md
+++ b/Community/blitzit/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: blitzit
+description: Interact with Blitzit task management via MCP. Create, update, and manage tasks, lists, and schedules. Use when the user mentions "Blitzit", wants to manage tasks, or needs focus/productivity tools.
+category: Productivity & Planning
+metadata:
+  author: YOUR_HANDLE.zo.computer
+  emojis: ["⚡", "✅", "📋"]
+tags:
+  - tasks
+  - productivity
+  - focus
+  - time-management
+  - mcp
+---
+
+# Blitzit Task Management
+
+Interact with Blitzit - a task management and focus app - via the Model Context Protocol (MCP).
+
+## When to Use
+
+Use this skill when the user wants to:
+- Create, update, or delete tasks
+- Manage task lists
+- Schedule tasks for specific times
+- Get today's tasks
+- Track time estimates and completions
+- Organize work with subtasks
+
+## Available Tools
+
+### Task Operations
+- `create_task` - Create a new task (MUST call `list_lists` first to get available lists)
+- `create_multiple_tasks` - Batch create multiple tasks
+- `list_tasks` - List tasks with optional filtering
+- `get_task` - Get details of a specific task
+- `update_task` - Update an existing task
+- `delete_task` - Permanently delete a task
+- `complete_task` - Mark a task as completed
+- `duplicate_task` - Duplicate a task
+
+### List Operations
+- `list_lists` - Get all lists (ALWAYS call this first before creating tasks)
+- `create_list` - Create a new list
+- `update_list` - Rename or change list color
+- `archive_list` / `unarchive_list` - Archive or restore lists
+- `duplicate_list` - Duplicate a list with all tasks
+
+### Schedule & Time
+- `get_todays_tasks` - Get tasks scheduled for today
+- `get_current_time` - Get current time with user timezone (CALL THIS before scheduling)
+
+## Usage via mcporter
+
+```bash
+# List available tools
+npx mcporter list blitzit
+
+# Call a tool
+npx mcporter call blitzit.list_lists
+npx mcporter call blitzit.create_task title="My task" listId="list-id-here"
+```
+
+## Important Notes
+
+### Before Creating Tasks
+1. **ALWAYS call `list_lists` first** to get available list IDs
+2. Pick the appropriate list based on task context, or ask the user
+
+### Scheduling Tasks
+1. **ALWAYS call `get_current_time` first** to get timezone context
+2. Convert target local time to UTC, then calculate timestamp
+3. Use `scheduleTime` in milliseconds
+
+### Notes vs Subtasks
+- `description` = Task notes/details (supports HTML formatting)
+- `subtasks` = Checklist items within the task (array of {title, isDone})
+
+### Time Values
+All time values (`estimateTime`, `timeTaken`) must be in **milliseconds**:
+- 10 minutes = 600000 ms
+- 1 hour = 3600000 ms
+
+## Authentication
+
+The Blitzit MCP server uses OAuth authentication. Tokens are stored in:
+- mcporter config: `/home/workspace/config/mcporter.json`
+- Zo Secrets: `BLITZIT_ACCESS_TOKEN`, `BLITZIT_REFRESH_TOKEN`
+
+If authentication expires, re-run the OAuth flow by opening:
+`https://integration-prd.blitzit.app/mcp/authorize`
+
+## Configuration
+
+- **MCP Server URL**: `https://integration-prd.blitzit.app/mcp`
+- **OAuth Discovery**: `https://integration-prd.blitzit.app/.well-known/oauth-authorization-server`
+- **Scopes**: `tasks:read`, `tasks:write`, `lists:read`, `lists:write`
+
+## Examples
+
+### Create a task
+```bash
+# First get lists
+npx mcporter call blitzit.list_lists
+
+# Then create task
+npx mcporter call blitzit.create_task \
+  title="Review pull request" \
+  listId="work-list-id" \
+  board="today" \
+  estimateTime=1800000
+```
+
+### Get today's tasks
+```bash
+npx mcporter call blitzit.get_todays_tasks
+```
+
+### Schedule a task for tomorrow at 2pm
+```bash
+# Get current time first
+npx mcporter call blitzit.get_current_time
+
+# Calculate timestamp and create/update task
+npx mcporter call blitzit.update_task \
+  taskId="task-id" \
+  scheduleTime=1769589000000 \
+  scheduleTimeEnabled=true
+```

--- a/Community/skill-publishing/SKILL.md
+++ b/Community/skill-publishing/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: skill-publishing
+description: Package and publish skills to the Zo Skills Hub. Use when the user asks to "publish this skill", "create a PR for this skill", or "package and submit to skills hub".
+category: Development
+metadata:
+  author: YOUR_HANDLE.zo.computer
+  emojis: ["📦", "🚀", "📝"]
+tags:
+  - skills
+  - publishing
+  - github
+  - pr
+---
+
+# Skill Publishing
+
+Package and publish your custom skills to the Zo Skills Hub for others to use.
+
+## When to Use
+
+Use this skill when:
+- User says "publish this skill" or "submit to skills hub"
+- User wants to share a skill they created
+- User mentions "package this skill" or "create a PR for my skill"
+- User asks how to contribute a skill to the community
+
+## Prerequisites
+
+1. **GitHub CLI (gh)** must be authenticated
+2. **bun** must be available (pre-installed on Zo)
+3. The skill must be in `/home/workspace/Skills/<skill-name>/` with a valid `SKILL.md`
+
+## Publishing Workflow
+
+### Step 1: Validate the Skill
+
+Before publishing, ensure the skill follows the Agent Skills spec:
+
+```bash
+# Check skill structure
+ls -la /home/workspace/Skills/<skill-name>/
+
+# Verify SKILL.md frontmatter has required fields:
+# - name (lowercase, hyphens only, matches directory name)
+# - description (1-1024 chars)
+# - metadata.author
+```
+
+Required frontmatter fields:
+```yaml
+---
+name: my-skill
+description: Brief description of what the skill does
+metadata:
+  author: your-handle.zo.computer
+---
+```
+
+Optional but recommended:
+- `category` - One of: Development, Productivity & Planning, Writing & Content, Data & Integrations, Media & Graphics, Communication, Research & Learning, System & Admin, External, Community
+- `metadata.emojis` - Array of 0-3 emojis
+- `tags` - Array of searchable keywords
+- `compatibility` - Environment requirements
+
+### Step 2: Clone the Skills Hub
+
+```bash
+cd /home/workspace
+git clone --depth=1 https://github.com/zocomputer/skills.git skills-hub
+```
+
+### Step 3: Copy Skill to Community Folder
+
+```bash
+cp -r /home/workspace/Skills/<skill-name> /home/workspace/skills-hub/Community/
+```
+
+### Step 4: Run Validation
+
+```bash
+cd /home/workspace/skills-hub
+bun validate
+```
+
+If validation fails, fix the issues reported.
+
+### Step 5: Create a Branch and Commit
+
+```bash
+cd /home/workspace/skills-hub
+git checkout -b add-<skill-name>-skill
+git add Community/<skill-name>/
+git commit -m "Add <skill-name> skill"
+```
+
+### Step 6: Push and Create PR
+
+```bash
+# Push to your fork
+gh repo fork zocomputer/skills --clone=false --remote=true 2>/dev/null || true
+git push -u origin HEAD
+
+# Create PR
+gh pr create --repo zocomputer/skills \
+  --title "Add <skill-name> skill" \
+  --body "$(cat <<'EOF'
+## Description
+
+Brief description of what this skill does and when to use it.
+
+## Features
+
+- Feature 1
+- Feature 2
+
+## Testing
+
+Describe how you tested the skill.
+
+## Checklist
+
+- [ ] SKILL.md has required frontmatter (name, description, metadata.author)
+- [ ] Skill directory name matches `name` in frontmatter
+- [ ] Description clearly explains when to use the skill
+- [ ] No sensitive data (API keys, tokens) included
+- [ ] `bun validate` passes
+EOF
+)"
+```
+
+## Skill Structure Requirements
+
+### Directory Structure
+
+```
+skill-name/
+├── SKILL.md          # Required: Main skill file with frontmatter
+├── scripts/          # Optional: Executable scripts
+├── references/       # Optional: Documentation and references
+└── assets/           # Optional: Static resources
+```
+
+### SKILL.md Format
+
+```markdown
+---
+name: skill-name
+description: When to use this skill and what it does
+category: Development
+metadata:
+  author: handle.zo.computer
+  emojis: ["📦", "🚀"]
+tags:
+  - keyword1
+  - keyword2
+compatibility: Created for Zo Computer
+---
+
+# Skill Title
+
+Brief introduction.
+
+## When to Use
+
+Describe scenarios when this skill should be activated.
+
+## Instructions
+
+Detailed instructions for using the skill.
+
+## Examples
+
+Examples of how to use the skill.
+```
+
+## Validation Rules
+
+The `bun validate` command checks:
+
+1. **Required directories**: Skill must be in Zo/, External/, Community/, or Connections/
+2. **Allowed subdirectories**: Only `assets/`, `references/`, `scripts/`
+3. **SKILL.md exists**: Every skill must have a SKILL.md file
+4. **Frontmatter fields**:
+   - `name` - Required, 1-64 chars, lowercase/numbers/hyphens only
+   - `description` - Required, 1-1024 chars
+   - `metadata.author` - Required
+5. **Directory name matches `name`**: The skill folder must match the `name` field
+
+## Quick Commands
+
+```bash
+# Validate all skills
+cd /home/workspace/skills-hub && bun validate
+
+# Generate manifest (done automatically on merge)
+cd /home/workspace/skills-hub && bun manifest
+
+# Sync external skills
+cd /home/workspace/skills-hub && bun sync
+
+# Check PR status
+gh pr list --repo zocomputer/skills --author @me
+```
+
+## Common Issues
+
+### "name field doesn't match directory name"
+- Ensure the skill folder name matches the `name` in frontmatter exactly
+- Use lowercase with hyphens (e.g., `my-skill` not `MySkill`)
+
+### "Missing required field"
+- Add `name`, `description`, and `metadata.author` to frontmatter
+
+### "Invalid directory structure"
+- Move files to allowed subdirectories: `scripts/`, `references/`, `assets/`
+- Remove any other directories
+
+## After PR Merge
+
+Once your PR is merged:
+1. The skill appears in the manifest.json automatically
+2. Users can install it via: `Skills > Install > <skill-name>`
+3. The skill appears in the Zo Skills Hub README
+
+## Example: Full Publishing Session
+
+```
+User: "Package my analytics-tracking skill and publish to the Zo skills hub"
+
+Zo should:
+1. Validate the skill at /home/workspace/Skills/analytics-tracking/SKILL.md
+2. Clone or update the skills-hub repo
+3. Copy the skill to Community/
+4. Run bun validate
+5. Create branch, commit, push
+6. Create PR with descriptive title and body
+7. Report PR URL to user
+```

--- a/Community/skill-publishing/SKILL.md
+++ b/Community/skill-publishing/SKILL.md
@@ -30,6 +30,92 @@ Use this skill when:
 2. **bun** must be available (pre-installed on Zo)
 3. The skill must be in `/home/workspace/Skills/<skill-name>/` with a valid `SKILL.md`
 
+## ⚠️ Sanitization (REQUIRED)
+
+**CRITICAL: Always sanitize skills before publishing.** Skills must NOT contain any personally identifiable information (PII), secrets, or user-specific data.
+
+### What Must Be Sanitized
+
+| Data Type | Example | Replace With |
+|-----------|---------|--------------|
+| Email addresses | `user@gmail.com` | `your-email@example.com` or remove |
+| User handles | `curtastrophe.zo.computer` | `YOUR_HANDLE.zo.computer` |
+| API keys / tokens | `sk_live_abc123...` | `YOUR_API_KEY` or remove |
+| Passwords / secrets | `mySecretPass123` | `YOUR_SECRET` or remove |
+| Specific file paths | `/Users/curtis/Documents/` | `/home/workspace/` or generic path |
+| Phone numbers | `+1-780-555-1234` | Remove or `+1-555-555-5555` |
+| Real names | `John Smith` | Remove or generic placeholder |
+| Company names (if private) | `Acme Corp` | Remove or `Your Company` |
+| Internal URLs | `https://internal.company.com` | Remove or generic |
+| Database names | `my_prod_database` | `your_database` |
+| IP addresses | `192.168.1.100` | `192.168.1.1` or remove |
+
+### Sanitization Process
+
+**Step 1: Scan for PII patterns**
+
+```bash
+# Check for email addresses
+grep -rE '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' /home/workspace/Skills/<skill-name>/
+
+# Check for API keys (common patterns)
+grep -rE '(sk_live|sk_test|api_key|apikey|token|secret|password)\s*[=:]\s*["\']?[^\s"\'\"]+' /home/workspace/Skills/<skill-name>/
+
+# Check for phone numbers
+grep -rE '\+?[0-9]{1,3}[-. ]?\(?[0-9]{3}\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}' /home/workspace/Skills/<skill-name>/
+
+# Check for your handle
+grep -r 'curtastrophe\|<your-handle>' /home/workspace/Skills/<skill-name>/
+```
+
+**Step 2: Replace with placeholders**
+
+Use generic placeholders that clearly indicate where the user should substitute their own values:
+
+```yaml
+# Good examples:
+author: YOUR_HANDLE.zo.computer
+api_key: YOUR_API_KEY_HERE
+email: your-email@example.com
+```
+
+**Step 3: Verify frontmatter**
+
+Ensure `metadata.author` uses a placeholder, NOT your actual handle:
+
+```yaml
+# WRONG:
+metadata:
+  author: curtastrophe.zo.computer
+
+# CORRECT:
+metadata:
+  author: YOUR_HANDLE.zo.computer
+```
+
+### Pre-Publish Sanitization Checklist
+
+Before copying the skill to skills-hub, verify:
+
+- [ ] **No email addresses** (yours or others')
+- [ ] **No API keys, tokens, or secrets** (even example ones)
+- [ ] **No personal handles** in author field or code examples
+- [ ] **No specific file paths** containing your username
+- [ ] **No phone numbers**
+- [ ] **No real names** of individuals
+- [ ] **No internal/private URLs**
+- [ ] **No database names** that identify specific installations
+- [ ] **No IP addresses** (or use `192.168.x.x` ranges)
+- [ ] **All placeholders are obvious** (use `YOUR_*` prefix)
+
+### Files to Check
+
+Sanitize ALL files in the skill directory:
+- `SKILL.md` - Main skill file
+- `scripts/*.ts` or `scripts/*.py` - Any scripts
+- `references/*.md` - Documentation files
+- `assets/*` - Check for embedded text in images/docs
+
 ## Publishing Workflow
 
 ### Step 1: Validate the Skill
@@ -228,11 +314,25 @@ Once your PR is merged:
 User: "Package my analytics-tracking skill and publish to the Zo skills hub"
 
 Zo should:
-1. Validate the skill at /home/workspace/Skills/analytics-tracking/SKILL.md
-2. Clone or update the skills-hub repo
-3. Copy the skill to Community/
-4. Run bun validate
-5. Create branch, commit, push
-6. Create PR with descriptive title and body
-7. Report PR URL to user
+1. Sanitize the skill - scan for and remove all PII
+2. Validate the skill at /home/workspace/Skills/analytics-tracking/SKILL.md
+3. Clone or update the skills-hub repo
+4. Copy the sanitized skill to Community/
+5. Run bun validate
+6. Create branch, commit, push
+7. Create PR with descriptive title and body
+8. Report PR URL to user
 ```
+
+## Sanitization Quick Reference
+
+When in doubt, use these replacements:
+
+| If you see... | Replace with... |
+|---------------|-----------------|
+| Your actual handle | `YOUR_HANDLE.zo.computer` |
+| Your actual email | `your-email@example.com` |
+| Any API key/token | `YOUR_API_KEY` or remove entirely |
+| Specific paths like `/Users/yourname/` | `/home/workspace/` |
+| Company-specific URLs | Remove or use `https://api.example.com` |
+| Real person names | Remove or use generic names |


### PR DESCRIPTION
## Description

This PR adds two new community skills:

### 1. blitzit
Interact with Blitzit task management via MCP. Create, update, and manage tasks, lists, and schedules.

**Features:**
- Create, update, delete tasks
- Manage task lists
- Schedule tasks for specific times
- Get today's tasks
- Track time estimates and completions
- OAuth authentication support

### 2. skill-publishing
Package and publish skills to the Zo Skills Hub. A meta-skill that helps users contribute their own skills.

**Features:**
- Validates skill structure and frontmatter
- Guides through cloning, copying, and validating
- Creates branches, commits, and PRs
- Documents the full publishing workflow

## Testing

- Both skills pass `bun validate`
- blitzit was tested with live MCP connection to Blitzit
- skill-publishing follows the exact workflow used to create this PR

## Checklist

- [x] SKILL.md has required frontmatter (name, description, metadata.author)
- [x] Skill directory name matches `name` in frontmatter
- [x] Description clearly explains when to use the skill
- [x] No sensitive data (API keys, tokens) included
- [x] `bun validate` passes