### PR TITLE
Add zo-security-audit community skill

### DIFF
--- a/Community/zo-security-audit/SKILL.md
+++ b/Community/zo-security-audit/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: zo-security-audit
+description: Comprehensive security audit for Zo Computer. Scans for hardcoded secrets, sensitive files, .env hygiene, open ports, git history leaks, publicly exposed zo.space routes/assets, hosted service security, and integration/agent review. Generates a severity-rated report with actionable remediation steps. Use when the user asks to audit, harden, or review the security posture of their Zo Computer.
+metadata:
+  author: davidj.zo.computer
+  category: Community
+  display-name: Security Audit
+  emoji: "\U0001F6E1"
+---
+# Zo Security Audit
+
+Run a full security audit of this Zo Computer. The audit covers six categories:
+
+1. **Secrets & Credentials** — hardcoded API keys, tokens, passwords in source files
+2. **Sensitive Files** — private keys, credential files, databases in the workspace
+3. **Environment / .env Files** — .env files with hardcoded values instead of Zo Secrets references
+4. **Network & Services** — open ports, listening processes
+5. **Git History** — secrets leaked in git commit history
+6. **Public Exposure** — publicly accessible zo.space routes, assets, hosted services, agents
+
+## How to Run
+
+### Step 1: Filesystem & Network Scan
+
+Run the scanner script:
+
+```bash
+bun /home/workspace/Skills/zo-security-audit/scripts/audit.ts
+```
+
+This saves initial findings to `/home/workspace/Documents/security-audit.json`.
+
+Use `--help` to see options (e.g., `--category secrets` to scan only one category).
+
+### Step 2: Zo Tool-Based Checks
+
+After running the script, use your Zo tools to check the following and **append findings to the JSON**:
+
+#### 2a. zo.space Route Exposure
+
+1. Call `list_space_routes()` to get all routes.
+2. For each route, call `get_space_route(path)` to inspect code and visibility.
+3. Flag findings:
+   - **All API routes** → severity `medium` with note "API routes are always publicly accessible. Review whether auth is implemented."
+   - **Pages with `public=true`** → severity `info` with note "Publicly visible page — verify this is intentional."
+   - **API routes without auth pattern** (no header check in code) → severity `high` with remediation "Add authentication to protect this endpoint."
+   - **API routes that accept POST/PUT/DELETE without auth** → severity `high`
+
+#### 2b. zo.space Asset Exposure
+
+1. Call `list_space_assets()`.
+2. All assets are public. Flag any that look sensitive:
+   - Files named like credentials, keys, configs, database dumps → severity `high`
+   - Large data files → severity `medium`
+   - Normal assets (images, CSS, JS) → severity `info` (just note they're public)
+
+#### 2c. Hosted Services
+
+1. Call `list_user_services()`.
+2. For each service with an HTTP URL, flag as severity `info` — note the service is network-accessible.
+3. If a service label suggests it handles sensitive data (e.g., "database", "admin", "api"), flag as `medium`.
+
+#### 2d. Agents & Rules
+
+1. Call `list_agents()` (use the tool, not a command).
+2. Review each agent's instruction. Flag:
+   - Agents that send emails/SMS → severity `info` with note "This agent sends external communications."
+   - Agents that reference API keys or secrets in their instruction text → severity `high` with remediation "Don't put secrets in agent instructions. Use Zo Secrets."
+   - Agents with very broad permissions or instructions → severity `low` with note for review
+3. Call `list_rules()` and review for any rules that might override security behaviors.
+
+#### 2e. Integration Review
+
+Note which external apps are connected (Gmail, Drive, Calendar, Linear, Notion, etc.) as severity `info` findings so the user can review their connected integrations.
+
+### Step 3: Generate Reports
+
+After combining all findings:
+
+1. **Read** the JSON from `/home/workspace/Documents/security-audit.json`
+2. **Merge** in the Zo tool-based findings from Step 2
+3. **Write** the updated JSON back to `/home/workspace/Documents/security-audit.json`
+4. **Generate** a markdown report at `/home/workspace/Documents/security-audit-report.md` with:
+   - Executive summary with overall risk score
+   - Findings grouped by category, ordered by severity
+   - Each finding should include: severity badge, title, description, file/location, and remediation
+   - A remediation checklist at the end
+
+### Step 4: Offer Remediation (Interactive Mode Only)
+
+When running interactively (not as a scheduled agent), after presenting the report:
+
+1. Ask the user if they'd like you to fix any findings
+2. For each fixable finding, offer specific actions:
+   - **Public page that should be private** → "I can set this page to private. Want me to?"
+   - **Hardcoded secret** → "I can move this to Zo Secrets and update the code to use `process.env.KEY_NAME`. Want me to?"
+   - **Unprotected API route** → "I can add authentication to this route. Want me to?"
+   - **.env with hardcoded values** → "I can migrate these values to Zo Secrets. Want me to?"
+   - **Sensitive file** → "I can move this to a safer location or remove it. Want me to?"
+   - **Git history leak** → "I can help you purge this from git history using git-filter-repo."
+3. Execute fixes the user approves
+
+## Severity Levels
+
+| Level | Meaning |
+|-------|---------|
+| Critical | Immediate action required — active credential exposure |
+| High | Should fix soon — significant security risk |
+| Medium | Moderate risk — review and address when possible |
+| Low | Minor concern — improve when convenient |
+| Info | Informational — no action needed, awareness only |
+
+## Output Format
+
+The scanner produces a JSON file with this structure:
+
+```json
+{
+  "timestamp": "2026-03-04T12:00:00.000Z",
+  "findings": [
+    {
+      "id": "F-0001",
+      "category": "secrets",
+      "severity": "critical",
+      "title": "AWS Access Key detected",
+      "description": "Found in src/config.ts at line 42",
+      "file": "src/config.ts",
+      "line": 42,
+      "detail": "AKIA●●●●●●●●●●●●WXYZ",
+      "remediation": "Rotate this AWS key immediately and store it in Zo Secrets."
+    }
+  ],
+  "summary": { "critical": 1, "high": 3, "medium": 5, "low": 2, "info": 10 },
+  "metadata": { "scannedFiles": 1234, "scannedDirs": 56, "duration": "2.3s" }
+}
+```
+
+## Notes
+
+- The scanner automatically redacts detected secrets in the output (only first/last 4 chars shown)
+- False-positive filtering is built in for Google Fonts URLs, test fixtures, docker-compose variables, and the patterns file itself
+- Files larger than 1MB are skipped for performance
+- The `patterns.json` file in `assets/` can be extended with additional secret patterns

--- a/Community/zo-security-audit/assets/patterns.json
+++ b/Community/zo-security-audit/assets/patterns.json
@@ -1,0 +1,41 @@
+{
+  "secrets": [
+    { "name": "AWS Access Key", "pattern": "AKIA[0-9A-Z]{16}", "severity": "critical", "remediation": "Rotate this AWS key immediately and store it in Zo Secrets (Settings > Advanced)." },
+    { "name": "AWS Secret Key", "pattern": "(?:aws_secret_access_key|aws_secret)\\s*[:=]\\s*['\"]?[A-Za-z0-9/+=]{40}", "severity": "critical", "remediation": "Rotate this AWS secret key and move it to Zo Secrets." },
+    { "name": "Private Key File", "pattern": "-----BEGIN\\s+(?:RSA|DSA|EC|OPENSSH|PGP)\\s+PRIVATE\\s+KEY-----", "severity": "critical", "remediation": "Remove this private key from the workspace. Store it in Zo Secrets or a proper key vault." },
+    { "name": "Stripe Secret Key", "pattern": "sk_(?:live|test)_[a-zA-Z0-9]{24,}", "severity": "critical", "remediation": "Move this Stripe key to Zo Secrets and reference it as process.env.STRIPE_SECRET_KEY." },
+    { "name": "Stripe Webhook Secret", "pattern": "whsec_[a-zA-Z0-9]{24,}", "severity": "high", "remediation": "Move this webhook secret to Zo Secrets." },
+    { "name": "GitHub Personal Access Token", "pattern": "gh[pousr]_[A-Za-z0-9_]{36,}", "severity": "critical", "remediation": "Revoke this GitHub token at github.com/settings/tokens and store the new one in Zo Secrets." },
+    { "name": "Slack Token", "pattern": "xox[bpors]-[a-zA-Z0-9\\-]{10,}", "severity": "critical", "remediation": "Revoke this Slack token and regenerate via Slack API settings. Store in Zo Secrets." },
+    { "name": "Generic API Key Assignment", "pattern": "(?:api[_\\-]?key|apikey)\\s*[:=]\\s*['\"][a-zA-Z0-9_\\-]{20,}['\"]", "severity": "high", "remediation": "Move this API key to Zo Secrets (Settings > Advanced) and reference via environment variable." },
+    { "name": "Generic Secret/Password Assignment", "pattern": "(?:password|passwd|secret|token|credential|auth_token)\\s*[:=]\\s*['\"][^\\s'\"]{8,}['\"]", "severity": "high", "remediation": "Never hardcode secrets. Move to Zo Secrets and reference as an environment variable." },
+    { "name": "Password in URL", "pattern": "://[^:\\s]+:[^@\\s]+@[^\\s]+", "severity": "critical", "remediation": "Remove credentials from URLs. Use environment variables for connection strings." },
+    { "name": "Google OAuth Client Secret", "pattern": "\"client_secret\"\\s*:\\s*\"[A-Za-z0-9_\\-]{24,}\"", "severity": "high", "remediation": "Move OAuth secrets to Zo Secrets. Do not commit credentials.json to version control." },
+    { "name": "SendGrid API Key", "pattern": "SG\\.[a-zA-Z0-9_\\-]{22}\\.[a-zA-Z0-9_\\-]{43}", "severity": "critical", "remediation": "Revoke and regenerate this SendGrid key. Store in Zo Secrets." },
+    { "name": "Twilio Auth Token", "pattern": "(?:twilio.*(?:token|secret|auth))\\s*[:=]\\s*['\"]?[a-f0-9]{32}", "severity": "critical", "remediation": "Rotate this Twilio token and store in Zo Secrets." }
+  ],
+  "sensitive_filenames": [
+    "id_rsa", "id_dsa", "id_ecdsa", "id_ed25519",
+    ".pem", ".key", ".p12", ".pfx", ".jks", ".keystore",
+    "credentials.json", "service-account.json", "service_account.json",
+    "token.json", ".htpasswd", ".netrc", ".pgpass",
+    "wp-config.php", "database.yml", "secrets.yml", "master.key"
+  ],
+  "sensitive_extensions": [
+    ".pem", ".key", ".p12", ".pfx", ".jks", ".keystore",
+    ".sqlite", ".sqlite3", ".db", ".sql", ".dump"
+  ],
+  "skip_dirs": [
+    "node_modules", ".git", "Trash", ".cache", ".npm", ".bun",
+    "__pycache__", ".venv", "venv", ".zo", "dist", "build"
+  ],
+  "skip_extensions": [
+    ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".webp", ".avif",
+    ".mp3", ".mp4", ".mov", ".avi", ".mkv", ".wav", ".ogg", ".webm",
+    ".woff", ".woff2", ".ttf", ".eot", ".otf",
+    ".zip", ".gz", ".tar", ".bz2", ".7z", ".rar",
+    ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+    ".pyc", ".o", ".so", ".dylib", ".dll", ".exe", ".bin",
+    ".lock", ".map"
+  ]
+}

--- a/Community/zo-security-audit/scripts/audit.ts
+++ b/Community/zo-security-audit/scripts/audit.ts
@@ -1,0 +1,503 @@
+#!/usr/bin/env bun
+import { readdir, stat, readFile, writeFile, access } from "fs/promises";
+import { join, basename, extname, relative } from "path";
+
+const WORKSPACE = "/home/workspace";
+const SKILL_DIR = join(WORKSPACE, "Skills/zo-security-audit");
+const DEFAULT_OUTPUT = join(WORKSPACE, "Documents/security-audit.json");
+
+interface Finding {
+  id: string;
+  category: "secrets" | "sensitive_files" | "env_files" | "network" | "git_history" | "exposure" | "integrations";
+  severity: "critical" | "high" | "medium" | "low" | "info";
+  title: string;
+  description: string;
+  file?: string;
+  line?: number;
+  detail?: string;
+  remediation: string;
+}
+
+interface AuditResult {
+  timestamp: string;
+  findings: Finding[];
+  summary: Record<string, number>;
+  metadata: {
+    scannedFiles: number;
+    scannedDirs: number;
+    duration: string;
+  };
+}
+
+interface PatternDef {
+  name: string;
+  pattern: string;
+  severity: string;
+  remediation: string;
+}
+
+interface PatternsConfig {
+  secrets: PatternDef[];
+  sensitive_filenames: string[];
+  sensitive_extensions: string[];
+  skip_dirs: string[];
+  skip_extensions: string[];
+}
+
+let findingCounter = 0;
+function nextId(): string {
+  return `F-${String(++findingCounter).padStart(4, "0")}`;
+}
+
+async function loadPatterns(): Promise<PatternsConfig> {
+  const raw = await readFile(join(SKILL_DIR, "assets/patterns.json"), "utf-8");
+  return JSON.parse(raw);
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function walkFiles(
+  dir: string,
+  skipDirs: Set<string>,
+  skipExts: Set<string>,
+  callback: (filepath: string) => Promise<void>,
+  stats: { files: number; dirs: number }
+): Promise<void> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  stats.dirs++;
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (skipDirs.has(entry.name) || entry.name.startsWith(".")) continue;
+      await walkFiles(fullPath, skipDirs, skipExts, callback, stats);
+    } else if (entry.isFile()) {
+      const ext = extname(entry.name).toLowerCase();
+      if (skipExts.has(ext)) continue;
+      const s = await stat(fullPath).catch(() => null);
+      if (!s || s.size > 1_000_000) continue; // skip files > 1MB
+      stats.files++;
+      await callback(fullPath);
+    }
+  }
+}
+
+async function scanSecrets(config: PatternsConfig): Promise<Finding[]> {
+  const findings: Finding[] = [];
+  const skipDirs = new Set(config.skip_dirs);
+  const skipExts = new Set(config.skip_extensions);
+  const patterns = config.secrets.map((p) => ({
+    ...p,
+    regex: new RegExp(p.pattern, "gi"),
+  }));
+  const stats = { files: 0, dirs: 0 };
+
+  await walkFiles(
+    WORKSPACE,
+    skipDirs,
+    skipExts,
+    async (filepath) => {
+      let content: string;
+      try {
+        content = await readFile(filepath, "utf-8");
+      } catch {
+        return;
+      }
+
+      const lines = content.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        for (const pat of patterns) {
+          pat.regex.lastIndex = 0;
+          const match = pat.regex.exec(line);
+          if (match) {
+            const matchStr = match[0];
+            const relPath = relative(WORKSPACE, filepath);
+            const isFalsePositive =
+              matchStr.includes("fonts.googleapis.com") ||
+              matchStr.includes("fonts.gstatic.com") ||
+              relPath === "Skills/zo-security-audit/assets/patterns.json" ||
+              (pat.name === "Password in URL" && /user:pass@|user:password@/.test(matchStr)) ||
+              (pat.name === "Password in URL" && /\$\{[^}]+\}/.test(matchStr)) ||
+              (relPath.includes("/tests/") && /test[-_](?:password|secret|key)|password123/.test(matchStr)) ||
+              (pat.name === "Slack Token" && matchStr.includes("xxxx"));
+            if (isFalsePositive) continue;
+            const redacted =
+              match[0].length > 8
+                ? match[0].slice(0, 4) + "●".repeat(Math.min(match[0].length - 8, 20)) + match[0].slice(-4)
+                : "●".repeat(match[0].length);
+            findings.push({
+              id: nextId(),
+              category: "secrets",
+              severity: pat.severity as Finding["severity"],
+              title: `${pat.name} detected`,
+              description: `Found in ${relative(WORKSPACE, filepath)} at line ${i + 1}`,
+              file: relative(WORKSPACE, filepath),
+              line: i + 1,
+              detail: redacted,
+              remediation: pat.remediation,
+            });
+          }
+        }
+      }
+    },
+    stats
+  );
+
+  return findings;
+}
+
+async function scanSensitiveFiles(config: PatternsConfig): Promise<Finding[]> {
+  const findings: Finding[] = [];
+  const skipDirs = new Set(config.skip_dirs);
+  const sensitiveNames = new Set(config.sensitive_filenames);
+  const sensitiveExts = new Set(config.sensitive_extensions);
+  const stats = { files: 0, dirs: 0 };
+
+  await walkFiles(
+    WORKSPACE,
+    skipDirs,
+    new Set(),
+    async (filepath) => {
+      const name = basename(filepath);
+      const ext = extname(filepath).toLowerCase();
+      const rel = relative(WORKSPACE, filepath);
+
+      if (sensitiveNames.has(name)) {
+        findings.push({
+          id: nextId(),
+          category: "sensitive_files",
+          severity: name.includes("id_rsa") || name.includes("id_ed25519") ? "critical" : "high",
+          title: `Sensitive file: ${name}`,
+          description: `Found at ${rel}`,
+          file: rel,
+          remediation:
+            "Consider whether this file needs to be in your workspace. Private keys and credentials should be stored in Zo Secrets or removed entirely.",
+        });
+      } else if (sensitiveExts.has(ext) && !rel.startsWith("Skills/")) {
+        const s = await stat(filepath).catch(() => null);
+        const sizeMB = s ? (s.size / 1_000_000).toFixed(1) : "?";
+        findings.push({
+          id: nextId(),
+          category: "sensitive_files",
+          severity: [".key", ".pem", ".p12", ".pfx"].includes(ext) ? "high" : "medium",
+          title: `Sensitive file type: ${name} (${sizeMB}MB)`,
+          description: `Found at ${rel}`,
+          file: rel,
+          remediation:
+            ext === ".key" || ext === ".pem"
+              ? "Move cryptographic keys out of the workspace or into Zo Secrets."
+              : "Review whether database/SQL files should be stored in the workspace. Consider access controls.",
+        });
+      }
+    },
+    stats
+  );
+
+  return findings;
+}
+
+async function scanEnvFiles(config: PatternsConfig): Promise<Finding[]> {
+  const findings: Finding[] = [];
+  const skipDirs = new Set(config.skip_dirs);
+  const stats = { files: 0, dirs: 0 };
+
+  await walkFiles(
+    WORKSPACE,
+    skipDirs,
+    new Set(),
+    async (filepath) => {
+      const name = basename(filepath);
+      if (!name.startsWith(".env") && name !== ".env") return;
+
+      const rel = relative(WORKSPACE, filepath);
+      let content: string;
+      try {
+        content = await readFile(filepath, "utf-8");
+      } catch {
+        return;
+      }
+
+      const lines = content.split("\n");
+      const hardcodedKeys: string[] = [];
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const match = trimmed.match(/^([A-Z_][A-Z0-9_]*)=(.+)$/);
+        if (match) {
+          const value = match[2].replace(/^['"]|['"]$/g, "");
+          if (value && !value.startsWith("$") && !value.startsWith("${") && value.length > 3) {
+            hardcodedKeys.push(match[1]);
+          }
+        }
+      }
+
+      if (hardcodedKeys.length > 0) {
+        findings.push({
+          id: nextId(),
+          category: "env_files",
+          severity: "high",
+          title: `.env file with hardcoded values: ${name}`,
+          description: `${rel} contains ${hardcodedKeys.length} hardcoded value(s): ${hardcodedKeys.slice(0, 5).join(", ")}${hardcodedKeys.length > 5 ? "..." : ""}`,
+          file: rel,
+          detail: `Keys: ${hardcodedKeys.join(", ")}`,
+          remediation:
+            "Move these values to Zo Secrets (Settings > Advanced). Reference them as environment variables instead of storing in .env files.",
+        });
+      }
+    },
+    stats
+  );
+
+  return findings;
+}
+
+async function scanNetwork(): Promise<Finding[]> {
+  const findings: Finding[] = [];
+
+  try {
+    const proc = Bun.spawn(["ss", "-tlnp"], { stdout: "pipe", stderr: "pipe" });
+    const output = await new Response(proc.stdout).text();
+    const lines = output.trim().split("\n").slice(1); // skip header
+
+    for (const line of lines) {
+      const parts = line.split(/\s+/);
+      const localAddr = parts[3] || "";
+      const processInfo = parts.slice(5).join(" ");
+
+      const addrMatch = localAddr.match(/^([\d.*:]+):(\d+)$/);
+      if (!addrMatch) continue;
+
+      const [, host, port] = addrMatch;
+      const portNum = parseInt(port, 10);
+
+      const knownPorts = new Set([3100, 9090, 9093]); // Loki, Prometheus, etc.
+      if (knownPorts.has(portNum)) continue;
+
+      const bindAll = host === "*" || host === "0.0.0.0" || host === "::";
+
+      if (bindAll) {
+        findings.push({
+          id: nextId(),
+          category: "network",
+          severity: "medium",
+          title: `Service listening on all interfaces: port ${port}`,
+          description: `${processInfo || "Unknown process"} is bound to ${host}:${port}`,
+          detail: line.trim(),
+          remediation: `Consider binding to 127.0.0.1:${port} instead of ${host}:${port} to limit exposure. If this is a Zo-managed service, verify it needs external access.`,
+        });
+      } else {
+        findings.push({
+          id: nextId(),
+          category: "network",
+          severity: "info",
+          title: `Service listening on port ${port}`,
+          description: `${processInfo || "Unknown process"} bound to ${localAddr}`,
+          detail: line.trim(),
+          remediation: "No action needed — service is bound to localhost only.",
+        });
+      }
+    }
+  } catch (e) {
+    findings.push({
+      id: nextId(),
+      category: "network",
+      severity: "info",
+      title: "Network scan skipped",
+      description: `Could not run ss command: ${e}`,
+      remediation: "Ensure ss is installed (apt install iproute2).",
+    });
+  }
+
+  return findings;
+}
+
+async function scanGitHistory(): Promise<Finding[]> {
+  const findings: Finding[] = [];
+
+  // Find all git repos in workspace
+  try {
+    const proc = Bun.spawn(["find", WORKSPACE, "-name", ".git", "-type", "d", "-maxdepth", "4"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = await new Response(proc.stdout).text();
+    const gitDirs = output.trim().split("\n").filter(Boolean);
+
+    for (const gitDir of gitDirs) {
+      const repoDir = join(gitDir, "..");
+      const repoName = relative(WORKSPACE, repoDir);
+
+      // Check for secrets in recent git history (last 50 commits)
+      const highRiskPatterns = [
+        "AKIA[0-9A-Z]{16}",
+        "sk_(live|test)_[a-zA-Z0-9]{24,}",
+        "-----BEGIN.*PRIVATE KEY-----",
+        "ghp_[A-Za-z0-9_]{36}",
+      ];
+
+      for (const pattern of highRiskPatterns) {
+        try {
+          const grepProc = Bun.spawn(
+            ["git", "-C", repoDir, "log", "--all", "-n", "50", "-p", "--grep-reflog=.", "-G", pattern],
+            { stdout: "pipe", stderr: "pipe" }
+          );
+          const grepOut = await new Response(grepProc.stdout).text();
+          if (grepOut.trim().length > 0) {
+            findings.push({
+              id: nextId(),
+              category: "git_history",
+              severity: "critical",
+              title: `Secret pattern in git history: ${repoName}`,
+              description: `Repository "${repoName}" has commits matching a secret pattern. Even deleted secrets persist in git history.`,
+              file: repoName,
+              remediation:
+                "Use git-filter-repo or BFG Repo Cleaner to purge secrets from history. Rotate the exposed credential immediately.",
+            });
+            break; // one finding per repo is enough
+          }
+        } catch {
+          // skip
+        }
+      }
+
+      // Check for .env files committed
+      try {
+        const lsProc = Bun.spawn(["git", "-C", repoDir, "ls-files", "--", "*.env", ".env*"], {
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const lsOut = await new Response(lsProc.stdout).text();
+        const envFiles = lsOut.trim().split("\n").filter(Boolean);
+        if (envFiles.length > 0) {
+          findings.push({
+            id: nextId(),
+            category: "git_history",
+            severity: "high",
+            title: `Env files tracked in git: ${repoName}`,
+            description: `${envFiles.length} env file(s) are tracked: ${envFiles.join(", ")}`,
+            file: repoName,
+            detail: envFiles.join(", "),
+            remediation: "Add .env* to .gitignore and remove tracked env files with: git rm --cached .env",
+          });
+        }
+      } catch {
+        // skip
+      }
+    }
+  } catch {
+    // no git repos found
+  }
+
+  return findings;
+}
+
+function summarize(findings: Finding[]): Record<string, number> {
+  const summary: Record<string, number> = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  for (const f of findings) {
+    summary[f.severity] = (summary[f.severity] || 0) + 1;
+  }
+  return summary;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(`
+Zo Security Audit Scanner
+
+Usage: bun audit.ts [--output <path>] [--category <name>] [--json]
+
+Options:
+  --output <path>     Save JSON results to file (default: ${DEFAULT_OUTPUT})
+  --category <name>   Run only a specific category:
+                        secrets, sensitive_files, env_files, network, git_history
+  --json              Output raw JSON to stdout (for piping)
+  --help, -h          Show this help
+
+Categories scanned:
+  secrets             Scans files for hardcoded API keys, tokens, passwords
+  sensitive_files     Finds private keys, credentials files, databases
+  env_files           Checks .env files for hardcoded values
+  network             Lists open ports and listening services
+  git_history         Checks git repos for leaked secrets in history
+
+Note: This script handles filesystem/network scanning. Zo tool-based checks
+(zo.space routes, services, agents, integrations) are done by Zo directly
+when running the full skill per SKILL.md instructions.
+`);
+    process.exit(0);
+  }
+
+  const outputIdx = args.indexOf("--output");
+  const outputPath = outputIdx >= 0 && args[outputIdx + 1] ? args[outputIdx + 1] : DEFAULT_OUTPUT;
+  const categoryIdx = args.indexOf("--category");
+  const onlyCategory = categoryIdx >= 0 ? args[categoryIdx + 1] : null;
+  const jsonMode = args.includes("--json");
+
+  const start = Date.now();
+  const config = await loadPatterns();
+  const allFindings: Finding[] = [];
+
+  const categories: Record<string, () => Promise<Finding[]>> = {
+    secrets: () => scanSecrets(config),
+    sensitive_files: () => scanSensitiveFiles(config),
+    env_files: () => scanEnvFiles(config),
+    network: () => scanNetwork(),
+    git_history: () => scanGitHistory(),
+  };
+
+  if (onlyCategory) {
+    if (!categories[onlyCategory]) {
+      console.error(`Unknown category: ${onlyCategory}`);
+      process.exit(1);
+    }
+    if (!jsonMode) console.log(`Scanning: ${onlyCategory}...`);
+    allFindings.push(...(await categories[onlyCategory]()));
+  } else {
+    for (const [name, fn] of Object.entries(categories)) {
+      if (!jsonMode) process.stdout.write(`Scanning: ${name}...`);
+      const results = await fn();
+      allFindings.push(...results);
+      if (!jsonMode) console.log(` ${results.length} finding(s)`);
+    }
+  }
+
+  const duration = ((Date.now() - start) / 1000).toFixed(1);
+  const result: AuditResult = {
+    timestamp: new Date().toISOString(),
+    findings: allFindings,
+    summary: summarize(allFindings),
+    metadata: { scannedFiles: 0, scannedDirs: 0, duration: `${duration}s` },
+  };
+
+  if (jsonMode) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    await writeFile(outputPath, JSON.stringify(result, null, 2));
+    console.log(`\n✅ Scan complete in ${duration}s`);
+    console.log(`   Findings: ${allFindings.length} total`);
+    console.log(
+      `   🔴 ${result.summary.critical} critical  🟠 ${result.summary.high} high  🟡 ${result.summary.medium} medium  🔵 ${result.summary.low} low  ⚪ ${result.summary.info} info`
+    );
+    console.log(`   Report saved to: ${outputPath}`);
+  }
+}
+
+main().catch((e) => {
+  console.error("Audit failed:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds a comprehensive security audit skill for Zo Computer
- Includes a Bun-based scanner script (`scripts/audit.ts`) that checks for hardcoded secrets, sensitive files, .env hygiene, open ports, and git history leaks
- Includes configurable secret detection patterns (`assets/patterns.json`) covering AWS, Stripe, GitHub, Slack, SendGrid, Twilio, OAuth, and generic credentials
- SKILL.md provides step-by-step instructions for both the automated scanner and manual Zo tool-based checks (zo.space routes, assets, services, agents, integrations)
- Supports interactive remediation — offering to fix findings like moving secrets to Zo Secrets, restricting file permissions, and purging git history

## What it scans
| Category | What it checks |
|----------|---------------|
| Secrets & Credentials | Hardcoded API keys, tokens, passwords in source files |
| Sensitive Files | Private keys, credential files, databases in the workspace |
| Environment Files | .env files with hardcoded values instead of Zo Secrets |
| Network & Services | Open ports, listening processes bound to all interfaces |
| Git History | Secrets leaked in commit history, .env files tracked in git |
| Public Exposure | zo.space routes, assets, hosted services, agents (via Zo tools) |

## Test plan
- [x] Passes `bun validate` with no new warnings
- [x] SKILL.md has required frontmatter (`name`, `description`, `metadata.author`)
- [x] Only uses allowed subdirectories (`scripts/`, `assets/`)
- [x] Scanner script tested on a live Zo Computer with 500+ files
- [x] No user-specific paths or credentials in any files

🤖 Generated with [Claude Code](https://claude.com/claude-code)