### PR TITLE
Add zopenclaw skill

### DIFF
--- a/Community/zopenclaw/SKILL.md
+++ b/Community/zopenclaw/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: zopenclaw
+description: |
+  Install and run OpenClaw on Zo Computer with Tailscale private networking, browser Control UI, and Zo MCP tools via mcporter. Use this skill whenever the user wants to set up OpenClaw on their Zo, install OpenClaw, run OpenClaw, host OpenClaw, or asks about getting OpenClaw running on Zo. Also use when the user mentions "openclaw", "open claw", "personal agent framework", or asks about running a persistent AI agent on their Zo with Telegram/Discord/WhatsApp access. Handles Tailscale setup, OpenClaw installation, mcporter setup for Zo tools, two-phase gateway bootstrap, reprovision-safe service registration, and health verification. NOT for general Zo agent setup (use heartbeats and native Zo skills instead).
+compatibility: Requires Zo Computer, Node.js (pre-installed on Zo), npm, curl, jq
+metadata:
+  author: skeletorjs
+  category: Integration
+  display-name: Install OpenClaw on Zo
+  tags: openclaw, agent, tailscale, personal-agent, framework
+---
+# zopenclaw
+
+Install OpenClaw on Zo Computer with Tailscale private networking.
+
+## What This Sets Up
+
+- OpenClaw agent framework (persistent, 24/7)
+- Tailscale private mesh network (secure access to Control UI + SSH)
+- Browser-based Control UI via HTTPS on your tailnet
+- Gateway registered as a Zo User Service (survives reprovisions and crashes)
+- Zo MCP tools bridged into OpenClaw via mcporter (web search, Gmail, Calendar, media generation, etc.)
+
+## Prerequisites
+
+- Zo Computer account (any tier)
+- Tailscale account (free tier works)
+- API key from an LLM provider (Anthropic, OpenAI, OpenRouter, etc.)
+- A messaging channel token (Telegram bot, Discord bot, or WhatsApp)
+- Tailscale Serve enabled for this node (required for Control UI over HTTPS)
+
+## When to Read References
+
+- **references/architecture.md** -- When debugging, when the user asks WHY something works the way it does, or when you need to understand the two-phase bootstrap, Tailscale networking mode, or the `register_user_service` pattern
+- **references/troubleshooting.md** -- When something isn't working: gateway crashes, Tailscale not connecting, `tools.profile` reverting, port conflicts, reprovision issues, or workspace size limits
+
+## How to Run This Skill
+
+There are six steps. Steps 1 and 3 require user action. Steps 2, 4, 5, and 6 are automated by Zo.
+
+### Step 1: Save your Tailscale auth key (user action)
+
+1. Go to https://login.tailscale.com/admin/settings/keys
+2. Create a **reusable** auth key (reusable is important -- Zo restarts between sessions)
+3. Go to Zo [Settings > Advanced](/?t=settings&s=advanced)
+4. Add a secret: name = `TAILSCALE_AUTHKEY`, value = the key (starts with `tskey-auth-`)
+
+### Step 2: Run the install script (Zo runs)
+
+```bash
+bash /home/workspace/Skills/zopenclaw/scripts/install.sh
+```
+
+This script:
+- Validates `TAILSCALE_AUTHKEY` exists in environment
+- Installs Tailscale binary (if not present)
+- Writes Tailscale startup script (`/usr/local/bin/start-tailscale.sh`)
+- Saves auth key to `~/.zo_secrets`
+- Installs OpenClaw via npm (if not present)
+
+After the script completes, Zo registers Tailscale as a Zo User Service:
+
+```
+register_user_service(
+  label="tailscale",
+  protocol="tcp",
+  local_port=41641,
+  entrypoint="/usr/local/bin/start-tailscale.sh",
+  workdir="/root"
+)
+```
+
+Wait for Tailscale to connect (~10 seconds), then verify:
+
+```bash
+tailscale status
+```
+
+**Important: Enable Tailscale Serve (user action).** Serve must be enabled for this node before the Control UI will work over HTTPS. Get the node ID and give the user the enablement link:
+
+```bash
+tailscale status --json | jq -r '.Self.ID'
+```
+
+Tell the user to open:
+
+`https://login.tailscale.com/f/serve?node=<node-id>`
+
+If Serve is not enabled, the Control UI will fail with "requires device identity" because only insecure origins will reach the gateway. Do not proceed to Step 3 until the user confirms Serve is enabled.
+
+### Step 3: Run OpenClaw onboarding (user action)
+
+The user opens Zo's terminal panel and runs:
+
+```
+openclaw onboard
+```
+
+This is interactive -- the user picks their LLM provider, model, and messaging channel. Do NOT try to automate this. Do NOT use `--install-daemon` (we use `register_user_service` instead).
+
+Wait for the user to confirm onboarding is complete before proceeding.
+
+### Step 4: Run the bootstrap script (Zo runs)
+
+```bash
+bash /home/workspace/Skills/zopenclaw/scripts/bootstrap.sh
+```
+
+This script:
+- Sets `tools.profile` to `full`
+- Patches gateway config to current schema (`gateway.bind`, `gateway.tailscale.mode`, `gateway.auth.mode`, `gateway.controlUi.enabled`) and removes deprecated keys (`host`, `tailscaleServe`, `tokenAuth`, `enableControlUI`)
+- Sets `gateway.auth.allowTailscale = true` (allows Tailscale-authenticated browser access)
+- Sets `gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback = true` (fixes "requires device identity" error through Tailscale Serve)
+- Sets `gateway.tailscale.resetOnExit = false` (prevents Serve reset when gateway stops, since we manage Serve separately)
+- Removes any existing `trustedProxies` (needed for two-phase bootstrap)
+- Migrates gateway token to `~/.zo_secrets`
+- Pre-publishes Tailscale Serve to port 18789 (best effort -- may need manual setup if Serve is not yet enabled)
+- Stops any existing gateway processes
+
+After the script completes, Zo performs the bootstrap sequence:
+
+**Phase 1 -- Start gateway WITHOUT trustedProxies:**
+
+```
+register_user_service(
+  label="openclaw-gateway",
+  protocol="tcp",
+  local_port=18789,
+  entrypoint="bash -c 'cd /root/.openclaw && exec openclaw gateway run'",
+  workdir="/root/.openclaw"
+)
+```
+
+Wait for readiness (poll instead of fixed sleep), then pair the local device:
+
+```bash
+for i in $(seq 1 20); do
+  if openclaw gateway status 2>&1 | grep -qE 'RPC probe: ok|Listening:'; then
+    break
+  fi
+  sleep 1
+done
+openclaw devices list
+```
+
+If there is a pending request, approve it:
+
+```bash
+/home/workspace/Skills/zopenclaw/scripts/pairing-helper.sh device <request-id>
+```
+
+**Phase 2 -- Add trustedProxies and restart:**
+
+```bash
+jq '.gateway.trustedProxies = ["127.0.0.1/32"]' ~/.openclaw/openclaw.json > /tmp/oc.json && mv /tmp/oc.json ~/.openclaw/openclaw.json
+supervisorctl -s http://127.0.0.1:29011 restart openclaw-gateway
+```
+
+**Phase 3 -- Verify Tailscale Serve HTTPS (bootstrap.sh already attempts this, but verify/fix here):**
+
+```bash
+tailscale serve status --json | jq .
+```
+
+If the serve mapping is missing or wrong, reset and re-publish:
+
+```bash
+tailscale serve reset
+tailscale serve --bg --yes 18789
+tailscale serve status --json | jq .
+```
+
+Expected proxy target:
+
+`https://<tailscale-hostname>/ -> http://127.0.0.1:18789`
+
+If you see `127.0.0.1:3000` (or any other port), reset and re-run the commands above.
+
+**Phase 4 -- Provision HTTPS certificate:**
+
+```bash
+TS_HOST=$(tailscale status --json | jq -r '.Self.DNSName' | sed 's/\.$//')
+tailscale cert "$TS_HOST"
+```
+
+### Step 5: Verify (Zo runs)
+
+```bash
+bash /home/workspace/Skills/zopenclaw/scripts/verify.sh
+```
+
+On success:
+
+- Tell the user their Control UI is at `https://<tailscale-hostname>`
+- Tell the user to access ONLY the HTTPS tailnet hostname URL
+- Do NOT use `http://<tailscale-ip>:18789` or any non-HTTPS proxy URL
+
+If the UI says "pairing required", approve pending requests:
+
+```bash
+openclaw devices list
+openclaw devices approve <request-id>
+```
+
+If Telegram asks for pairing code:
+
+```bash
+/home/workspace/Skills/zopenclaw/scripts/pairing-helper.sh telegram <PAIRING_CODE>
+```
+
+### Step 6: Connect Zo Tools via mcporter (Zo runs)
+
+OpenClaw does not have native MCP client support (it's an open feature request). mcporter bridges MCP servers into OpenClaw's tool system, giving your agent access to Zo's 50+ tools (web search, Gmail, Calendar, Drive, media generation, etc.).
+
+**Prerequisites:** The user needs a Zo access token.
+
+1. Direct the user to [Settings > Advanced](/?t=settings&s=advanced)
+2. In the **Access Tokens** area, create a new token
+3. Save the token value as a secret named `ZO_ACCESS_TOKEN` in the **Secrets** area on the same page
+
+**Configure mcporter (Zo runs):**
+
+mcporter was installed by the install script in Step 2. Add Zo's MCP server:
+
+```bash
+source /root/.zo_secrets
+mcporter config add zo https://api.zo.computer/mcp \
+  --header "Authorization: Bearer $ZO_ACCESS_TOKEN" \
+  --scope home
+```
+
+Verify the connection:
+
+```bash
+mcporter list
+mcporter call zo.web_search --args '{"query": "test", "time_range": "day"}'
+```
+
+If `mcporter list` shows the zo server and the test call returns results, the bridge is working.
+
+Restart the gateway so OpenClaw picks up the new tools:
+
+```bash
+supervisorctl -s http://127.0.0.1:29011 restart openclaw-gateway
+```
+
+The user can now ask their OpenClaw agent to use Zo tools (search the web, check email, manage calendar, generate images, etc.) via the mcporter bridge.
+
+## Telegram Group Messages (Important)
+
+If OpenClaw warns:
+
+`channels.telegram.groupPolicy is "allowlist" but groupAllowFrom is empty`
+
+then group chats will be silently dropped. Fix one of these:
+
+- Add allowed sender IDs to `channels.telegram.groupAllowFrom` (or `channels.telegram.allowFrom`)
+- Set `channels.telegram.groupPolicy` to `open`
+
+If any checks fail, read `references/troubleshooting.md` for diagnosis and fixes.

--- a/Community/zopenclaw/references/architecture.md
+++ b/Community/zopenclaw/references/architecture.md
@@ -1,0 +1,77 @@
+# zopenclaw Architecture Reference
+
+This document explains WHY each decision was made. Read this for context when debugging issues or when the user asks about the design.
+
+## Why Tailscale
+
+Tailscale creates a private mesh network (tailnet) between your devices. On Zo, it serves three purposes:
+
+1. **Private access to Control UI** -- OpenClaw's browser-based management interface is only accessible on your tailnet, not the public internet
+2. **HTTPS certificates** -- Tailscale provisions TLS certs automatically via its own CA, no manual SSL setup
+3. **SSH access** -- You can SSH into your Zo from any device on your tailnet (`ssh root@zo-workspace`)
+
+Without Tailscale, the Control UI would either be inaccessible (localhost only) or publicly exposed (security risk). Tailscale gives private access with zero config.
+
+Tailscale runs in userspace networking mode (`--tun=userspace-networking`) because Zo containers don't have iptables/netfilter access.
+
+## Why `register_user_service` (not raw supervisord)
+
+Zo periodically reprovisions containers for maintenance. When this happens:
+
+- Manual edits to `/etc/zo/supervisord-user.conf` get wiped
+- Processes started with `nohup` or manual supervisord entries disappear
+- Only `/root/` and `/home/` data survives, plus services registered via `register_user_service`
+
+`register_user_service` is Zo's native process manager. Services registered through it:
+- Auto-start on boot
+- Auto-restart on crash
+- Survive container reprovisions
+- Get proper log files in `/dev/shm/`
+
+Both Tailscale and the OpenClaw gateway are registered this way.
+
+## Why the Two-Phase Bootstrap
+
+OpenClaw's gateway has a `trustedProxies` config that tells it to trust `X-Forwarded-For` and `Tailscale-User-Login` headers from reverse proxies. Tailscale Serve acts as a reverse proxy on localhost.
+
+**The deadlock:**
+- If `trustedProxies` is set before device pairing, CLI connections fail (they don't send proxy headers, so the gateway can't identify the client)
+- If `trustedProxies` is NOT set, Tailscale browser connections can't authenticate (gateway sees all traffic from 127.0.0.1 with no identity)
+
+**The fix (two-phase bootstrap):**
+1. Start gateway WITHOUT `trustedProxies`
+2. Run `openclaw devices list` to pair the local CLI device (works because no proxy trust is required for direct connections)
+3. Add `trustedProxies: ["127.0.0.1/32"]` to config
+4. Restart gateway
+
+Now both connection types work:
+- Browser connections through Tailscale are trusted (they come through the proxy at 127.0.0.1 with identity headers)
+- The already-paired CLI device still works via direct connection
+
+## Why mcporter for Zo Tools
+
+OpenClaw does not have native MCP client support. GitHub issue #29053 is an open feature request for it. The `mcpServers` block in `openclaw.json` is for exposing OpenClaw as an MCP server to other tools, not for consuming external MCP servers.
+
+mcporter is the current standard bridge that connects external MCP servers into OpenClaw's tool system. It's maintained by Peter Steinberger (OpenClaw's creator) and is widely used in the community for integrating services like Linear, Context7, Firecrawl, and others.
+
+For Zo, mcporter bridges the Zo MCP endpoint (`https://api.zo.computer/mcp`) into OpenClaw, giving the agent access to 50+ Zo tools: web search, Gmail, Calendar, Drive, media generation, sending SMS/email, and more. The config is a single command:
+
+```bash
+mcporter config add zo https://api.zo.computer/mcp \
+  --header "Authorization: Bearer $ZO_ACCESS_TOKEN" \
+  --scope home
+```
+
+The access token is a long-lived Zo access token (not a session token) created in Settings > Advanced > Access Tokens and stored as a secret. Unlike the 24-hour tokens used in some community guides, these don't expire silently.
+
+When OpenClaw eventually ships native MCP client support, the mcporter bridge can be replaced with a direct config entry. Until then, mcporter is required.
+
+## Why User Runs `openclaw onboard` Manually
+
+OpenClaw supports many LLM providers (Anthropic, OpenAI, OpenRouter, Google, local models, etc.) and many messaging channels (Telegram, Discord, WhatsApp, Slack, Signal, iMessage, IRC, etc.). The onboarding wizard handles all of these.
+
+If we replicated the wizard in our skill, we'd have to update it every time OpenClaw adds a provider or channel. Instead, we let the user run the official wizard in Zo's terminal, then we handle everything Zo-specific afterward.
+
+## Why Secrets Go in Settings > Advanced
+
+API keys and tokens must NEVER appear in chat. Chat logs are stored and could be reviewed. Zo's Settings > Advanced provides encrypted secret storage that's accessible to the environment as env vars. The install script reads `TAILSCALE_AUTHKEY` from env, not from user input.

--- a/Community/zopenclaw/references/troubleshooting.md
+++ b/Community/zopenclaw/references/troubleshooting.md
@@ -1,0 +1,206 @@
+# zopenclaw Troubleshooting
+
+## `tools.profile` reverts to "messaging"
+
+After OpenClaw updates or re-running onboard, `tools.profile` can silently reset. This blocks shell, file, and web access. Fix:
+
+```bash
+openclaw config set tools.profile full
+openclaw config get tools.profile
+```
+
+## Gateway not picking up config/workspace changes
+
+Config and workspace changes require a gateway restart:
+
+```bash
+supervisorctl -s http://127.0.0.1:29011 restart openclaw-gateway
+```
+
+## Tailscale not connecting
+
+```bash
+# Check auth key exists
+grep TAILSCALE /root/.zo_secrets
+
+# Check error logs
+tail -50 /dev/shm/tailscale_err.log
+
+# Check status
+tailscale status
+```
+
+## Container reprovision wiped something
+
+If Tailscale or the gateway stopped after a reprovision and services were registered via `register_user_service`, they should auto-recover. If not, re-run the install and bootstrap scripts.
+
+If services were registered manually (raw supervisord edits), they're gone. Re-run the full skill.
+
+## Port conflict on 18789
+
+```bash
+pkill -f 'openclaw gateway'
+sleep 2
+supervisorctl -s http://127.0.0.1:29011 restart openclaw-gateway
+```
+
+## Gateway crashes and stays offline
+
+Check logs:
+
+```bash
+tail -50 /dev/shm/openclaw-gateway.log
+tail -50 /dev/shm/openclaw-gateway_err.log
+```
+
+If registered via `register_user_service`, it should auto-restart. If it keeps crashing, check the config:
+
+```bash
+cat ~/.openclaw/openclaw.json | jq '.gateway'
+```
+
+## Tailscale hostname not resolving
+
+Enable MagicDNS on your tailnet: https://login.tailscale.com/admin/dns
+
+## Control UI error: "requires device identity (use HTTPS or localhost secure context)"
+
+This error means the browser reached the gateway without a secure trusted context.
+
+Common causes:
+
+- Using non-HTTPS URL (for example `http://<tailscale-ip>:18789`)
+- Using the wrong proxy URL/domain
+- Tailscale Serve not enabled for the node
+- Tailscale Serve pointing to the wrong local port (for example `127.0.0.1:3000` instead of `127.0.0.1:18789`)
+- Device not paired yet
+
+Check and fix:
+
+```bash
+# 1) Confirm Tailscale is running
+tailscale status --json | jq -r '.BackendState, .Self.DNSName, .Self.ID'
+
+# 2) Confirm Serve is enabled/configured for HTTPS and port 18789
+tailscale serve status --json | jq .
+
+# 3) If needed, reset and re-publish the gateway
+tailscale serve reset
+tailscale serve --bg --yes 18789
+tailscale serve status --json | jq .
+
+# 4) Provision cert (should succeed when Serve/TLS is allowed)
+TS_HOST=$(tailscale status --json | jq -r '.Self.DNSName' | sed 's/\.$//')
+tailscale cert "$TS_HOST"
+
+# 5) Pair pending devices if UI says "pairing required"
+openclaw devices list
+openclaw devices approve <request-id>
+```
+
+Use ONLY this URL in browser:
+
+`https://<tailscale-hostname>`
+
+Do NOT use:
+
+- `http://<tailscale-ip>:18789`
+- any non-HTTPS host/proxy URL
+
+If Telegram pairing is requested, approve with:
+
+```bash
+openclaw pairing approve telegram <PAIRING_CODE>
+```
+
+## Telegram group messages are silently dropped
+
+Symptom:
+
+Doctor warning shows:
+
+`channels.telegram.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty`
+
+Impact:
+
+- Direct messages can work
+- Group messages are silently ignored
+
+Fix options:
+
+1. Add sender IDs to `channels.telegram.groupAllowFrom` (preferred for strict allowlists)
+2. Or set `channels.telegram.groupPolicy` to `open` if you want broad group access
+
+Then restart the gateway:
+
+```bash
+supervisorctl -s http://127.0.0.1:29011 restart openclaw-gateway
+```
+
+## `openclaw onboard` fails with validation error
+
+Symptom:
+
+Onboarding crashes during model validation, often with errors about unsupported config keys (e.g., `compat` key in models.json).
+
+Cause:
+
+OpenClaw's local model registry (`~/.openclaw/models.json` or the npm-installed models data) may contain provider entries with config keys that the current version's validator doesn't recognize.
+
+Fix:
+
+```bash
+# Find the models.json that onboarding uses
+find /root/.openclaw -name "models.json" 2>/dev/null
+find $(npm root -g)/openclaw -name "models.json" 2>/dev/null
+
+# Inspect the failing provider entry
+cat <path-to-models.json> | jq '.[] | select(.id == "<provider-id>")'
+
+# Remove the offending key (e.g., a bad "compat" block)
+TMPFILE=$(mktemp)
+jq 'map(if .id == "<provider-id>" then del(.compat) else . end)' <path-to-models.json> > "$TMPFILE" && mv "$TMPFILE" <path-to-models.json>
+```
+
+Then retry `openclaw onboard`. If it fails again on a different key, inspect and remove that key too. If the provider itself is broken, remove the entire entry and pick a different provider during onboarding.
+
+## mcporter: Zo tools not appearing in OpenClaw
+
+Symptom:
+
+After configuring mcporter with Zo's MCP endpoint, the OpenClaw agent can't use Zo tools, or `mcporter list` doesn't show the zo server.
+
+Check:
+
+```bash
+# Verify mcporter config
+mcporter config list
+
+# Test the connection directly
+mcporter call zo.web_search --args '{"query": "test", "time_range": "day"}'
+
+# Check if ZO_ACCESS_TOKEN is set
+grep ZO_ACCESS_TOKEN /root/.zo_secrets
+```
+
+Common causes:
+
+- **Token not saved:** The user needs to create an access token at Settings > Advanced > Access Tokens, then save it as `ZO_ACCESS_TOKEN` in Settings > Advanced > Secrets
+- **Token expired or invalid:** Zo access tokens created in Settings > Advanced should be long-lived, but verify the token is still valid
+- **Gateway not restarted:** After adding the mcporter config, restart the gateway: `supervisorctl -s http://127.0.0.1:29011 restart openclaw-gateway`
+- **mcporter not installed:** Verify with `which mcporter`. If missing, run `npm install -g mcporter@latest`
+
+## Workspace files exceed 20,000 chars
+
+OpenClaw loads all `.md` files from `/root/.openclaw/workspace/` into agent context at session start. If total size exceeds 20,000 characters, content gets silently truncated. Monitor:
+
+```bash
+total=0
+for f in /root/.openclaw/workspace/*.md; do
+  chars=$(wc -c < "$f")
+  printf "%6d chars  %s\n" "$chars" "$f"
+  total=$((total + chars))
+done
+echo "------"
+printf "%6d total (limit: 20,000)\n" "$total"
+```

--- a/Community/zopenclaw/scripts/bootstrap.sh
+++ b/Community/zopenclaw/scripts/bootstrap.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+set -euo pipefail
+
+CONFIG="$HOME/.openclaw/openclaw.json"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "ERROR: $CONFIG not found."
+  echo "Run 'openclaw onboard' in Zo's terminal first."
+  exit 1
+fi
+
+echo "=== zopenclaw bootstrap ==="
+echo ""
+
+# --- Phase 1: Fix tools.profile ---
+
+echo "--- Fixing tools.profile ---"
+openclaw config set tools.profile full
+PROFILE=$(openclaw config get tools.profile 2>/dev/null || echo "unknown")
+if [ "$PROFILE" = "full" ]; then
+  echo "[OK] tools.profile = full"
+else
+  echo "[WARN] tools.profile = $PROFILE (expected 'full')"
+  echo "       Trying direct config edit..."
+  TMPFILE=$(mktemp)
+  jq '.tools.profile = "full"' "$CONFIG" > "$TMPFILE" && mv "$TMPFILE" "$CONFIG"
+  echo "[OK] tools.profile patched directly"
+fi
+
+# --- Phase 2: Patch gateway config (WITHOUT trustedProxies) ---
+
+echo ""
+echo "--- Patching gateway config ---"
+
+TMPFILE=$(mktemp)
+jq '
+  .gateway.bind = "loopback"
+  | .gateway.tailscale.mode = "serve"
+  | .gateway.tailscale.resetOnExit = false
+  | .gateway.auth.mode = "token"
+  | .gateway.auth.allowTailscale = true
+  | .gateway.controlUi.enabled = true
+  | .gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback = true
+  | del(.gateway.host, .gateway.tailscaleServe, .gateway.tokenAuth, .gateway.enableControlUI, .gateway.trustedProxies)
+' "$CONFIG" > "$TMPFILE" && mv "$TMPFILE" "$CONFIG"
+
+echo "[OK] gateway.bind = loopback"
+echo "[OK] gateway.tailscale.mode = serve"
+echo "[OK] gateway.auth.mode = token"
+echo "[OK] gateway.auth.allowTailscale = true"
+echo "[OK] gateway.controlUi.enabled = true"
+echo "[OK] gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback = true"
+echo "[OK] removed deprecated gateway keys and cleared trustedProxies for pairing"
+
+# --- Phase 3: Migrate gateway token to .zo_secrets ---
+
+SECRETS_FILE="/root/.zo_secrets"
+GW_TOKEN=$(jq -r '.gateway.auth.token // .gateway.token // empty' "$CONFIG")
+
+if [ -n "$GW_TOKEN" ]; then
+  if ! grep -q 'OPENCLAW_GATEWAY_TOKEN' "$SECRETS_FILE" 2>/dev/null; then
+    echo "export OPENCLAW_GATEWAY_TOKEN=\"$GW_TOKEN\"" >> "$SECRETS_FILE"
+    echo "[OK] Gateway token migrated to ~/.zo_secrets"
+  else
+    echo "[OK] Gateway token already in ~/.zo_secrets"
+  fi
+else
+  echo "[OK] No gateway token to migrate (will be set on first start)"
+fi
+
+# --- Phase 4: Stop existing gateway ---
+
+echo ""
+echo "--- Stopping existing gateway processes ---"
+supervisorctl -s http://127.0.0.1:29011 stop openclaw-gateway 2>/dev/null || true
+pkill -f 'openclaw gateway' 2>/dev/null || true
+sleep 2
+echo "[OK] Existing gateway processes stopped"
+
+# --- Phase 5: Pre-publish Tailscale Serve (best effort) ---
+
+echo ""
+echo "--- Preparing Tailscale Serve mapping ---"
+if tailscale serve reset >/dev/null 2>&1 && tailscale serve --bg --yes 18789 >/dev/null 2>&1; then
+  echo "[OK] Tailscale Serve published to local gateway port 18789"
+else
+  echo "[WARN] Could not publish Tailscale Serve automatically."
+  echo "       Enable Serve for this node in Tailscale admin, then run:"
+  echo "       tailscale serve reset"
+  echo "       tailscale serve --bg --yes 18789"
+fi
+
+echo ""
+echo "=== Bootstrap config complete ==="
+echo ""
+echo "NEXT STEPS (Zo handles these automatically):"
+echo "  1. Register gateway as Zo User Service"
+echo "  2. Poll for readiness until gateway responds"
+echo "  3. Run 'openclaw devices list' to pair local device"
+echo "  4. Add trustedProxies to config"
+echo "  5. Restart gateway"
+echo "  6. Confirm Tailscale Serve is active"

--- a/Community/zopenclaw/scripts/install.sh
+++ b/Community/zopenclaw/scripts/install.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "=== zopenclaw install ==="
+echo ""
+
+# --- Validate prerequisites ---
+
+if [ -z "${TAILSCALE_AUTHKEY:-}" ]; then
+  if [ -f /root/.zo_secrets ]; then
+    source /root/.zo_secrets
+  fi
+  if [ -z "${TAILSCALE_AUTHKEY:-}" ]; then
+    echo "ERROR: TAILSCALE_AUTHKEY not found in environment."
+    echo ""
+    echo "To fix:"
+    echo "  1. Go to https://login.tailscale.com/admin/settings/keys"
+    echo "  2. Create a reusable auth key"
+    echo "  3. Go to Zo Settings > Advanced"
+    echo "  4. Add secret: TAILSCALE_AUTHKEY = your key (starts with tskey-auth-)"
+    echo "  5. Re-run this script"
+    exit 1
+  fi
+fi
+
+echo "[OK] TAILSCALE_AUTHKEY found"
+
+# --- Install Tailscale binary ---
+
+if command -v tailscale &>/dev/null || test -x /usr/sbin/tailscaled; then
+  echo "[OK] Tailscale binary already installed"
+else
+  echo "     Installing Tailscale..."
+  curl -fsSL https://tailscale.com/install.sh | sh
+  echo "[OK] Tailscale installed"
+fi
+
+# --- Write Tailscale startup script ---
+
+cat > /usr/local/bin/start-tailscale.sh << 'TSEOF'
+#!/bin/bash
+set -e
+
+source /root/.zo_secrets
+
+TAILSCALE_STATE_DIR="/var/lib/tailscale"
+mkdir -p "$TAILSCALE_STATE_DIR"
+mkdir -p /var/run/tailscale
+
+tailscaled \
+  --tun=userspace-networking \
+  --state="$TAILSCALE_STATE_DIR/tailscaled.state" \
+  --socket=/var/run/tailscale/tailscaled.sock &
+DAEMON_PID=$!
+
+for i in $(seq 1 30); do
+  [ -S /var/run/tailscale/tailscaled.sock ] && break
+  sleep 1
+done
+
+tailscale up \
+  --authkey="$TAILSCALE_AUTHKEY" \
+  --hostname="zo-workspace" \
+  --accept-routes
+
+wait $DAEMON_PID
+TSEOF
+
+chmod 755 /usr/local/bin/start-tailscale.sh
+echo "[OK] Tailscale startup script written to /usr/local/bin/start-tailscale.sh"
+
+# --- Save auth key to .zo_secrets ---
+
+SECRETS_FILE="/root/.zo_secrets"
+touch "$SECRETS_FILE" && chmod 600 "$SECRETS_FILE"
+
+if ! grep -q 'TAILSCALE_AUTHKEY' "$SECRETS_FILE" 2>/dev/null; then
+  echo "export TAILSCALE_AUTHKEY=\"$TAILSCALE_AUTHKEY\"" >> "$SECRETS_FILE"
+  echo "[OK] Auth key saved to ~/.zo_secrets"
+else
+  echo "[OK] Auth key already in ~/.zo_secrets"
+fi
+
+if ! grep -q 'source /root/.zo_secrets' /root/.bashrc 2>/dev/null; then
+  echo 'source /root/.zo_secrets' >> /root/.bashrc
+fi
+
+# --- Install OpenClaw ---
+
+if command -v openclaw &>/dev/null; then
+  echo "[OK] OpenClaw already installed: $(openclaw --version)"
+else
+  echo "     Installing OpenClaw..."
+  npm install -g openclaw@latest
+  echo "[OK] OpenClaw installed: $(openclaw --version)"
+fi
+
+# --- Install mcporter ---
+
+if command -v mcporter &>/dev/null; then
+  echo "[OK] mcporter already installed: $(mcporter --version 2>/dev/null || echo 'unknown version')"
+else
+  echo "     Installing mcporter (MCP bridge for Zo tools)..."
+  npm install -g mcporter@latest
+  echo "[OK] mcporter installed"
+fi
+
+echo ""
+echo "=== Install complete ==="
+echo ""
+echo "NEXT STEPS:"
+echo "  1. Zo registers Tailscale as a Zo User Service (automatic)"
+echo "  2. Open Zo's terminal and run: openclaw onboard"
+echo "  3. Follow the prompts to pick your LLM provider and messaging channel"
+echo "  4. When done, tell Zo to run the bootstrap"

--- a/Community/zopenclaw/scripts/pairing-helper.sh
+++ b/Community/zopenclaw/scripts/pairing-helper.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  pairing-helper.sh list
+  pairing-helper.sh device <request-id>
+  pairing-helper.sh telegram <pairing-code>
+
+Commands:
+  list                 Show pending and paired devices.
+  device <request-id>  Approve a pending device pairing request.
+  telegram <code>      Approve a Telegram pairing code.
+EOF
+}
+
+if [ "${1:-}" = "" ]; then
+  usage
+  exit 1
+fi
+
+case "$1" in
+  list)
+    openclaw devices list
+    ;;
+  device)
+    if [ "${2:-}" = "" ]; then
+      echo "Missing request-id"
+      usage
+      exit 1
+    fi
+    openclaw devices approve "$2"
+    ;;
+  telegram)
+    if [ "${2:-}" = "" ]; then
+      echo "Missing pairing code"
+      usage
+      exit 1
+    fi
+    openclaw pairing approve telegram "$2"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/Community/zopenclaw/scripts/uninstall.sh
+++ b/Community/zopenclaw/scripts/uninstall.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "=== zopenclaw Uninstall ==="
+echo ""
+echo "This will stop and remove the OpenClaw gateway and Tailscale services."
+echo "OpenClaw config (~/.openclaw/) and Tailscale binaries are NOT removed."
+echo ""
+
+read -rp "Continue? [y/N] " confirm
+if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+  echo "Cancelled."
+  exit 0
+fi
+
+echo ""
+
+# --- Stop and remove gateway ---
+
+echo "--- Stopping OpenClaw gateway ---"
+supervisorctl -s http://127.0.0.1:29011 stop openclaw-gateway 2>/dev/null || true
+pkill -f 'openclaw gateway' 2>/dev/null || true
+echo "[OK] Gateway stopped"
+echo ""
+echo "NOTE: Zo should run delete_user_service for 'openclaw-gateway'"
+
+# --- Stop and remove Tailscale ---
+
+echo ""
+echo "--- Stopping Tailscale ---"
+supervisorctl -s http://127.0.0.1:29011 stop tailscale 2>/dev/null || true
+echo "[OK] Tailscale stopped"
+echo ""
+echo "NOTE: Zo should run delete_user_service for 'tailscale'"
+
+# --- Remove startup script ---
+
+rm -f /usr/local/bin/start-tailscale.sh
+echo "[OK] Removed /usr/local/bin/start-tailscale.sh"
+
+# --- Clean secrets ---
+
+sed -i '/TAILSCALE_AUTHKEY/d' /root/.zo_secrets 2>/dev/null || true
+sed -i '/OPENCLAW_GATEWAY_TOKEN/d' /root/.zo_secrets 2>/dev/null || true
+echo "[OK] Removed Tailscale and gateway secrets from ~/.zo_secrets"
+
+# --- Uninstall OpenClaw ---
+
+echo ""
+read -rp "Also uninstall OpenClaw (npm uninstall -g openclaw)? [y/N] " uninstall_oc
+if [[ "$uninstall_oc" =~ ^[Yy]$ ]]; then
+  npm uninstall -g openclaw 2>/dev/null || true
+  echo "[OK] OpenClaw uninstalled"
+else
+  echo "[OK] OpenClaw kept installed"
+fi
+
+echo ""
+echo "=== Uninstall complete ==="
+echo ""
+echo "What was NOT removed:"
+echo "  - ~/.openclaw/ (config + workspace)"
+echo "  - Tailscale binaries (/usr/bin/tailscale, /usr/sbin/tailscaled)"
+echo "  - Tailscale state (/var/lib/tailscale/)"
+echo ""
+echo "Zo still needs to run delete_user_service for both services."

