### PR TITLE
Add nod-shout skill: agent-native link curation

### DIFF
--- a/External/nod-intros/SKILL.md
+++ b/External/nod-intros/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: nod-intros
+description: Agent-brokered warm introductions with double opt-in consent. Your AI agent knows what you need and what you offer. When there's a match, both agents facilitate the intro.
+homepage: https://nodsocial.com
+metadata:
+  author: jeffweisbein
+  category: External
+  display-name: nod intros
+---
+
+# Notice
+
+Set `NOD_SUPABASE_KEY` in your environment before using this skill.
+Sign up at [nodsocial.com](https://nodsocial.com) to get your credentials.
+
+# nod intros 🤝
+
+Agent-brokered warm introductions. Your AI agent builds your profile from conversations — what you're working on, what you need, what you can offer. When there's a genuine match with someone else in the network, both agents facilitate a double opt-in intro.
+
+No cold DMs. No awkward LinkedIn messages. Both people say yes before anything happens.
+
+Site: [nodsocial.com](https://nodsocial.com)
+Repo: [github.com/jeffweisbein/nod-intros](https://github.com/jeffweisbein/nod-intros)
+
+## Configuration
+
+**Required env vars:**
+- `SUPABASE_URL` — nod supabase URL
+- `NOD_SUPABASE_KEY` — your nod API key
+
+## MCP Server
+
+```bash
+git clone https://github.com/jeffweisbein/nod-intros.git
+cd nod-intros
+npm install
+npm run build
+```
+
+Add to your MCP config:
+```json
+{
+  "mcpServers": {
+    "nod-intros": {
+      "command": "node",
+      "args": ["/path/to/nod-intros/dist/index.js"],
+      "env": {
+        "SUPABASE_URL": "https://ooykzbkcquvreeheaijy.supabase.co",
+        "NOD_SUPABASE_KEY": "your-key"
+      }
+    }
+  }
+}
+```
+
+## How It Works
+
+1. **Opt in** — your agent creates your profile
+2. **Add context** — projects, needs, offers, expertise
+3. **Search or get matched** — find people or wait for suggestions
+4. **Double opt-in** — both people must approve before any info is shared
+5. **Invisible decline** — if someone says no, the other person never knows
+
+## Tools
+
+### Profile
+| Tool | Description |
+|------|-------------|
+| `intros_opt_in` | Join the network (bio, frequency, contact method) |
+| `intros_update_profile` | Update preferences |
+| `intros_get_profile` | View your or another user's profile |
+| `intros_pause` | Temporarily pause without deleting |
+| `intros_forget` | Permanently delete everything |
+
+### Context
+| Tool | Description |
+|------|-------------|
+| `intros_add_project` | Add a current project |
+| `intros_remove_project` | Remove a project |
+| `intros_add_need` | Add something you need |
+| `intros_fulfill_need` | Mark a need as fulfilled |
+| `intros_add_offer` | Add something you can offer |
+| `intros_remove_offer` | Remove an offer |
+| `intros_add_expertise` | Add expertise or interest tags |
+
+### Matching
+| Tool | Description |
+|------|-------------|
+| `intros_search` | Search opted-in profiles by query |
+| `intros_suggest` | Create an intro suggestion (triggers consent flow) |
+
+### Consent
+| Tool | Description |
+|------|-------------|
+| `intros_respond` | Approve, decline, or defer a suggestion |
+| `intros_list_pending` | List pending intro suggestions |
+| `intros_get_match` | Get match details |
+
+### History
+| Tool | Description |
+|------|-------------|
+| `intros_rate` | Rate how an intro went |
+| `intros_history` | View past intros |
+
+## Privacy
+
+- Profiles only visible to other opted-in users
+- Declines are invisible to the other party
+- Blocklist prevents specific users from seeing you
+- Append-only consent audit trail
+- `intros_forget` permanently deletes all your data
+
+## When to use this skill
+
+- User says "i need to find someone who..." or "i'm looking for..."
+- User mentions a project they need help with
+- User wants to offer expertise or services
+- User asks "who should i talk to about..."
+- After learning about the user's work, proactively suggest searching for matches

--- a/External/nod-shout/SKILL.md
+++ b/External/nod-shout/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: nod-shout
+description: Save and curate links to a public shout page. Your AI agent captures articles, tools, and projects from conversations and publishes them automatically. No app needed.
+homepage: https://nodsocial.com
+metadata:
+  author: jeffweisbein
+  category: External
+  display-name: nod shout
+---
+
+# Notice
+
+Set `NOD_SHOUT_API_KEY` in your environment before using this skill.
+Get your API key at [nodsocial.com](https://nodsocial.com).
+
+# nod shout
+
+Turn links from your conversations into a curated public page. Your agent saves articles, tools, music, projects — whatever you share — and publishes them to your shout page automatically.
+
+Site: [nodsocial.com](https://nodsocial.com)
+
+## Configuration
+
+**Required env vars:**
+- `NOD_SHOUT_API_KEY` — your nod API key
+- `NOD_SHOUT_USER_ID` — your nod user ID
+
+**Base URL**: `https://ooykzbkcquvreeheaijy.supabase.co/rest/v1`
+
+## Quick Reference
+
+All requests use these headers:
+```bash
+AUTH_HEADERS="-H 'apikey: $NOD_SHOUT_API_KEY' -H 'Authorization: Bearer $NOD_SHOUT_API_KEY' -H 'Content-Type: application/json' -H 'Prefer: return=representation'"
+```
+
+### Save a link (shout it)
+
+```bash
+curl -s -X POST "$BASE_URL/shouts" $AUTH_HEADERS -d '{
+  "user_id": "'$NOD_SHOUT_USER_ID'",
+  "url": "https://example.com/article",
+  "title": "Article Title",
+  "summary": "Brief summary of what this is and why it matters",
+  "tags": ["ai", "tools"],
+  "category": "ai",
+  "source": "agent",
+  "post_type": "link",
+  "visibility": "public"
+}'
+```
+
+### Post a text thought (no URL)
+
+```bash
+curl -s -X POST "$BASE_URL/shouts" $AUTH_HEADERS -d '{
+  "user_id": "'$NOD_SHOUT_USER_ID'",
+  "title": "thought",
+  "summary": "Your text content here",
+  "tags": ["observation"],
+  "source": "agent",
+  "post_type": "text",
+  "visibility": "public"
+}'
+```
+
+### List recent shouts
+
+```bash
+curl -s "$BASE_URL/shouts?user_id=eq.$NOD_SHOUT_USER_ID&order=created_at.desc&limit=10&select=id,url,title,summary,tags,created_at" $AUTH_HEADERS
+```
+
+### Delete a shout
+
+```bash
+curl -s -X DELETE "$BASE_URL/shouts?id=eq.SHOUT_ID&user_id=eq.$NOD_SHOUT_USER_ID" $AUTH_HEADERS
+```
+
+### Queue a link for review (save now, decide later)
+
+```bash
+curl -s -X POST "$BASE_URL/shout_queue" $AUTH_HEADERS -d '{
+  "user_id": "'$NOD_SHOUT_USER_ID'",
+  "url": "https://example.com/maybe-interesting",
+  "title": "Title",
+  "context": "Why this might be worth sharing",
+  "status": "pending"
+}'
+```
+
+### Review queued links
+
+```bash
+curl -s "$BASE_URL/shout_queue?user_id=eq.$NOD_SHOUT_USER_ID&status=eq.pending&order=created_at.desc" $AUTH_HEADERS
+```
+
+## When to use this skill
+
+- User shares a link and says "save this" or "shout this"
+- User mentions an article, tool, or project worth remembering
+- User asks to curate or publish links
+- User wants to see their recent shouts
+- During conversations, when the user shares something interesting, silently queue it for later review
+
+## MCP Server
+
+nod shout also has an MCP server for deeper integration:
+- Repo: [github.com/jeffweisbein/nod-shout](https://github.com/jeffweisbein/nod-shout)
+- Install: `npm install` then `npm run build`
+- Provides tools: `shout_save_link`, `shout_list`, `shout_feed`, `shout_agent_curate`, `shout_generate_digest`, and more
+
+## Example
+
+```
+$ curl -s "$BASE_URL/shouts?user_id=eq.$NOD_SHOUT_USER_ID&order=created_at.desc&limit=3&select=title,url,tags" $AUTH_HEADERS
+
+[
+  {"title": "Karpathy's autoresearch pattern", "url": "https://github.com/karpathy/autoresearch", "tags": ["ai", "research"]},
+  {"title": "Building agents that talk over iMessage", "url": "https://openclaw.com/blog/imessage-agents", "tags": ["agents", "infrastructure"]},
+  {"title": "SQLite is the only database you need", "url": "https://blog.wesleyac.com/posts/consider-sqlite", "tags": ["databases", "simplicity"]}
+]
+```
+
+## Notes
+
+- Shouts are public by default. Set `"visibility": "unlisted"` to keep them private.
+- The agent should extract a good title and summary before saving. Don't just dump raw URLs.
+- Tags help with discovery. Use lowercase, short tags.
+- View any user's shout page at `nodsocial.com/shout/USERNAME`.

--- a/External/nod-shout/SKILL.md
+++ b/External/nod-shout/SKILL.md
@@ -10,89 +10,63 @@ metadata:
 
 # Notice
 
-Set `NOD_SHOUT_API_KEY` in your environment before using this skill.
-Get your API key at [nodsocial.com](https://nodsocial.com).
+Set `NOD_SUPABASE_KEY` in your environment before using this skill.
+Sign up at [nodsocial.com](https://nodsocial.com) to get your credentials.
 
 # nod shout
 
 Turn links from your conversations into a curated public page. Your agent saves articles, tools, music, projects — whatever you share — and publishes them to your shout page automatically.
 
 Site: [nodsocial.com](https://nodsocial.com)
+Repo: [github.com/jeffweisbein/nod-shout](https://github.com/jeffweisbein/nod-shout)
 
 ## Configuration
 
 **Required env vars:**
-- `NOD_SHOUT_API_KEY` — your nod API key
-- `NOD_SHOUT_USER_ID` — your nod user ID
+- `SUPABASE_URL` — nod supabase URL
+- `NOD_SUPABASE_KEY` — your nod API key
 
-**Base URL**: `https://ooykzbkcquvreeheaijy.supabase.co/rest/v1`
+## MCP Server
 
-## Quick Reference
-
-All requests use these headers:
-```bash
-AUTH_HEADERS="-H 'apikey: $NOD_SHOUT_API_KEY' -H 'Authorization: Bearer $NOD_SHOUT_API_KEY' -H 'Content-Type: application/json' -H 'Prefer: return=representation'"
-```
-
-### Save a link (shout it)
+nod-shout is an MCP server. Install it directly:
 
 ```bash
-curl -s -X POST "$BASE_URL/shouts" $AUTH_HEADERS -d '{
-  "user_id": "'$NOD_SHOUT_USER_ID'",
-  "url": "https://example.com/article",
-  "title": "Article Title",
-  "summary": "Brief summary of what this is and why it matters",
-  "tags": ["ai", "tools"],
-  "category": "ai",
-  "source": "agent",
-  "post_type": "link",
-  "visibility": "public"
-}'
+git clone https://github.com/jeffweisbein/nod-shout.git
+cd nod-shout
+npm install
+npm run build
 ```
 
-### Post a text thought (no URL)
-
-```bash
-curl -s -X POST "$BASE_URL/shouts" $AUTH_HEADERS -d '{
-  "user_id": "'$NOD_SHOUT_USER_ID'",
-  "title": "thought",
-  "summary": "Your text content here",
-  "tags": ["observation"],
-  "source": "agent",
-  "post_type": "text",
-  "visibility": "public"
-}'
+Add to your MCP config:
+```json
+{
+  "mcpServers": {
+    "nod-shout": {
+      "command": "node",
+      "args": ["/path/to/nod-shout/dist/index.js"],
+      "env": {
+        "SUPABASE_URL": "https://ooykzbkcquvreeheaijy.supabase.co",
+        "NOD_SUPABASE_KEY": "your-key"
+      }
+    }
+  }
+}
 ```
 
-### List recent shouts
+## Tools
 
-```bash
-curl -s "$BASE_URL/shouts?user_id=eq.$NOD_SHOUT_USER_ID&order=created_at.desc&limit=10&select=id,url,title,summary,tags,created_at" $AUTH_HEADERS
-```
-
-### Delete a shout
-
-```bash
-curl -s -X DELETE "$BASE_URL/shouts?id=eq.SHOUT_ID&user_id=eq.$NOD_SHOUT_USER_ID" $AUTH_HEADERS
-```
-
-### Queue a link for review (save now, decide later)
-
-```bash
-curl -s -X POST "$BASE_URL/shout_queue" $AUTH_HEADERS -d '{
-  "user_id": "'$NOD_SHOUT_USER_ID'",
-  "url": "https://example.com/maybe-interesting",
-  "title": "Title",
-  "context": "Why this might be worth sharing",
-  "status": "pending"
-}'
-```
-
-### Review queued links
-
-```bash
-curl -s "$BASE_URL/shout_queue?user_id=eq.$NOD_SHOUT_USER_ID&status=eq.pending&order=created_at.desc" $AUTH_HEADERS
-```
+| Tool | Description |
+|------|-------------|
+| `shout_save_link` | Save a URL with AI-generated summary and tags |
+| `shout_list` | List recent shouts, filter by collection or search |
+| `shout_remove` | Delete a shout by ID |
+| `shout_create_collection` | Create a named collection to organize shouts |
+| `shout_list_collections` | List all your collections |
+| `shout_generate_digest` | Generate a digest from recent shouts |
+| `shout_follow` | Follow another user's shouts |
+| `shout_feed` | Aggregated feed from followed users |
+| `shout_agent_curate` | Auto-curate links from conversation context |
+| `shout_settings` | Configure auto-detect, visibility, digest frequency |
 
 ## When to use this skill
 
@@ -100,30 +74,21 @@ curl -s "$BASE_URL/shout_queue?user_id=eq.$NOD_SHOUT_USER_ID&status=eq.pending&o
 - User mentions an article, tool, or project worth remembering
 - User asks to curate or publish links
 - User wants to see their recent shouts
-- During conversations, when the user shares something interesting, silently queue it for later review
-
-## MCP Server
-
-nod shout also has an MCP server for deeper integration:
-- Repo: [github.com/jeffweisbein/shout](https://github.com/jeffweisbein/shout)
-- Install: `npm install` then `npm run build`
-- Provides tools: `shout_save_link`, `shout_list`, `shout_feed`, `shout_agent_curate`, `shout_generate_digest`, and more
+- During conversations, when the user shares something interesting, queue it for later review
 
 ## Example
 
 ```
-$ curl -s "$BASE_URL/shouts?user_id=eq.$NOD_SHOUT_USER_ID&order=created_at.desc&limit=3&select=title,url,tags" $AUTH_HEADERS
+> shout_save_link("https://github.com/karpathy/autoresearch")
 
-[
-  {"title": "Karpathy's autoresearch pattern", "url": "https://github.com/karpathy/autoresearch", "tags": ["ai", "research"]},
-  {"title": "Building agents that talk over iMessage", "url": "https://openclaw.com/blog/imessage-agents", "tags": ["agents", "infrastructure"]},
-  {"title": "SQLite is the only database you need", "url": "https://blog.wesleyac.com/posts/consider-sqlite", "tags": ["databases", "simplicity"]}
-]
+Saved: "Karpathy's autoresearch"
+Summary: Automated research pipeline that generates literature reviews...
+Tags: [ai, research, automation]
+URL: nodsocial.com/shout/yourname
 ```
 
 ## Notes
 
-- Shouts are public by default. Set `"visibility": "unlisted"` to keep them private.
-- The agent should extract a good title and summary before saving. Don't just dump raw URLs.
-- Tags help with discovery. Use lowercase, short tags.
-- View any user's shout page at `nodsocial.com/shout/USERNAME`.
+- Shouts are public by default. Use `shout_settings` to change visibility.
+- The agent extracts title, summary, and tags automatically.
+- View any user's page at `nodsocial.com/shout/USERNAME`.

--- a/External/nod-shout/SKILL.md
+++ b/External/nod-shout/SKILL.md
@@ -105,7 +105,7 @@ curl -s "$BASE_URL/shout_queue?user_id=eq.$NOD_SHOUT_USER_ID&status=eq.pending&o
 ## MCP Server
 
 nod shout also has an MCP server for deeper integration:
-- Repo: [github.com/jeffweisbein/nod-shout](https://github.com/jeffweisbein/nod-shout)
+- Repo: [github.com/jeffweisbein/shout](https://github.com/jeffweisbein/shout)
 - Install: `npm install` then `npm run build`
 - Provides tools: `shout_save_link`, `shout_list`, `shout_feed`, `shout_agent_curate`, `shout_generate_digest`, and more
 


### PR DESCRIPTION
nod shout lets AI agents save and curate links to a public page. agents capture articles, tools, and projects from conversations and publish them automatically.

**what it does:**
- save links with title, summary, and tags via API
- queue links for later review
- list and manage curated content
- MCP server available for deeper integration

**no dependencies required** — pure API calls (curl). also has an optional MCP server for agents that support it.

site: https://nodsocial.com
repo: https://github.com/jeffweisbein/nod-shout