### PR TITLE
Add zo-local-backup community skill

### DIFF
--- a/Community/zo-local-backup/SKILL.md
+++ b/Community/zo-local-backup/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: zo-local-backup
+description: Backup and restore your entire Zo Computer to a single encrypted archive (.enc). Includes workspace files, zo.space routes/assets, agents, rules, personas, services, and secrets. Use when the user wants a simple downloadable backup or wants to restore from one.
+compatibility: Created for Zo Computer
+metadata:
+  author: davidj.zo.computer
+---
+# Zo Local Backup
+
+Creates a single encrypted `.enc` file containing your entire Zo — workspace files, zo.space routes, agents, rules, personas, services, and secrets. Encrypted with AES-256-CBC (PBKDF2, 600k iterations) via openssl.
+
+## Backup Workflow
+
+1. **Ask the user for a passphrase** (they'll need it to restore).
+
+2. **Export Zo configurations** to a temp staging directory:
+
+   ```bash
+   export ZO_CONFIG_DIR=$(mktemp -d /tmp/zo-config-XXXX)
+   ```
+
+   Use MCP tools to collect and save each config category. **Collect agents, rules, personas, and services in parallel** since they are independent calls.
+
+   - **Routes**: Read route source files directly from the Zo filesystem instead of calling `get_space_route()` for each route (which is extremely slow for 100+ routes and truncates large files). Use a Python script via `run_bash_command`:
+     1. Call `list_space_routes()` to get the list of all routes with their path, route_type, and public status.
+     2. Read route source code from `/__substrate/space/routes/pages/*.tsx` and `/__substrate/space/routes/api/*.ts`. Filename conventions:
+        - **Pages**: strip leading `/`, replace `/` with `-`, add `.tsx`. Special case: `/` → `_home.tsx`.
+          - `/about` → `about.tsx`
+          - `/blog/posts/hello` → `blog-posts-hello.tsx`
+        - **APIs**: strip leading `/`, replace `/` with `-` (**keep the `api-` prefix**), add `.ts`.
+          - `/api/hello` → `api-hello.ts`
+          - `/api/users/list` → `api-users-list.ts`
+          - `/api/admin/settings` → `api-admin-settings.ts`
+        - **Dynamic params**: `:` is kept literally → `/api/posts/:id` → `api-posts-:id.ts`
+        - **Wildcards**: `*` is kept literally → `/api/files/*` → `api-files-*.ts`
+     3. Write a Python script that reads all files and saves the combined list (with path, route_type, public, code) to `$ZO_CONFIG_DIR/routes.json`. The recommended approach is to glob all files from both directories, then match each against the route list — rather than building filenames manually for each route path.
+   - **Assets**: Call `list_space_assets()`. Save to `$ZO_CONFIG_DIR/assets.json`. Download asset files using a **Python script** (not shell curl/mkdir — those commands are unavailable in the Zo zsh environment). Use `urllib.request` with `concurrent.futures.ThreadPoolExecutor` (20 workers) to download from `http://localhost:3099/ASSET_PATH` into `$ZO_CONFIG_DIR/asset-files/`, preserving directory structure.
+   - **Agents**: Call `list_agents()`. Save to `$ZO_CONFIG_DIR/agents.json`.
+   - **Rules**: Call `list_rules()`. Save to `$ZO_CONFIG_DIR/rules.json`.
+   - **Personas**: Call `list_personas()`. Save to `$ZO_CONFIG_DIR/personas.json`.
+   - **Services**: Call `list_user_services()`. Save to `$ZO_CONFIG_DIR/services.json`.
+   - **Secrets/env vars**: Run `env | grep -v '^_=' | sort` and save output to `$ZO_CONFIG_DIR/env_vars.txt`. Warn the user that secret values are included in the backup and the passphrase protects them.
+
+   > **Important notes:**
+   > - Do NOT use `get_space_route()` in a loop — it's too slow for many routes and truncates large ones. Read from the filesystem instead.
+   > - Do NOT use shell commands like `curl`, `mkdir`, `dirname` for asset downloads — they are not available in the Zo zsh shell. Use Python (`urllib.request`) instead.
+   > - Save MCP tool results (agents, rules, etc.) to JSON files using `run_bash_command` with a Python one-liner or heredoc, since the results come back as structured data.
+   > - API route filenames keep the `api-` prefix — do NOT strip it. The full URL path `/api/foo/bar` becomes `api-foo-bar.ts`.
+
+3. **Run the backup script**:
+
+   ```bash
+   python3 scripts/backup.py backup \
+     --passphrase "USER_PASSPHRASE" \
+     --config-dir "$ZO_CONFIG_DIR"
+   ```
+
+4. **Clean up** the temp config dir:
+   ```bash
+   rm -rf $ZO_CONFIG_DIR
+   ```
+
+5. **Report** the output file path and size. The file is at `/home/workspace/zo-backup-DATE.enc`. Tell the user they can download it from their workspace.
+
+## Restore Workflow
+
+### Step 1: Setup
+
+1. **Ask the user** for the passphrase and confirm which backup file to restore from.
+
+2. **List backup contents** to show what's available:
+   ```bash
+   python3 scripts/backup.py restore \
+     --passphrase "USER_PASSPHRASE" \
+     --archive /home/workspace/zo-backup-XXXX.enc \
+     --list-only
+   ```
+
+3. **Present the restore menu.** Show the user which categories are available and let them choose what to restore. Present it like this:
+
+   > **Your backup contains:**
+   > 1. **Workspace files** — X files (Y new, Z conflicts)
+   > 2. **zo.space routes & assets** — N routes, M assets
+   > 3. **Agents** — N agents
+   > 4. **Rules** — N rules
+   > 5. **Personas** — N personas
+   > 6. **Services** — N services
+   > 7. **Secrets/env vars** — N variables
+   >
+   > Which would you like to restore? (e.g. "all", "1 and 2", "just agents and rules", "everything except secrets")
+
+4. **Extract the backup** to a temp directory:
+   ```bash
+   export ZO_RESTORE_DIR=$(mktemp -d /tmp/zo-restore-XXXX)
+   python3 scripts/backup.py restore \
+     --passphrase "USER_PASSPHRASE" \
+     --archive /home/workspace/zo-backup-XXXX.enc \
+     --extract-to "$ZO_RESTORE_DIR"
+   ```
+
+### Step 2: Restore selected categories
+
+Only restore the categories the user selected. Each category is independent — skip any the user didn't ask for.
+
+#### Category 1: Workspace files
+
+1. **Analyze conflicts**:
+   ```bash
+   python3 scripts/backup.py restore \
+     --passphrase "USER_PASSPHRASE" \
+     --archive /home/workspace/zo-backup-XXXX.enc \
+     --extract-to "$ZO_RESTORE_DIR" \
+     --diff
+   ```
+   Show the user the conflict summary. Ask which files to overwrite.
+
+2. **Apply files**:
+   - Copy new files (no conflicts):
+     ```bash
+     python3 scripts/backup.py restore \
+       --passphrase "PASS" --archive FILE --extract-to "$ZO_RESTORE_DIR" --copy-new
+     ```
+   - Overwrite specific conflicting files the user approved:
+     ```bash
+     python3 scripts/backup.py restore \
+       --passphrase "PASS" --archive FILE --extract-to "$ZO_RESTORE_DIR" \
+       --copy-files '["path/to/file1.txt", "path/to/file2.txt"]'
+     ```
+
+#### Category 2: zo.space routes & assets
+
+- **Assets**: Simply copy the asset files directly to `/__substrate/space/assets/` using `cp -r` or Python's shutil. This is much faster than individual `update_space_asset` tool calls:
+  ```bash
+  cp -r "$ZO_RESTORE_DIR/zo-config/asset-files/"* /__substrate/space/assets/
+  ```
+  Or in Python:
+  ```python
+  import shutil
+  shutil.copytree(src_dir, dest_dir, dirs_exist_ok=True)
+  ```
+  This works because assets are served directly from the filesystem — no database update needed.
+
+- **Routes**: read_file `$ZO_RESTORE_DIR/zo-config/routes.json`. For each route, call `update_space_route(path, route_type, code)` to recreate it. Ask user before overwriting existing routes.
+
+#### Category 3: Agents
+
+Read `$ZO_RESTORE_DIR/zo-config/agents.json`. Show the user the list and recreate them with `create_agent()`. If agents with the same name already exist, ask before overwriting.
+
+#### Category 4: Rules
+
+Read `$ZO_RESTORE_DIR/zo-config/rules.json`. Show the user the list and recreate with `create_rule()`. If rules with the same name already exist, ask before overwriting.
+
+#### Category 5: Personas
+
+Read `$ZO_RESTORE_DIR/zo-config/personas.json`. Show the user the list and recreate with `create_persona()`. If personas with the same name already exist, ask before overwriting.
+
+#### Category 6: Services
+
+Read `$ZO_RESTORE_DIR/zo-config/services.json`. Show the user the list and recreate with `register_user_service()`. If services with the same name already exist, ask before overwriting.
+
+#### Category 7: Secrets/env vars
+
+Read `$ZO_RESTORE_DIR/zo-config/env_vars.txt`. Show the user the env var names (but NOT values) that were backed up. Tell the user to manually re-add any secrets they need via [Settings > Advanced](/?t=settings&s=advanced), since secrets cannot be set programmatically.
+
+### Step 3: Clean up
+
+```bash
+rm -rf $ZO_RESTORE_DIR
+```
+
+Report a summary of what was restored and what was skipped.
+
+## Decryption Without Zo
+
+The backup can be decrypted on any machine with openssl:
+```bash
+openssl enc -d -aes-256-cbc -salt -pbkdf2 -iter 600000 \
+  -in zo-backup-XXXX.enc -out backup.zip -pass pass:YOUR_PASSPHRASE
+unzip backup.zip
+```
+
+## Known Issues & Tips
+
+- **API filename convention**: API route files keep the `api-` prefix. `/api/hello` → `api-hello.ts`, NOT `hello.ts`.
+- **Special characters in filenames**: Dynamic params (`:id`) and wildcards (`*`) are kept literally in filenames. Don't escape or transform them.
+- **Use a glob-first approach for routes**: Glob `/__substrate/space/routes/pages/*.tsx` and `routes/api/*.ts` to find all files, then match against `list_space_routes()` — rather than building filenames manually per route.
+- **Parallel collection**: Agents, rules, personas, and services can all be collected in a single parallel batch. Routes and assets require filesystem/HTTP access and are better handled via Python scripts.
+- **Assets are just files**: Assets live in `/__substrate/space/assets/` and are served directly. Copy files to restore — no API calls needed.
+- **Assets must also go in `dist/`**: The server serves from `/__substrate/space/dist/`. After copying assets, also copy them to `dist/`. Note that `bun run build` clears `dist/`, so copy assets *after* building.
+- **Regenerate `.routes.json` after filesystem writes**: Direct file writes can leave the route database stale or corrupted. Regenerate it by globbing all route files and writing complete entries with all fields (path, route_type, public, code).
+- **Homepage special case**: The `/` route must exist as `routes/pages/index.tsx` AND be mapped in `.routes.json` with path `"/"`.
+- **Verify after restore**: Test routes with `curl http://localhost:3099/PATH` and check `list_space_routes()` to confirm everything appears. Rebuild and restart if needed.
+
+## Script Reference
+
+```
+python3 scripts/backup.py --help
+python3 scripts/backup.py backup --help
+python3 scripts/backup.py restore --help
+```

--- a/Community/zo-local-backup/scripts/backup.py
+++ b/Community/zo-local-backup/scripts/backup.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""zo-local-backup: Backup and restore your Zo Computer to an encrypted archive.
+
+Usage:
+  backup.py backup --passphrase PASS [--config-dir DIR] [--output FILE]
+  backup.py restore --passphrase PASS --archive FILE --list-only
+  backup.py restore --passphrase PASS --archive FILE --extract-to DIR
+  backup.py restore --passphrase PASS --archive FILE --extract-to DIR --diff
+  backup.py restore --passphrase PASS --archive FILE --prepare-assets DIR
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import zipfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from datetime import datetime, timezone
+from urllib.request import Request, urlopen
+from urllib.error import URLError
+
+WORKSPACE = Path("/home/workspace")
+SPACE_API_BASE = "http://localhost:3099"
+
+EXCLUDE_DIRS = {
+    "node_modules", ".git", "Trash", "__pycache__", ".cache",
+    ".next", ".nuxt", ".venv", "venv", ".trunk", ".tox",
+    "bower_components", ".parcel-cache", ".turbo",
+}
+
+EXCLUDE_FILES = {".DS_Store", "Thumbs.db"}
+
+EXCLUDE_EXTENSIONS = {".pyc", ".pyo"}
+
+EXCLUDE_PATTERNS = {"zo-backup-*.enc"}
+
+MAX_FILE_SIZE = 100 * 1024 * 1024  # skip files > 100 MB
+
+
+def should_exclude(path: Path) -> bool:
+    parts = path.relative_to(WORKSPACE).parts
+    for part in parts:
+        if part in EXCLUDE_DIRS:
+            return True
+    if path.name in EXCLUDE_FILES:
+        return True
+    if path.suffix in EXCLUDE_EXTENSIONS:
+        return True
+    if path.name.startswith("zo-backup-") and path.name.endswith(".enc"):
+        return True
+    try:
+        if path.is_symlink():
+            return True
+        if path.stat().st_size > MAX_FILE_SIZE:
+            return True
+    except OSError:
+        return True
+    return False
+
+
+def collect_workspace_files():
+    for root, dirs, files in os.walk(WORKSPACE):
+        dirs[:] = sorted(d for d in dirs if d not in EXCLUDE_DIRS)
+        for f in sorted(files):
+            fp = Path(root) / f
+            if not should_exclude(fp):
+                yield fp
+
+
+def create_backup_zip(zip_path: str, config_dir: str = None):
+    count = 0
+    total_size = 0
+
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        print("Collecting workspace files...")
+        for fp in collect_workspace_files():
+            try:
+                rel = fp.relative_to(WORKSPACE)
+                arcname = f"workspace/{rel}"
+                zf.write(fp, arcname)
+                fsize = fp.stat().st_size
+                count += 1
+                total_size += fsize
+                if count % 1000 == 0:
+                    print(f"  {count} files ({total_size / 1024 / 1024:.1f} MB)...")
+            except (OSError, PermissionError) as e:
+                print(f"  Warning: skipping {fp}: {e}", file=sys.stderr)
+
+        if config_dir and Path(config_dir).exists():
+            print("Adding Zo configurations...")
+            for fp in sorted(Path(config_dir).rglob("*")):
+                if fp.is_file():
+                    arcname = f"zo-config/{fp.relative_to(config_dir)}"
+                    zf.write(fp, arcname)
+
+        manifest = {
+            "version": 1,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "file_count": count,
+            "total_size_bytes": total_size,
+            "excludes": sorted(EXCLUDE_DIRS),
+        }
+        zf.writestr("manifest.json", json.dumps(manifest, indent=2))
+
+    print(f"Zip created: {count} files, {total_size / 1024 / 1024:.1f} MB uncompressed")
+    return count, total_size
+
+
+def encrypt_file(input_path: str, output_path: str, passphrase: str):
+    result = subprocess.run(
+        [
+            "openssl", "enc", "-aes-256-cbc", "-salt", "-pbkdf2",
+            "-iter", "600000", "-in", input_path, "-out", output_path,
+            "-pass", f"pass:{passphrase}",
+        ],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Encryption failed: {result.stderr.strip()}")
+
+
+def decrypt_file(input_path: str, output_path: str, passphrase: str):
+    result = subprocess.run(
+        [
+            "openssl", "enc", "-d", "-aes-256-cbc", "-salt", "-pbkdf2",
+            "-iter", "600000", "-in", input_path, "-out", output_path,
+            "-pass", f"pass:{passphrase}",
+        ],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Decryption failed (wrong passphrase?): {result.stderr.strip()}")
+
+
+def cmd_backup(args):
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H%M")
+    output = args.output or str(WORKSPACE / f"zo-backup-{timestamp}.enc")
+
+    with tempfile.TemporaryDirectory(prefix="zo-backup-") as tmpdir:
+        zip_path = os.path.join(tmpdir, "backup.zip")
+        create_backup_zip(zip_path, args.config_dir)
+
+        zip_size = os.path.getsize(zip_path)
+        print(f"Compressed zip size: {zip_size / 1024 / 1024:.1f} MB")
+        print("Encrypting with AES-256-CBC (PBKDF2, 600k iterations)...")
+
+        encrypt_file(zip_path, output, args.passphrase)
+        enc_size = os.path.getsize(output)
+
+    print(f"\nBackup complete: {output}")
+    print(f"Encrypted size: {enc_size / 1024 / 1024:.1f} MB")
+    return output
+
+
+def cmd_restore_list(args):
+    with tempfile.TemporaryDirectory(prefix="zo-restore-") as tmpdir:
+        zip_path = os.path.join(tmpdir, "backup.zip")
+        print("Decrypting...")
+        decrypt_file(args.archive, zip_path, args.passphrase)
+
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            try:
+                manifest = json.loads(zf.read("manifest.json"))
+                print(f"\n{'='*50}")
+                print(f"Backup created: {manifest.get('created_at', 'unknown')}")
+                print(f"Version: {manifest.get('version', '?')}")
+                print(f"Files: {manifest.get('file_count', '?')}")
+                print(f"Original size: {manifest.get('total_size_bytes', 0) / 1024 / 1024:.1f} MB")
+                print(f"{'='*50}")
+            except KeyError:
+                pass
+
+            categories = {}
+            for info in zf.infolist():
+                if info.filename == "manifest.json":
+                    continue
+                cat = info.filename.split("/")[0]
+                categories.setdefault(cat, []).append(info)
+
+            for cat, items in sorted(categories.items()):
+                total_cat_size = sum(i.file_size for i in items)
+                print(f"\n[{cat}] — {len(items)} items, {total_cat_size / 1024 / 1024:.1f} MB")
+                for item in items[:30]:
+                    display = "/".join(item.filename.split("/")[1:])
+                    print(f"  {display} ({item.file_size:,} bytes)")
+                if len(items) > 30:
+                    print(f"  ... and {len(items) - 30} more")
+
+
+def cmd_restore_extract(args):
+    extract_to = args.extract_to
+    os.makedirs(extract_to, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="zo-restore-") as tmpdir:
+        zip_path = os.path.join(tmpdir, "backup.zip")
+        print("Decrypting...")
+        decrypt_file(args.archive, zip_path, args.passphrase)
+
+        print(f"Extracting to {extract_to}...")
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            zf.extractall(extract_to)
+
+    print("Extraction complete.")
+
+
+def cmd_restore_diff(args):
+    extract_to = args.extract_to
+    source = Path(extract_to) / "workspace"
+    if not source.exists():
+        print("ERROR: No workspace directory found. Run with --extract-to first.", file=sys.stderr)
+        sys.exit(1)
+
+    conflicts = []
+    new_files = []
+    unchanged = 0
+
+    for fp in sorted(source.rglob("*")):
+        if not fp.is_file():
+            continue
+        rel = fp.relative_to(source)
+        dest = WORKSPACE / rel
+
+        if dest.exists():
+            try:
+                if fp.read_bytes() == dest.read_bytes():
+                    unchanged += 1
+                else:
+                    conflicts.append(str(rel))
+            except OSError:
+                conflicts.append(str(rel))
+        else:
+            new_files.append(str(rel))
+
+    zo_config = Path(extract_to) / "zo-config"
+    config_items = {}
+    if zo_config.exists():
+        for fp in sorted(zo_config.rglob("*.json")):
+            name = fp.stem
+            try:
+                data = json.loads(fp.read_text())
+                if isinstance(data, list):
+                    config_items[name] = len(data)
+                elif isinstance(data, dict):
+                    config_items[name] = len(data.get("items", data.get("data", [data])))
+                else:
+                    config_items[name] = 1
+            except (json.JSONDecodeError, OSError):
+                config_items[name] = "?"
+
+    result = {
+        "workspace": {
+            "new_files": len(new_files),
+            "conflicts": len(conflicts),
+            "unchanged": unchanged,
+            "conflict_list": conflicts[:100],
+            "new_file_list": new_files[:100],
+            "has_more_conflicts": len(conflicts) > 100,
+            "has_more_new_files": len(new_files) > 100,
+        },
+        "zo_config": config_items,
+    }
+    print(json.dumps(result, indent=2))
+
+
+def copy_new_files(extract_to: str):
+    source = Path(extract_to) / "workspace"
+    if not source.exists():
+        return
+    copied = 0
+    for fp in sorted(source.rglob("*")):
+        if not fp.is_file():
+            continue
+        rel = fp.relative_to(source)
+        dest = WORKSPACE / rel
+        if not dest.exists():
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(fp.read_bytes())
+            copied += 1
+    print(f"Copied {copied} new files.")
+
+
+def copy_specific_files(extract_to: str, file_list_json: str):
+    source = Path(extract_to) / "workspace"
+    files = json.loads(file_list_json)
+    copied = 0
+    for rel_str in files:
+        src = source / rel_str
+        dest = WORKSPACE / rel_str
+        if src.exists():
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(src.read_bytes())
+            copied += 1
+    print(f"Overwrote {copied} files.")
+
+
+def cmd_restore_assets(args):
+    """Generate JSON of asset upload commands (helper for efficient restore)."""
+    extract_to = args.extract_to
+    asset_files_dir = Path(extract_to) / "zo-config" / "asset-files"
+    assets_file = Path(extract_to) / "zo-config" / "assets.json"
+    
+    if not assets_file.exists():
+        print(f"ERROR: {assets_file} not found", file=sys.stderr)
+        sys.exit(1)
+    
+    with open(assets_file) as f:
+        assets = json.load(f)
+    
+    # Get list of files that exist locally
+    existing_files = set()
+    if asset_files_dir.exists():
+        for fp in asset_files_dir.rglob("*"):
+            if fp.is_file():
+                rel = fp.relative_to(asset_files_dir)
+                existing_files.add("/" + str(rel).replace(os.sep, "/"))
+    
+    # Generate tool calls
+    calls = []
+    for a in assets:
+        asset_path = a.get("path", a.get("asset_path", ""))
+        if asset_path in existing_files:
+            rel_path = asset_path.lstrip("/")
+            local_file = str(asset_files_dir / rel_path)
+            calls.append({
+                "tool": "update_space_asset",
+                "params": {
+                    "source_file": local_file,
+                    "asset_path": asset_path
+                }
+            })
+    
+    output = json.dumps(calls, indent=2)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(output)
+        print(f"Generated {len(calls)} asset upload commands → {args.output}")
+    else:
+        print(output)
+    
+    return len(calls)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Zo Local Backup — backup and restore your Zo Computer"
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    bp = sub.add_parser("backup", help="Create an encrypted backup")
+    bp.add_argument("--passphrase", required=True)
+    bp.add_argument("--config-dir", help="Directory containing exported zo config JSONs")
+    bp.add_argument("--output", help="Output file path (default: workspace/zo-backup-DATE.enc)")
+
+    rp = sub.add_parser("restore", help="Restore from an encrypted backup")
+    rp.add_argument("--passphrase", required=True)
+    rp.add_argument("--archive", required=True, help="Path to .enc backup file")
+    rp.add_argument("--list-only", action="store_true", help="List backup contents without extracting")
+    rp.add_argument("--extract-to", help="Extract backup to this directory")
+    rp.add_argument("--diff", action="store_true", help="Show merge analysis (requires prior --extract-to)")
+    rp.add_argument("--copy-new", action="store_true", help="Copy only new files (no conflicts)")
+    rp.add_argument("--copy-files", help="JSON array of relative paths to overwrite")
+    rp.add_argument("--prepare-assets", metavar="DIR", help="Generate JSON of asset upload commands (helper for efficient restore)")
+    rp.add_argument("--output", "-o", help="Output file for --prepare-assets")
+
+    args = parser.parse_args()
+
+    if args.command == "backup":
+        cmd_backup(args)
+    elif args.command == "restore":
+        if args.list_only:
+            cmd_restore_list(args)
+        elif args.copy_new:
+            if not args.extract_to:
+                print("--extract-to required with --copy-new", file=sys.stderr)
+                sys.exit(1)
+            copy_new_files(args.extract_to)
+        elif args.copy_files:
+            if not args.extract_to:
+                print("--extract-to required with --copy-files", file=sys.stderr)
+                sys.exit(1)
+            copy_specific_files(args.extract_to, args.copy_files)
+        elif args.diff:
+            if not args.extract_to:
+                print("--extract-to required with --diff", file=sys.stderr)
+                sys.exit(1)
+            cmd_restore_diff(args)
+        elif args.prepare_assets:
+            args.extract_to = args.prepare_assets
+            cmd_restore_assets(args)
+        elif args.extract_to:
+            cmd_restore_extract(args)
+        else:
+            print("Specify --list-only, --extract-to DIR, --diff, --copy-new, or --copy-files", file=sys.stderr)
+            sys.exit(1)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Community/zo-openclaw-backup/SKILL.md
+++ b/Community/zo-openclaw-backup/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: zo-openclaw-backup
+description: Backup and restore a local OpenClaw instance running on your Zo Computer. Wraps `openclaw backup` CLI with optional AES-256-CBC encryption. Use when the user wants to back up or restore their OpenClaw state, config, credentials, and workspaces.
+compatibility: Created for Zo Computer
+metadata:
+  author: davidj.zo.computer
+---
+# Zo OpenClaw Backup
+
+Creates a backup of your local OpenClaw instance using the `openclaw backup` CLI, with optional passphrase encryption (AES-256-CBC, PBKDF2 600k iterations).
+
+## Prerequisites
+
+- OpenClaw must be installed and available on `$PATH`. Run `openclaw --version` to verify.
+- If not installed, direct the user to https://docs.openclaw.ai/install
+
+## Backup Workflow
+
+1. **Check OpenClaw is installed**:
+   ```bash
+   openclaw --version
+   ```
+   If not found, stop and tell the user to install it first.
+
+2. **Ask the user**:
+   - Whether to include workspaces (default: yes)
+   - Whether to encrypt with a passphrase (recommended)
+   - Output location (default: `/home/workspace/`)
+
+3. **Run the backup**:
+   ```bash
+   python3 scripts/backup.py backup \
+     [--passphrase "PASSPHRASE"] \
+     [--no-include-workspace] \
+     [--only-config] \
+     [--verify] \
+     [--output /path/to/output/]
+   ```
+
+   The script will:
+   - Call `openclaw backup create` with the appropriate flags
+   - Verify the archive if `--verify` is passed
+   - Optionally encrypt the `.tar.gz` to a `.tar.gz.enc` file
+   - Clean up the unencrypted archive after encryption
+   - Report the final file path and size
+
+4. **Report** the output file path and size. Tell the user they can download it from their workspace.
+
+## Restore Workflow
+
+1. **Ask the user** for the backup file path and passphrase (if encrypted).
+
+2. **Decrypt** (if encrypted):
+   ```bash
+   python3 scripts/backup.py restore \
+     --archive /path/to/backup.tar.gz.enc \
+     --passphrase "PASSPHRASE" \
+     --list-only
+   ```
+
+3. **Show contents** and let the user confirm they want to restore.
+
+4. **Extract and restore**:
+   ```bash
+   python3 scripts/backup.py restore \
+     --archive /path/to/backup.tar.gz.enc \
+     --passphrase "PASSPHRASE" \
+     --extract-to /tmp/openclaw-restore-XXXX
+   ```
+
+   The script extracts the archive. The user can then use `openclaw` or manually place files back.
+
+5. **Clean up** the temp directory after restore.
+
+## Verify an Existing Backup
+
+```bash
+python3 scripts/backup.py verify \
+  --archive /path/to/backup.tar.gz \
+  [--passphrase "PASSPHRASE"]
+```
+
+If encrypted, the script decrypts to a temp file first, then runs `openclaw backup verify`.
+
+## Decryption Without Zo
+
+The encrypted backup can be decrypted on any machine with openssl:
+```bash
+openssl enc -d -aes-256-cbc -salt -pbkdf2 -iter 600000 \
+  -in openclaw-backup-XXXX.tar.gz.enc -out openclaw-backup.tar.gz \
+  -pass pass:YOUR_PASSPHRASE
+```
+
+Then extract normally:
+```bash
+tar xzf openclaw-backup.tar.gz
+```
+
+## What Gets Backed Up
+
+Per the OpenClaw docs (https://docs.openclaw.ai/cli/backup):
+- **State directory** (`~/.openclaw`) — sessions, memory, plugins, etc.
+- **Active config file** — the main OpenClaw configuration
+- **OAuth / credentials directory** — tokens and secrets
+- **Workspace directories** — discovered from config (unless `--no-include-workspace`)
+
+With `--only-config`, only the active config file is archived.
+
+## Script Reference
+
+```
+python3 scripts/backup.py --help
+python3 scripts/backup.py backup --help
+python3 scripts/backup.py restore --help
+python3 scripts/backup.py verify --help
+```

--- a/Community/zo-openclaw-backup/scripts/backup.py
+++ b/Community/zo-openclaw-backup/scripts/backup.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""zo-openclaw-backup: Backup and restore a local OpenClaw instance.
+
+Usage:
+  backup.py backup [--passphrase PASS] [--no-include-workspace] [--only-config] [--verify] [--output DIR]
+  backup.py restore --archive FILE [--passphrase PASS] --list-only
+  backup.py restore --archive FILE [--passphrase PASS] --extract-to DIR
+  backup.py verify --archive FILE [--passphrase PASS]
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+WORKSPACE = Path("/home/workspace")
+DEFAULT_OUTPUT_DIR = WORKSPACE
+
+
+def check_openclaw():
+    try:
+        result = subprocess.run(
+            ["openclaw", "--version"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0:
+            version = result.stdout.strip() or result.stderr.strip()
+            print(f"OpenClaw found: {version}")
+            return True
+    except FileNotFoundError:
+        pass
+    except subprocess.TimeoutExpired:
+        pass
+    print("ERROR: openclaw not found on PATH. Install from https://docs.openclaw.ai/install", file=sys.stderr)
+    return False
+
+
+def encrypt_file(input_path: str, output_path: str, passphrase: str):
+    result = subprocess.run(
+        [
+            "openssl", "enc", "-aes-256-cbc", "-salt", "-pbkdf2",
+            "-iter", "600000", "-in", input_path, "-out", output_path,
+            "-pass", f"pass:{passphrase}",
+        ],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Encryption failed: {result.stderr.strip()}")
+
+
+def decrypt_file(input_path: str, output_path: str, passphrase: str):
+    result = subprocess.run(
+        [
+            "openssl", "enc", "-d", "-aes-256-cbc", "-salt", "-pbkdf2",
+            "-iter", "600000", "-in", input_path, "-out", output_path,
+            "-pass", f"pass:{passphrase}",
+        ],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Decryption failed (wrong passphrase?): {result.stderr.strip()}")
+
+
+def is_encrypted(archive_path: str) -> bool:
+    return archive_path.endswith(".enc")
+
+
+def resolve_archive(archive_path: str, passphrase: str = None, tmpdir: str = None):
+    """If archive is encrypted, decrypt to tmpdir and return path to .tar.gz. Otherwise return as-is."""
+    if is_encrypted(archive_path):
+        if not passphrase:
+            print("ERROR: Encrypted archive requires --passphrase", file=sys.stderr)
+            sys.exit(1)
+        decrypted = os.path.join(tmpdir, "openclaw-backup.tar.gz")
+        print("Decrypting archive...")
+        decrypt_file(archive_path, decrypted, passphrase)
+        return decrypted
+    return archive_path
+
+
+def cmd_backup(args):
+    if not check_openclaw():
+        sys.exit(1)
+
+    output_dir = args.output or str(DEFAULT_OUTPUT_DIR)
+    os.makedirs(output_dir, exist_ok=True)
+
+    cmd = ["openclaw", "backup", "create", "--output", output_dir]
+
+    if args.no_include_workspace:
+        cmd.append("--no-include-workspace")
+    if args.only_config:
+        cmd.append("--only-config")
+    if args.verify:
+        cmd.append("--verify")
+
+    if args.dry_run:
+        cmd.extend(["--dry-run", "--json"])
+        print(f"Dry run: {' '.join(cmd)}")
+
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+
+    if result.returncode != 0:
+        print(f"ERROR: openclaw backup create failed (exit {result.returncode})", file=sys.stderr)
+        sys.exit(1)
+
+    # Find the created archive — openclaw writes a timestamped .tar.gz
+    tar_path = None
+    for line in (result.stdout + result.stderr).splitlines():
+        line = line.strip()
+        if line.endswith(".tar.gz") and os.path.isfile(line):
+            tar_path = line
+            break
+
+    if not tar_path:
+        # Fallback: find the most recent .tar.gz in output_dir
+        candidates = sorted(
+            Path(output_dir).glob("*-openclaw-backup.tar.gz"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        if candidates:
+            tar_path = str(candidates[0])
+
+    if not tar_path or not os.path.isfile(tar_path):
+        print("ERROR: Could not locate the created backup archive.", file=sys.stderr)
+        print("Check the output above for the archive path.", file=sys.stderr)
+        sys.exit(1)
+
+    tar_size = os.path.getsize(tar_path)
+    print(f"\nBackup archive: {tar_path}")
+    print(f"Archive size: {tar_size / 1024 / 1024:.1f} MB")
+
+    # Encrypt if passphrase provided
+    if args.passphrase:
+        enc_path = tar_path + ".enc"
+        print(f"Encrypting with AES-256-CBC (PBKDF2, 600k iterations)...")
+        encrypt_file(tar_path, enc_path, args.passphrase)
+
+        enc_size = os.path.getsize(enc_path)
+        os.remove(tar_path)
+        print(f"Encrypted backup: {enc_path}")
+        print(f"Encrypted size: {enc_size / 1024 / 1024:.1f} MB")
+        print(f"(Unencrypted archive removed)")
+        return enc_path
+    else:
+        print("\nNote: Backup is NOT encrypted. Use --passphrase to encrypt.")
+        return tar_path
+
+
+def cmd_restore_list(args):
+    with tempfile.TemporaryDirectory(prefix="oc-restore-") as tmpdir:
+        tar_path = resolve_archive(args.archive, args.passphrase, tmpdir)
+
+        print(f"\nArchive contents:")
+        result = subprocess.run(
+            ["tar", "tzf", tar_path],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            print(f"ERROR: Failed to list archive: {result.stderr.strip()}", file=sys.stderr)
+            sys.exit(1)
+
+        entries = result.stdout.strip().splitlines()
+        dirs = set()
+        files = []
+        total = 0
+        for entry in entries:
+            if entry.endswith("/"):
+                dirs.add(entry)
+            else:
+                files.append(entry)
+                total += 1
+
+        # Group by top-level directory
+        groups = {}
+        for f in files:
+            parts = f.split("/", 1)
+            top = parts[0] if len(parts) > 1 else "(root)"
+            groups.setdefault(top, []).append(f)
+
+        print(f"{'=' * 50}")
+        print(f"Total entries: {total} files in {len(dirs)} directories")
+        print(f"{'=' * 50}")
+
+        for group, items in sorted(groups.items()):
+            print(f"\n[{group}] — {len(items)} files")
+            for item in items[:20]:
+                print(f"  {item}")
+            if len(items) > 20:
+                print(f"  ... and {len(items) - 20} more")
+
+        # Check for manifest
+        if "manifest.json" in files:
+            print("\n✓ manifest.json found in archive")
+
+
+def cmd_restore_extract(args):
+    extract_to = args.extract_to
+    os.makedirs(extract_to, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="oc-restore-") as tmpdir:
+        tar_path = resolve_archive(args.archive, args.passphrase, tmpdir)
+
+        print(f"Extracting to {extract_to}...")
+        result = subprocess.run(
+            ["tar", "xzf", tar_path, "-C", extract_to],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            print(f"ERROR: Extraction failed: {result.stderr.strip()}", file=sys.stderr)
+            sys.exit(1)
+
+    print(f"Extraction complete: {extract_to}")
+
+    # Show what was extracted
+    for item in sorted(Path(extract_to).iterdir()):
+        if item.is_dir():
+            count = sum(1 for _ in item.rglob("*") if _.is_file())
+            print(f"  {item.name}/ — {count} files")
+        else:
+            print(f"  {item.name} — {item.stat().st_size:,} bytes")
+
+
+def cmd_verify(args):
+    with tempfile.TemporaryDirectory(prefix="oc-verify-") as tmpdir:
+        tar_path = resolve_archive(args.archive, args.passphrase, tmpdir)
+
+        # Use openclaw's built-in verify if available
+        if check_openclaw():
+            print(f"Running openclaw backup verify...")
+            result = subprocess.run(
+                ["openclaw", "backup", "verify", tar_path],
+                capture_output=True, text=True,
+            )
+            if result.stdout:
+                print(result.stdout)
+            if result.stderr:
+                print(result.stderr, file=sys.stderr)
+            if result.returncode == 0:
+                print("✓ Archive verification passed")
+            else:
+                print("✗ Archive verification failed", file=sys.stderr)
+                sys.exit(1)
+        else:
+            # Fallback: basic tar integrity check
+            print("OpenClaw not available, running basic tar integrity check...")
+            result = subprocess.run(
+                ["tar", "tzf", tar_path],
+                capture_output=True, text=True,
+            )
+            if result.returncode == 0:
+                count = len(result.stdout.strip().splitlines())
+                print(f"✓ Archive is valid ({count} entries)")
+            else:
+                print(f"✗ Archive is corrupt: {result.stderr.strip()}", file=sys.stderr)
+                sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Zo OpenClaw Backup — backup and restore your OpenClaw instance"
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    bp = sub.add_parser("backup", help="Create a backup of your OpenClaw instance")
+    bp.add_argument("--passphrase", help="Encrypt the backup with this passphrase (AES-256-CBC)")
+    bp.add_argument("--no-include-workspace", action="store_true", help="Skip workspace directories")
+    bp.add_argument("--only-config", action="store_true", help="Back up only the config file")
+    bp.add_argument("--verify", action="store_true", help="Verify the archive after creation")
+    bp.add_argument("--dry-run", action="store_true", help="Show what would be backed up without creating")
+    bp.add_argument("--output", help="Output directory (default: /home/workspace/)")
+
+    rp = sub.add_parser("restore", help="Restore from a backup archive")
+    rp.add_argument("--archive", required=True, help="Path to .tar.gz or .tar.gz.enc backup file")
+    rp.add_argument("--passphrase", help="Passphrase for encrypted archives")
+    rp.add_argument("--list-only", action="store_true", help="List archive contents without extracting")
+    rp.add_argument("--extract-to", help="Extract archive to this directory")
+
+    vp = sub.add_parser("verify", help="Verify a backup archive")
+    vp.add_argument("--archive", required=True, help="Path to .tar.gz or .tar.gz.enc backup file")
+    vp.add_argument("--passphrase", help="Passphrase for encrypted archives")
+
+    args = parser.parse_args()
+
+    if args.command == "backup":
+        cmd_backup(args)
+    elif args.command == "restore":
+        if args.list_only:
+            cmd_restore_list(args)
+        elif args.extract_to:
+            cmd_restore_extract(args)
+        else:
+            print("Specify --list-only or --extract-to DIR", file=sys.stderr)
+            sys.exit(1)
+    elif args.command == "verify":
+        cmd_verify(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## zo-local-backup

Encrypted backup & restore for your entire Zo Computer — workspace files, zo.space routes/assets, agents, rules, personas, services, and secrets.

### Features
- Single `.enc` archive with AES-256-CBC encryption (PBKDF2, 600k iterations)
- Backup and restore via Python CLI (`scripts/backup.py`)
- Selective restore — choose which categories to restore
- Decryptable on any machine with openssl (no Zo required)
- Parallel collection of independent config categories

### Contents
- `SKILL.md` — Full backup/restore workflow instructions
- `scripts/backup.py` — CLI for encryption, decryption, diffing, and selective file restore

### Validation
- `bun validate` passes with no new warnings