--- a/Community/zopenclaw/scripts/verify.sh
+++ b/Community/zopenclaw/scripts/verify.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "=== zopenclaw Health Check ==="
+echo ""
+
+PASS=0
+FAIL=0
+
+check() {
+  local label="$1"
+  local cmd="$2"
+  if eval "$cmd" &>/dev/null; then
+    echo "[OK]   $label"
+    PASS=$((PASS + 1))
+  else
+    echo "[FAIL] $label"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check "OpenClaw installed" "openclaw --version"
+
+PROFILE=$(openclaw config get tools.profile 2>/dev/null || echo "unknown")
+if [ "$PROFILE" = "full" ]; then
+  echo "[OK]   tools.profile = full"
+  PASS=$((PASS + 1))
+else
+  echo "[FAIL] tools.profile = $PROFILE (should be 'full')"
+  FAIL=$((FAIL + 1))
+fi
+
+check "Tailscale connected" "tailscale status --json 2>/dev/null | jq -e '.BackendState == \"Running\"'"
+check "Tailscale service (supervisord)" "supervisorctl -s http://127.0.0.1:29011 status tailscale 2>/dev/null | grep RUNNING"
+check "Gateway service (supervisord)" "supervisorctl -s http://127.0.0.1:29011 status openclaw-gateway 2>/dev/null | grep RUNNING"
+check "Gateway RPC probe" "openclaw gateway status 2>&1 | grep -qE 'RPC probe: ok|Listening:'"
+check "Gateway Tailscale mode = serve" "jq -e '.gateway.tailscale.mode == \"serve\"' ~/.openclaw/openclaw.json"
+
+TS_HOST=$(tailscale status --json 2>/dev/null | jq -r '.Self.DNSName // empty' | sed 's/\.$//')
+if [ -n "$TS_HOST" ]; then
+  echo "[OK]   Tailscale hostname: $TS_HOST"
+  echo "       Control UI: https://$TS_HOST"
+  PASS=$((PASS + 1))
+else
+  echo "[FAIL] Could not resolve Tailscale hostname"
+  FAIL=$((FAIL + 1))
+fi
+
+check "Tailscale Serve HTTPS enabled (443)" "tailscale serve status --json 2>/dev/null | jq -e '.TCP[\"443\"].HTTPS == true'"
+if [ -n "$TS_HOST" ]; then
+  if tailscale serve status --json 2>/dev/null | jq -e --arg host "$TS_HOST" '.Web[$host + ":443"].Handlers["/"].Proxy == "http://127.0.0.1:18789"' &>/dev/null; then
+    echo "[OK]   Tailscale Serve target = http://127.0.0.1:18789"
+    PASS=$((PASS + 1))
+  else
+    echo "[FAIL] Tailscale Serve target is not http://127.0.0.1:18789"
+    FAIL=$((FAIL + 1))
+  fi
+fi
+
+if jq -e '.gateway.trustedProxies' ~/.openclaw/openclaw.json &>/dev/null; then
+  echo "[OK]   trustedProxies configured"
+  PASS=$((PASS + 1))
+else
+  echo "[FAIL] trustedProxies not set in config"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Community skill that installs and runs [OpenClaw](https://openclaw.ai/) on Zo Computer with:

- Tailscale private networking for secure Control UI access
- Reprovision-safe service registration via `register_user_service`
- Two-phase gateway bootstrap with device pairing
- Zo MCP tools bridged into OpenClaw via mcporter
- Full troubleshooting and architecture references

Includes install, bootstrap, verify, pairing-helper, and uninstall scripts.

**Author:** skeletorjs