### PR TITLE
Add arxiv research skill

### DIFF
--- a/Community/arxiv-research/SKILL.md
+++ b/Community/arxiv-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arxiv-research
-description: Search, download, and read arXiv papers directly. MCP-compatible tools with optional Markdown conversion for page-aware citations. Provides search_papers, download_paper, convert_paper, list_papers, read_paper, and deep-paper-analysis workflow.
+description: Search, download, and read arXiv papers directly. Provides search_papers, download_paper, list_papers, read_paper, convert (PDF to Markdown), and deep-paper-analysis workflow.
 compatibility: Created for Zo Computer
 metadata:
   author: ashishsoni08.zo.computer
@@ -8,17 +8,16 @@ metadata:
 
 # ArXiv Research Skill
 
-Search and access arXiv papers directly from Zo Computer with MCP-compatible tools.
+Search and access arXiv papers directly from Zo Computer.
 
 ## Features
 
 - **Search** arXiv papers with filters (date, categories)
 - **Download** papers by arXiv ID
 - **Convert** PDFs to Markdown (with page markers for citations)
-- **Read** papers as text or Markdown
-- **List** downloaded papers (with Markdown indicator [MD])
+- **Read** papers (auto-detects Markdown if available, else PDF text)
+- **List** downloaded papers (with [MD] indicator)
 - **Deep analysis** workflow for comprehensive paper review
-- **MCP mode** for direct JSON tool execution
 
 ## Tools
 
@@ -26,7 +25,7 @@ Search and access arXiv papers directly from Zo Computer with MCP-compatible too
 |---------|-------------|
 | `search` / `search_papers` | Search arXiv papers |
 | `download` / `download_paper` | Download paper by ID |
-| `convert` / `convert_paper` | Convert PDF to Markdown |
+| `convert` | Convert PDF to Markdown |
 | `list` / `list_papers` | List downloaded papers |
 | `read` / `read_paper` | Read paper content |
 | `mcp` | Execute MCP tools with JSON I/O |
@@ -38,7 +37,7 @@ Search and access arXiv papers directly from Zo Computer with MCP-compatible too
 
 ```bash
 bun arxiv.ts search "transformer architecture" --max 5
-bun arxiv.ts search_papers "AI safety" --categories cs.AI,cs.CY --from 2024-01-01
+bun arxiv.ts search_papers "quantum" --categories cs.AI,quant-ph
 ```
 
 ### Download a paper
@@ -54,25 +53,18 @@ Converts PDF to Markdown with page markers for exact citations:
 
 ```bash
 bun arxiv.ts convert 2401.12345
-# Creates: ~/.arxiv-mcp-server/papers/2401.12345.md
 ```
 
-**Requires:** `pip3 install PyMuPDF`
+**Requires:** `pip3 install PyMuPDF` (optionally `pip3 install pymupdf4llm` for better formatting)
 
 ### Read a paper
 
 ```bash
-# Read (auto-detects: markdown if converted, else PDF text)
+# Auto-detects: markdown if converted, else PDF text
 bun arxiv.ts read 2401.12345
 
-# Force text extraction from PDF
-bun arxiv.ts read 2401.12345 --format text
-
-# Force markdown (error if not converted)
-bun arxiv.ts read 2401.12345 --format markdown
-
-# Include page markers in output
-bun arxiv.ts read 2401.12345 --pages
+# JSON output for programmatic use
+bun arxiv.ts read 2401.12345 --json
 ```
 
 ### List papers
@@ -80,6 +72,8 @@ bun arxiv.ts read 2401.12345 --pages
 ```bash
 bun arxiv.ts list
 # Shows [MD] indicator for papers with Markdown version
+
+bun arxiv.ts list --json
 ```
 
 ### Deep paper analysis
@@ -88,7 +82,7 @@ bun arxiv.ts list
 bun arxiv.ts deep-paper-analysis 2401.12345
 ```
 
-Automatically downloads, reads, and outputs paper data for analysis.
+Automatically downloads, converts (if possible), reads, and outputs paper data for analysis.
 
 ### MCP Mode
 
@@ -96,13 +90,13 @@ Execute tools directly with JSON I/O:
 
 ```bash
 bun arxiv.ts mcp search_papers '{"query": "AI", "max_results": 5}'
-bun arxiv.ts mcp convert_paper '{"paper_id": "2401.12345"}'
-bun arxiv.ts mcp read_paper '{"paper_id": "2401.12345", "format": "markdown"}'
+bun arxiv.ts mcp download_paper '{"paper_id": "2401.12345"}'
+bun arxiv.ts mcp read_paper '{"paper_id": "2401.12345"}'
 ```
 
 ## Storage
 
-Downloaded papers stored at: `~/.arxiv-mcp-server/papers/`
+Downloaded papers stored at: `/home/workspace/Research/arxiv-papers/`
 
 - `*.pdf` — Original PDF files
 - `*.json` — Metadata
@@ -113,19 +107,13 @@ Downloaded papers stored at: `~/.arxiv-mcp-server/papers/`
 **Required:**
 - Bun (Zo's default runtime)
 
-**Optional (for PDF text extraction):**
+**Optional (for PDF text extraction fallback):**
 - `pdftotext` (poppler-utils) — fastest extraction
-- OR `PyPDF2` — `pip3 install PyPDF2`
+- OR `PyPDF2` — `pip3 install PyPDF2` (used via `scripts/extract_text.py`)
 
 **Optional (for Markdown conversion):**
-- `PyMuPDF` — `pip3 install PyMuPDF`
-- OR `pymupdf4llm` — `pip3 install pymupdf4llm` (better formatting)
-
-## MCP Compatibility
-
-This skill replicates the [arxiv-mcp-server](https://github.com/blazickjp/arxiv-mcp-server) but runs natively in Zo without Python/MCP protocol overhead.
-
-Same storage path, same tool names, same functionality — plus Markdown conversion for page-aware citations.
+- `PyMuPDF` — `pip3 install PyMuPDF` (used via `scripts/convert_to_markdown.py`)
+- `pymupdf4llm` — `pip3 install pymupdf4llm` (better formatting, optional)
 
 ## arXiv Categories
 

--- a/Community/arxiv-research/SKILL.md
+++ b/Community/arxiv-research/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: arxiv-research
+description: Search, download, and read arXiv papers directly. MCP-compatible tools with optional Markdown conversion for page-aware citations. Provides search_papers, download_paper, convert_paper, list_papers, read_paper, and deep-paper-analysis workflow.
+compatibility: Created for Zo Computer
+metadata:
+  author: ashishsoni08.zo.computer
+---
+
+# ArXiv Research Skill
+
+Search and access arXiv papers directly from Zo Computer with MCP-compatible tools.
+
+## Features
+
+- **Search** arXiv papers with filters (date, categories)
+- **Download** papers by arXiv ID
+- **Convert** PDFs to Markdown (with page markers for citations)
+- **Read** papers as text or Markdown
+- **List** downloaded papers (with Markdown indicator [MD])
+- **Deep analysis** workflow for comprehensive paper review
+- **MCP mode** for direct JSON tool execution
+
+## Tools
+
+| Command | Description |
+|---------|-------------|
+| `search` / `search_papers` | Search arXiv papers |
+| `download` / `download_paper` | Download paper by ID |
+| `convert` / `convert_paper` | Convert PDF to Markdown |
+| `list` / `list_papers` | List downloaded papers |
+| `read` / `read_paper` | Read paper content |
+| `mcp` | Execute MCP tools with JSON I/O |
+| `deep-paper-analysis` | Complete analysis workflow |
+
+## Usage
+
+### Search for papers
+
+```bash
+bun arxiv.ts search "transformer architecture" --max 5
+bun arxiv.ts search_papers "AI safety" --categories cs.AI,cs.CY --from 2024-01-01
+```
+
+### Download a paper
+
+```bash
+bun arxiv.ts download 2401.12345
+bun arxiv.ts download_paper 2401.12345
+```
+
+### Convert to Markdown (optional)
+
+Converts PDF to Markdown with page markers for exact citations:
+
+```bash
+bun arxiv.ts convert 2401.12345
+# Creates: ~/.arxiv-mcp-server/papers/2401.12345.md
+```
+
+**Requires:** `pip3 install PyMuPDF`
+
+### Read a paper
+
+```bash
+# Read (auto-detects: markdown if converted, else PDF text)
+bun arxiv.ts read 2401.12345
+
+# Force text extraction from PDF
+bun arxiv.ts read 2401.12345 --format text
+
+# Force markdown (error if not converted)
+bun arxiv.ts read 2401.12345 --format markdown
+
+# Include page markers in output
+bun arxiv.ts read 2401.12345 --pages
+```
+
+### List papers
+
+```bash
+bun arxiv.ts list
+# Shows [MD] indicator for papers with Markdown version
+```
+
+### Deep paper analysis
+
+```bash
+bun arxiv.ts deep-paper-analysis 2401.12345
+```
+
+Automatically downloads, reads, and outputs paper data for analysis.
+
+### MCP Mode
+
+Execute tools directly with JSON I/O:
+
+```bash
+bun arxiv.ts mcp search_papers '{"query": "AI", "max_results": 5}'
+bun arxiv.ts mcp convert_paper '{"paper_id": "2401.12345"}'
+bun arxiv.ts mcp read_paper '{"paper_id": "2401.12345", "format": "markdown"}'
+```
+
+## Storage
+
+Downloaded papers stored at: `~/.arxiv-mcp-server/papers/`
+
+- `*.pdf` — Original PDF files
+- `*.json` — Metadata
+- `*.md` — Markdown conversion (optional)
+
+## Dependencies
+
+**Required:**
+- Bun (Zo's default runtime)
+
+**Optional (for PDF text extraction):**
+- `pdftotext` (poppler-utils) — fastest extraction
+- OR `PyPDF2` — `pip3 install PyPDF2`
+
+**Optional (for Markdown conversion):**
+- `PyMuPDF` — `pip3 install PyMuPDF`
+- OR `pymupdf4llm` — `pip3 install pymupdf4llm` (better formatting)
+
+## MCP Compatibility
+
+This skill replicates the [arxiv-mcp-server](https://github.com/blazickjp/arxiv-mcp-server) but runs natively in Zo without Python/MCP protocol overhead.
+
+Same storage path, same tool names, same functionality — plus Markdown conversion for page-aware citations.
+
+## arXiv Categories
+
+Common categories: `cs.AI`, `cs.LG`, `cs.CL`, `cs.CV`, `cs.RO`, `cs.CY`, `quant-ph`, `stat.ML`

--- a/Community/arxiv-research/scripts/arxiv.ts
+++ b/Community/arxiv-research/scripts/arxiv.ts
@@ -1,0 +1,676 @@
+#!/usr/bin/env bun
+
+import { parseArgs } from "util";
+import { mkdir, readdir, readFile, writeFile, exists } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const STORAGE_PATH = join(homedir(), ".arxiv-mcp-server", "papers");
+
+interface ArxivEntry {
+  id: string;
+  title: string;
+  summary: string;
+  authors: string[];
+  published: string;
+  updated: string;
+  categories: string[];
+  pdf_url: string;
+  primary_category: string;
+}
+
+interface SearchOptions {
+  max?: number;
+  from?: string;
+  categories?: string;
+}
+
+async function ensureStorage() {
+  await mkdir(STORAGE_PATH, { recursive: true });
+}
+
+async function searchPapers(query: string, options: SearchOptions = {}): Promise<ArxivEntry[]> {
+  const max = options.max || 10;
+  const maxResults = Math.min(max, 50);
+
+  let url = `http://export.arxiv.org/api/query?search_query=all:${encodeURIComponent(query)}&start=0&max_results=${maxResults}&sortBy=relevance&sortOrder=descending`;
+
+  if (options.from) {
+    url += `&submittedDateFrom=${options.from}`;
+  }
+
+  if (options.categories) {
+    const cats = options.categories.split(",").map(c => c.trim());
+    const catQuery = cats.map(c => `cat:${c}`).join("+OR+");
+    url = url.replace(`all:${encodeURIComponent(query)}`, `(${catQuery})+AND+all:${encodeURIComponent(query)}`);
+  }
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Search failed: ${response.status} ${response.statusText}`);
+  }
+
+  const xml = await response.text();
+  return parseArxivFeed(xml);
+}
+
+function parseArxivFeed(xml: string): ArxivEntry[] {
+  const entries: ArxivEntry[] = [];
+  const entryRegex = /<entry>([\s\S]*?)<\/entry>/g;
+  let match;
+
+  while ((match = entryRegex.exec(xml)) !== null) {
+    const entryXml = match[1];
+
+    const idMatch = entryXml.match(/<id>([^<]+)<\/id>/);
+    const titleMatch = entryXml.match(/<title>([\s\S]*?)<\/title>/);
+    const summaryMatch = entryXml.match(/<summary>([\s\S]*?)<\/summary>/);
+    const publishedMatch = entryXml.match(/<published>([^<]+)<\/published>/);
+    const updatedMatch = entryXml.match(/<updated>([^<]+)<\/updated>/);
+
+    const authorMatches = [...entryXml.matchAll(/<author>\s*<name>([^<]+)<\/name>\s*<\/author>/g)];
+    const authors = authorMatches.map(m => m[1]);
+
+    const categoryMatches = [...entryXml.matchAll(/<category term="([^"]+)"/g)];
+    const categories = categoryMatches.map(m => m[1]);
+
+    const primaryCatMatch = entryXml.match(/<arxiv:primary_category term="([^"]+)"/);
+    const primary_category = primaryCatMatch ? primaryCatMatch[1] : categories[0] || "";
+
+    const arxivIdMatch = idMatch ? idMatch[1].match(/arxiv\.org\/abs\/(.+?)$/)
+      : entryXml.match(/<arxiv:id>([^<]+)<\/arxiv:id>/);
+    const arxivId = arxivIdMatch ? arxivIdMatch[1] : idMatch ? idMatch[1].split("/").pop() || "" : "";
+
+    entries.push({
+      id: arxivId,
+      title: titleMatch ? cleanText(titleMatch[1]) : "",
+      summary: summaryMatch ? cleanText(summaryMatch[1]) : "",
+      authors,
+      published: publishedMatch ? publishedMatch[1] : "",
+      updated: updatedMatch ? updatedMatch[1] : "",
+      categories,
+      pdf_url: `https://arxiv.org/pdf/${arxivId}.pdf`,
+      primary_category: primary_category
+    });
+  }
+
+  return entries;
+}
+
+function cleanText(text: string): string {
+  return text
+    .replace(/\s+/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .trim();
+}
+
+async function downloadPaper(paperId: string, silent = false): Promise<string> {
+  await ensureStorage();
+
+  const cleanId = paperId.replace(/^arxiv:/, "").trim();
+  const pdfPath = join(STORAGE_PATH, `${cleanId}.pdf`);
+  const metaPath = join(STORAGE_PATH, `${cleanId}.json`);
+
+  if (await exists(pdfPath)) {
+    if (!silent) console.log(`Paper ${cleanId} already downloaded.`);
+    return pdfPath;
+  }
+
+  const pdfUrl = `https://arxiv.org/pdf/${cleanId}.pdf`;
+  if (!silent) console.log(`Downloading ${cleanId}...`);
+
+  const response = await fetch(pdfUrl);
+  if (!response.ok) {
+    throw new Error(`Download failed: ${response.status} ${response.statusText}`);
+  }
+
+  const pdfBuffer = await response.arrayBuffer();
+  await writeFile(pdfPath, Buffer.from(pdfBuffer));
+
+  try {
+    const metaUrl = `http://export.arxiv.org/api/query?id_list=${cleanId}`;
+    const metaResponse = await fetch(metaUrl);
+    if (metaResponse.ok) {
+      const xml = await metaResponse.text();
+      const entries = parseArxivFeed(xml);
+      if (entries.length > 0) {
+        await writeFile(metaPath, JSON.stringify(entries[0], null, 2));
+      }
+    }
+  } catch {
+    // Metadata fetch failed, but PDF is downloaded
+  }
+
+  if (!silent) console.log(`Downloaded to ${pdfPath}`);
+  return pdfPath;
+}
+
+async function listPapers(json = false): Promise<{ id: string; title: string; path: string }[]> {
+  await ensureStorage();
+
+  const files = await readdir(STORAGE_PATH);
+  const pdfs = files.filter(f => f.endsWith(".pdf"));
+
+  const papers: { id: string; title: string; path: string; hasMarkdown: boolean }[] = [];
+
+  for (const pdf of pdfs) {
+    const paperId = pdf.replace(".pdf", "");
+    const metaPath = join(STORAGE_PATH, `${paperId}.json`);
+    const pdfPath = join(STORAGE_PATH, pdf);
+    const mdPath = join(STORAGE_PATH, `${paperId}.md`);
+
+    let title = "Unknown";
+    try {
+      if (await exists(metaPath)) {
+        const meta = JSON.parse(await readFile(metaPath, "utf-8"));
+        title = meta.title || "Unknown";
+      }
+    } catch {
+      // Ignore
+    }
+
+    papers.push({ id: paperId, title, path: pdfPath, hasMarkdown: await exists(mdPath) });
+  }
+
+  if (!json) {
+    if (papers.length === 0) {
+      console.log("No papers downloaded yet.");
+    } else {
+      console.log(`Found ${papers.length} paper(s):\n`);
+      for (const paper of papers) {
+        const mdIndicator = paper.hasMarkdown ? " [MD]" : "";
+        console.log(`  ${paper.id}: ${paper.title}${mdIndicator}`);
+      }
+    }
+  }
+
+  return papers.map(p => ({ id: p.id, title: p.title, path: p.path }));
+}
+
+async function readPaperContent(paperId: string, format?: "text" | "markdown", withPageMarkers = false): Promise<string | null> {
+  const cleanId = paperId.replace(/^arxiv:/, "").trim();
+  const pdfPath = join(STORAGE_PATH, `${cleanId}.pdf`);
+  const mdPath = join(STORAGE_PATH, `${cleanId}.md`);
+
+  if (!(await exists(pdfPath))) {
+    return null;
+  }
+
+  const hasMarkdown = await exists(mdPath);
+
+  // Determine format: explicit > auto-detect
+  if (format === "markdown") {
+    if (hasMarkdown) {
+      console.error("[Reading from Markdown]");
+      return await readFile(mdPath, "utf-8");
+    }
+    throw new Error(`Markdown not found for ${cleanId}. Run: bun arxiv.ts convert ${cleanId}`);
+  }
+
+  if (format === "text" || !hasMarkdown) {
+    if (!format) console.error("[Reading from PDF]");
+    let text: string;
+
+    // Try pdftotext first (fastest)
+    const proc = Bun.spawn(["which", "pdftotext"], { stdout: "pipe" });
+    const hasPdftotext = (await new Response(proc.stdout).text()).trim() !== "";
+
+    if (hasPdftotext) {
+      if (withPageMarkers) {
+        // Get text with page markers using -layout
+        const result = Bun.spawn(["pdftotext", "-layout", pdfPath, "-"], { stdout: "pipe" });
+        text = await new Response(result.stdout).text();
+      } else {
+        const result = Bun.spawn(["pdftotext", pdfPath, "-"], { stdout: "pipe" });
+        text = await new Response(result.stdout).text();
+      }
+    } else {
+      // Fallback to PyPDF2 with page-by-page extraction
+      const pythonScript = `
+import sys
+from PyPDF2 import PdfReader
+reader = PdfReader("${pdfPath}")
+text = ""
+for i, page in enumerate(reader.pages, 1):
+    ${withPageMarkers ? 'text += f"\\n--- Page {i} ---\\n"' : 'pass'}
+    page_text = page.extract_text()
+    if page_text:
+        text += page_text + "\\n"
+print(text)
+`;
+      const result = Bun.spawn(["python3", "-c", pythonScript], { stdout: "pipe", stderr: "pipe" });
+      text = await new Response(result.stdout).text();
+      if (!text.trim()) {
+        const err = await new Response(result.stderr).text();
+        if (err.includes("No module named")) {
+          throw new Error("PDF extraction requires PyPDF2. Install with: pip3 install PyPDF2");
+        }
+      }
+    }
+
+    return text;
+  }
+
+  // Auto: markdown exists and no explicit format
+  console.error("[Reading from Markdown]");
+  return await readFile(mdPath, "utf-8");
+}
+
+async function convertToMarkdown(paperId: string): Promise<string> {
+  const cleanId = paperId.replace(/^arxiv:/, "").trim();
+  const pdfPath = join(STORAGE_PATH, `${cleanId}.pdf`);
+  const mdPath = join(STORAGE_PATH, `${cleanId}.md`);
+
+  if (!(await exists(pdfPath))) {
+    throw new Error(`Paper ${cleanId} not found. Download it first.`);
+  }
+
+  // Check if already converted
+  if (await exists(mdPath)) {
+    console.log(`Markdown already exists for ${cleanId}`);
+    return mdPath;
+  }
+
+  // Try pymupdf4llm (best quality)
+  const pythonScript = `
+import sys
+try:
+    import fitz  # PyMuPDF
+    from pymupdf4llm import to_markdown
+except ImportError:
+    # Fallback: basic PyMuPDF
+    import fitz
+    doc = fitz.open("${pdfPath}")
+    md = ""
+    for page_num in range(len(doc)):
+        page = doc[page_num]
+        md += f"\\n\\n--- Page {page_num + 1} ---\\n\\n"
+        md += page.get_text()
+    doc.close()
+    print(md)
+    sys.exit(0)
+
+try:
+    md = to_markdown("${pdfPath}")
+    print(md)
+except Exception as e:
+    # Fallback without pymupdf4llm
+    doc = fitz.open("${pdfPath}")
+    md = ""
+    for page_num in range(len(doc)):
+        page = doc[page_num]
+        md += f"\\n\\n--- Page {page_num + 1} ---\\n\\n"
+        md += page.get_text()
+    doc.close()
+    print(md)
+`;
+
+  console.log(`Converting ${cleanId} to Markdown...`);
+  const result = Bun.spawn(["python3", "-c", pythonScript], { stdout: "pipe", stderr: "pipe" });
+  const text = await new Response(result.stdout).text();
+  const stderr = await new Response(result.stderr).text();
+
+  if (!text.trim()) {
+    if (stderr.includes("No module named")) {
+      throw new Error("PDF conversion requires PyMuPDF. Install with: pip3 install PyMuPDF");
+    }
+    throw new Error(`Conversion failed: ${stderr}`);
+  }
+
+  await writeFile(mdPath, text);
+  console.log(`Converted to ${mdPath}`);
+  return mdPath;
+}
+
+async function readPaper(paperId: string, maxChars = 5000, format?: "text" | "markdown", withPages = false): Promise<void> {
+  const text = await readPaperContent(paperId, format, withPages);
+
+  if (text === null) {
+    console.log(`Paper ${paperId} not found. Download it first:`);
+    console.log(`  bun arxiv.ts download ${paperId}`);
+    return;
+  }
+
+  const preview = text.slice(0, maxChars);
+  console.log(preview);
+  if (text.length > maxChars) {
+    console.log(`\n... (${text.length - maxChars} more characters)`);
+  }
+}
+
+async function getPaperMetadata(paperId: string): Promise<ArxivEntry | null> {
+  const cleanId = paperId.replace(/^arxiv:/, "").trim();
+  const metaPath = join(STORAGE_PATH, `${cleanId}.json`);
+
+  if (await exists(metaPath)) {
+    try {
+      return JSON.parse(await readFile(metaPath, "utf-8"));
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+// MCP-compatible functions
+async function mcpSearchPapers(args: { query: string; max_results?: number; date_from?: string; categories?: string[] }) {
+  try {
+    const catString = args.categories?.join(",");
+    const results = await searchPapers(args.query, {
+      max: args.max_results,
+      from: args.date_from,
+      categories: catString
+    });
+
+    const formatted = results.map(p => ({
+      id: p.id,
+      title: p.title,
+      authors: p.authors,
+      published: p.published,
+      categories: p.categories,
+      summary: p.summary,
+      pdf_url: p.pdf_url
+    }));
+
+    return { content: [{ type: "text", text: JSON.stringify(formatted, null, 2) }] };
+  } catch (error) {
+    return { content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+  }
+}
+
+async function mcpDownloadPaper(args: { paper_id: string }) {
+  try {
+    const path = await downloadPaper(args.paper_id, true);
+    return { content: [{ type: "text", text: JSON.stringify({ success: true, paper_id: args.paper_id, path }) }] };
+  } catch (error) {
+    return { content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+  }
+}
+
+async function mcpListPapers() {
+  const papers = await listPapers(true);
+  return { content: [{ type: "text", text: JSON.stringify(papers, null, 2) }] };
+}
+
+async function mcpReadPaper(args: { paper_id: string; format?: "text" | "markdown" }) {
+  const format = args.format || "text";
+  const text = await readPaperContent(args.paper_id, format);
+  if (text === null) {
+    return { content: [{ type: "text", text: `Paper ${args.paper_id} not found. Download it first.` }], isError: true };
+  }
+  return { content: [{ type: "text", text }] };
+}
+
+async function mcpConvertPaper(args: { paper_id: string }) {
+  try {
+    const path = await convertToMarkdown(args.paper_id);
+    return { content: [{ type: "text", text: JSON.stringify({ success: true, paper_id: args.paper_id, markdown_path: path }) }] };
+  } catch (error) {
+    return { content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+  }
+}
+
+async function main() {
+  const { positionals, values } = parseArgs({
+    args: Bun.argv.slice(2),
+    allowPositionals: true,
+    options: {
+      max: { type: "string" },
+      from: { type: "string" },
+      categories: { type: "string" },
+      json: { type: "boolean" },
+      format: { type: "string" },
+      pages: { type: "boolean" },
+      help: { type: "boolean", short: "h" }
+    }
+  });
+
+  const command = positionals[0];
+  const arg = positionals[1];
+
+  const commandMap: Record<string, string> = {
+    "search_papers": "search",
+    "download_paper": "download",
+    "list_papers": "list",
+    "read_paper": "read",
+    "convert_paper": "convert"
+  };
+  const normalizedCommand = commandMap[command] || command;
+
+  if (values.help || !command) {
+    console.log(`
+ArXiv Research Tool - MCP Compatible
+
+Usage:
+  bun arxiv.ts <command> [options]
+
+Commands:
+  search <query>              Search for papers
+  search_papers <query>       MCP alias for search
+  download <paper-id>         Download a paper by arXiv ID
+  download_paper <paper-id>   MCP alias for download
+  convert <paper-id>          Convert PDF to Markdown (PyMuPDF)
+  convert_paper <paper-id>    MCP alias for convert
+  list                        List all downloaded papers
+  list_papers                 MCP alias for list
+  read <paper-id>             Read content of a downloaded paper
+  read_paper <paper-id>       MCP alias for read
+  mcp <tool> <args>           Execute MCP tool directly (JSON I/O)
+
+Options:
+  --max <n>            Max results (default: 10, max: 50)
+  --from <date>        Date filter (YYYY-MM-DD format)
+  --categories <cats>  Comma-separated arXiv categories
+  --format <fmt>       Read format: auto (default, markdown if available, else text), text, or markdown
+  --pages              Include page markers when reading
+  --json               Output as JSON (for programmatic use)
+  -h, --help           Show this help
+
+Examples:
+  bun arxiv.ts search "transformer architecture" --max 5
+  bun arxiv.ts download 2401.12345
+  bun arxiv.ts convert 2401.12345
+  bun arxiv.ts read 2401.12345 --format markdown
+  bun arxiv.ts read 2401.12345 --pages
+  bun arxiv.ts mcp search_papers '{"query": "AI", "max_results": 5}'
+
+Prompt:
+  deep-paper-analysis  <paper_id>
+    Comprehensive analysis workflow that automatically downloads,
+    reads, and analyzes a paper. Only requires a paper ID.
+`);
+    process.exit(0);
+  }
+
+  if (normalizedCommand === "mcp") {
+    const toolName = arg;
+    const argsJson = positionals.slice(2).join(" ") || "{}";
+    const args = JSON.parse(argsJson);
+
+    let result;
+    switch (toolName) {
+      case "search_papers":
+        result = await mcpSearchPapers(args);
+        break;
+      case "download_paper":
+        result = await mcpDownloadPaper(args);
+        break;
+      case "list_papers":
+        result = await mcpListPapers();
+        break;
+      case "read_paper":
+        result = await mcpReadPaper(args);
+        break;
+      case "convert_paper":
+        result = await mcpConvertPaper(args);
+        break;
+      default:
+        console.error(`Unknown MCP tool: ${toolName}`);
+        process.exit(1);
+    }
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (normalizedCommand === "deep-paper-analysis") {
+    if (!arg) {
+      console.error("Error: Paper ID required for deep analysis");
+      console.exit(1);
+    }
+
+    const paperId = arg.replace(/^arxiv:/, "").trim();
+    console.log(`=== Deep Paper Analysis: ${paperId} ===\n`);
+
+    console.log("Step 1: Checking downloaded papers...");
+    const papers = await listPapers(true);
+    const exists = papers.some(p => p.id === paperId);
+
+    if (!exists) {
+      console.log(`Step 2: Downloading paper ${paperId}...`);
+      try {
+        await downloadPaper(paperId, true);
+        console.log("Downloaded successfully.\n");
+      } catch (error) {
+        console.error(`Failed to download: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    } else {
+      console.log("Step 2: Paper already downloaded.\n");
+    }
+
+    console.log("Step 3: Retrieving metadata...");
+    const metadata = await getPaperMetadata(paperId);
+    if (metadata) {
+      console.log(`Title: ${metadata.title}`);
+      console.log(`Authors: ${metadata.authors.join(", ")}`);
+      console.log(`Published: ${metadata.published.split("T")[0]}`);
+      console.log(`Categories: ${metadata.categories.join(", ")}`);
+      console.log(`Summary: ${metadata.summary.slice(0, 300)}...\n`);
+    }
+
+    console.log("Step 4: Reading paper content...");
+    const content = await readPaperContent(paperId, (values.format as any) || "text");
+    if (content === null) {
+      console.error("Failed to read paper content.");
+      process.exit(1);
+    }
+    console.log(`Extracted ${content.length.toLocaleString()} characters.\n`);
+
+    const output = {
+      paper_id: paperId,
+      metadata: metadata || null,
+      content_length: content.length,
+      content_preview: content.slice(0, 10000),
+      instructions: "Analyze this paper comprehensively covering: executive summary, research context, methodology, results, practical implications, theoretical contributions, future directions, and critical assessment."
+    };
+
+    console.log("=== ANALYSIS DATA ===");
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  try {
+    switch (normalizedCommand) {
+      case "search":
+      case "search_papers": {
+        if (!arg) {
+          console.error("Error: Search query required");
+          process.exit(1);
+        }
+        const results = await searchPapers(arg, {
+          max: values.max ? parseInt(values.max) : undefined,
+          from: values.from,
+          categories: values.categories
+        });
+
+        if (values.json) {
+          console.log(JSON.stringify(results, null, 2));
+        } else {
+          console.log(`Found ${results.length} paper(s):\n`);
+          for (const paper of results) {
+            console.log(`ID:        ${paper.id}`);
+            console.log(`Title:     ${paper.title}`);
+            console.log(`Authors:   ${paper.authors.join(", ")}`);
+            console.log(`Published: ${paper.published.split("T")[0]}`);
+            console.log(`Category:  ${paper.primary_category}`);
+            console.log(`Summary:   ${paper.summary.slice(0, 200)}...`);
+            console.log("---");
+          }
+        }
+        break;
+      }
+
+      case "download":
+      case "download_paper": {
+        if (!arg) {
+          console.error("Error: Paper ID required");
+          process.exit(1);
+        }
+        const path = await downloadPaper(arg);
+        if (values.json) {
+          console.log(JSON.stringify({ success: true, paper_id: arg, path }));
+        }
+        break;
+      }
+
+      case "convert":
+      case "convert_paper": {
+        if (!arg) {
+          console.error("Error: Paper ID required");
+          process.exit(1);
+        }
+        const mdPath = await convertToMarkdown(arg);
+        if (values.json) {
+          console.log(JSON.stringify({ success: true, paper_id: arg, markdown_path: mdPath }));
+        }
+        break;
+      }
+
+      case "list":
+      case "list_papers": {
+        if (values.json) {
+          const papers = await listPapers(true);
+          console.log(JSON.stringify(papers, null, 2));
+        } else {
+          await listPapers(false);
+        }
+        break;
+      }
+
+      case "read":
+      case "read_paper": {
+        if (!arg) {
+          console.error("Error: Paper ID required");
+          process.exit(1);
+        }
+        // Auto-detect format if not specified
+        const format = values.format as "text" | "markdown" | undefined;
+        if (values.json) {
+          const text = await readPaperContent(arg, format, values.pages);
+          if (text === null) {
+            console.log(JSON.stringify({ error: "Paper not found", paper_id: arg }));
+            process.exit(1);
+          }
+          console.log(JSON.stringify({ paper_id: arg, format: format || "auto", content: text }));
+        } else {
+          await readPaper(arg, 5000, format, values.pages);
+        }
+        break;
+      }
+
+      default: {
+        console.error(`Unknown command: ${command}`);
+        console.error("Run 'bun arxiv.ts --help' for usage");
+        process.exit(1);
+      }
+    }
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/Community/arxiv-research/scripts/arxiv.ts
+++ b/Community/arxiv-research/scripts/arxiv.ts
@@ -3,9 +3,8 @@
 import { parseArgs } from "util";
 import { mkdir, readdir, readFile, writeFile, exists } from "node:fs/promises";
 import { join } from "node:path";
-import { homedir } from "node:os";
 
-const STORAGE_PATH = join(homedir(), ".arxiv-mcp-server", "papers");
+const STORAGE_PATH = "/home/workspace/Research/arxiv-papers";
 
 interface ArxivEntry {
   id: string;
@@ -220,7 +219,6 @@ async function readPaperContent(paperId: string, format?: "text" | "markdown", w
 
     if (hasPdftotext) {
       if (withPageMarkers) {
-        // Get text with page markers using -layout
         const result = Bun.spawn(["pdftotext", "-layout", pdfPath, "-"], { stdout: "pipe" });
         text = await new Response(result.stdout).text();
       } else {
@@ -228,21 +226,16 @@ async function readPaperContent(paperId: string, format?: "text" | "markdown", w
         text = await new Response(result.stdout).text();
       }
     } else {
-      // Fallback to PyPDF2 with page-by-page extraction
-      const pythonScript = `
-import sys
-from PyPDF2 import PdfReader
-reader = PdfReader("${pdfPath}")
-text = ""
-for i, page in enumerate(reader.pages, 1):
-    ${withPageMarkers ? 'text += f"\\n--- Page {i} ---\\n"' : 'pass'}
-    page_text = page.extract_text()
-    if page_text:
-        text += page_text + "\\n"
-print(text)
-`;
-      const result = Bun.spawn(["python3", "-c", pythonScript], { stdout: "pipe", stderr: "pipe" });
+      // Fallback to external Python script
+      const scriptDir = import.meta.dirname || import.meta.url.replace("file://", "").replace(/\/[^\/]+$/, "");
+      const pyScript = join(scriptDir, "extract_text.py");
+      
+      const result = Bun.spawn(["python3", pyScript, pdfPath, withPageMarkers ? "true" : "false"], { 
+        stdout: "pipe", 
+        stderr: "pipe" 
+      });
       text = await new Response(result.stdout).text();
+      
       if (!text.trim()) {
         const err = await new Response(result.stderr).text();
         if (err.includes("No module named")) {
@@ -268,65 +261,33 @@ async function convertToMarkdown(paperId: string): Promise<string> {
     throw new Error(`Paper ${cleanId} not found. Download it first.`);
   }
 
-  // Check if already converted
   if (await exists(mdPath)) {
     console.log(`Markdown already exists for ${cleanId}`);
     return mdPath;
   }
 
-  // Try pymupdf4llm (best quality)
-  const pythonScript = `
-import sys
-try:
-    import fitz  # PyMuPDF
-    from pymupdf4llm import to_markdown
-except ImportError:
-    # Fallback: basic PyMuPDF
-    import fitz
-    doc = fitz.open("${pdfPath}")
-    md = ""
-    for page_num in range(len(doc)):
-        page = doc[page_num]
-        md += f"\\n\\n--- Page {page_num + 1} ---\\n\\n"
-        md += page.get_text()
-    doc.close()
-    print(md)
-    sys.exit(0)
-
-try:
-    md = to_markdown("${pdfPath}")
-    print(md)
-except Exception as e:
-    # Fallback without pymupdf4llm
-    doc = fitz.open("${pdfPath}")
-    md = ""
-    for page_num in range(len(doc)):
-        page = doc[page_num]
-        md += f"\\n\\n--- Page {page_num + 1} ---\\n\\n"
-        md += page.get_text()
-    doc.close()
-    print(md)
-`;
-
+  const scriptDir = import.meta.dirname || import.meta.url.replace("file://", "").replace(/\/[^\/]+$/, "");
+  const pyScript = join(scriptDir, "convert_to_markdown.py");
+  
   console.log(`Converting ${cleanId} to Markdown...`);
-  const result = Bun.spawn(["python3", "-c", pythonScript], { stdout: "pipe", stderr: "pipe" });
-  const text = await new Response(result.stdout).text();
+  
+  const result = Bun.spawn(["python3", pyScript, pdfPath, mdPath], { 
+    stdout: "pipe", 
+    stderr: "pipe" 
+  });
+  const output = await new Response(result.stdout).text();
   const stderr = await new Response(result.stderr).text();
 
-  if (!text.trim()) {
-    if (stderr.includes("No module named")) {
-      throw new Error("PDF conversion requires PyMuPDF. Install with: pip3 install PyMuPDF");
-    }
-    throw new Error(`Conversion failed: ${stderr}`);
+  if (!output.trim() && stderr.includes("No module named")) {
+    throw new Error("PDF conversion requires PyMuPDF. Install with: pip3 install PyMuPDF");
   }
 
-  await writeFile(mdPath, text);
   console.log(`Converted to ${mdPath}`);
   return mdPath;
 }
 
-async function readPaper(paperId: string, maxChars = 5000, format?: "text" | "markdown", withPages = false): Promise<void> {
-  const text = await readPaperContent(paperId, format, withPages);
+async function readPaper(paperId: string, maxChars = 5000, format?: "text" | "markdown"): Promise<void> {
+  const text = await readPaperContent(paperId, format);
 
   if (text === null) {
     console.log(`Paper ${paperId} not found. Download it first:`);
@@ -395,22 +356,12 @@ async function mcpListPapers() {
   return { content: [{ type: "text", text: JSON.stringify(papers, null, 2) }] };
 }
 
-async function mcpReadPaper(args: { paper_id: string; format?: "text" | "markdown" }) {
-  const format = args.format || "text";
-  const text = await readPaperContent(args.paper_id, format);
+async function mcpReadPaper(args: { paper_id: string }) {
+  const text = await readPaperContent(args.paper_id);
   if (text === null) {
     return { content: [{ type: "text", text: `Paper ${args.paper_id} not found. Download it first.` }], isError: true };
   }
   return { content: [{ type: "text", text }] };
-}
-
-async function mcpConvertPaper(args: { paper_id: string }) {
-  try {
-    const path = await convertToMarkdown(args.paper_id);
-    return { content: [{ type: "text", text: JSON.stringify({ success: true, paper_id: args.paper_id, markdown_path: path }) }] };
-  } catch (error) {
-    return { content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
-  }
 }
 
 async function main() {
@@ -422,8 +373,6 @@ async function main() {
       from: { type: "string" },
       categories: { type: "string" },
       json: { type: "boolean" },
-      format: { type: "string" },
-      pages: { type: "boolean" },
       help: { type: "boolean", short: "h" }
     }
   });
@@ -435,8 +384,7 @@ async function main() {
     "search_papers": "search",
     "download_paper": "download",
     "list_papers": "list",
-    "read_paper": "read",
-    "convert_paper": "convert"
+    "read_paper": "read"
   };
   const normalizedCommand = commandMap[command] || command;
 
@@ -452,29 +400,28 @@ Commands:
   search_papers <query>       MCP alias for search
   download <paper-id>         Download a paper by arXiv ID
   download_paper <paper-id>   MCP alias for download
-  convert <paper-id>          Convert PDF to Markdown (PyMuPDF)
-  convert_paper <paper-id>    MCP alias for convert
   list                        List all downloaded papers
   list_papers                 MCP alias for list
   read <paper-id>             Read content of a downloaded paper
   read_paper <paper-id>       MCP alias for read
+  convert <paper-id>          Convert PDF to Markdown (best for citations)
   mcp <tool> <args>           Execute MCP tool directly (JSON I/O)
 
 Options:
   --max <n>            Max results (default: 10, max: 50)
   --from <date>        Date filter (YYYY-MM-DD format)
   --categories <cats>  Comma-separated arXiv categories
-  --format <fmt>       Read format: auto (default, markdown if available, else text), text, or markdown
-  --pages              Include page markers when reading
   --json               Output as JSON (for programmatic use)
   -h, --help           Show this help
 
 Examples:
   bun arxiv.ts search "transformer architecture" --max 5
+  bun arxiv.ts search_papers "quantum" --categories cs.AI,quant-ph
   bun arxiv.ts download 2401.12345
+  bun arxiv.ts download_paper 2401.12345
+  bun arxiv.ts list --json
   bun arxiv.ts convert 2401.12345
-  bun arxiv.ts read 2401.12345 --format markdown
-  bun arxiv.ts read 2401.12345 --pages
+  bun arxiv.ts read 2401.12345
   bun arxiv.ts mcp search_papers '{"query": "AI", "max_results": 5}'
 
 Prompt:
@@ -504,9 +451,6 @@ Prompt:
       case "read_paper":
         result = await mcpReadPaper(args);
         break;
-      case "convert_paper":
-        result = await mcpConvertPaper(args);
-        break;
       default:
         console.error(`Unknown MCP tool: ${toolName}`);
         process.exit(1);
@@ -518,7 +462,8 @@ Prompt:
   if (normalizedCommand === "deep-paper-analysis") {
     if (!arg) {
       console.error("Error: Paper ID required for deep analysis");
-      console.exit(1);
+      console.error("  bun arxiv.ts deep-paper-analysis <paper-id>");
+      process.exit(1);
     }
 
     const paperId = arg.replace(/^arxiv:/, "").trim();
@@ -526,9 +471,9 @@ Prompt:
 
     console.log("Step 1: Checking downloaded papers...");
     const papers = await listPapers(true);
-    const exists = papers.some(p => p.id === paperId);
+    const paperExists = papers.some(p => p.id === paperId);
 
-    if (!exists) {
+    if (!paperExists) {
       console.log(`Step 2: Downloading paper ${paperId}...`);
       try {
         await downloadPaper(paperId, true);
@@ -551,8 +496,16 @@ Prompt:
       console.log(`Summary: ${metadata.summary.slice(0, 300)}...\n`);
     }
 
-    console.log("Step 4: Reading paper content...");
-    const content = await readPaperContent(paperId, (values.format as any) || "text");
+    console.log("Step 4: Converting to Markdown (if needed)...");
+    try {
+      await convertToMarkdown(paperId);
+      console.log("Markdown ready.\n");
+    } catch {
+      console.log("PDF text extraction will be used.\n");
+    }
+
+    console.log("Step 5: Reading paper content...");
+    const content = await readPaperContent(paperId);
     if (content === null) {
       console.error("Failed to read paper content.");
       process.exit(1);
@@ -616,19 +569,6 @@ Prompt:
         break;
       }
 
-      case "convert":
-      case "convert_paper": {
-        if (!arg) {
-          console.error("Error: Paper ID required");
-          process.exit(1);
-        }
-        const mdPath = await convertToMarkdown(arg);
-        if (values.json) {
-          console.log(JSON.stringify({ success: true, paper_id: arg, markdown_path: mdPath }));
-        }
-        break;
-      }
-
       case "list":
       case "list_papers": {
         if (values.json) {
@@ -646,18 +586,26 @@ Prompt:
           console.error("Error: Paper ID required");
           process.exit(1);
         }
-        // Auto-detect format if not specified
-        const format = values.format as "text" | "markdown" | undefined;
         if (values.json) {
-          const text = await readPaperContent(arg, format, values.pages);
+          const text = await readPaperContent(arg);
           if (text === null) {
             console.log(JSON.stringify({ error: "Paper not found", paper_id: arg }));
             process.exit(1);
           }
-          console.log(JSON.stringify({ paper_id: arg, format: format || "auto", content: text }));
+          console.log(JSON.stringify({ paper_id: arg, content: text }));
         } else {
-          await readPaper(arg, 5000, format, values.pages);
+          await readPaper(arg);
         }
+        break;
+      }
+
+      case "convert": {
+        if (!arg) {
+          console.error("Error: Paper ID required");
+          console.error("  bun arxiv.ts convert <paper-id>");
+          process.exit(1);
+        }
+        await convertToMarkdown(arg);
         break;
       }
 

--- a/Community/arxiv-research/scripts/convert_to_markdown.py
+++ b/Community/arxiv-research/scripts/convert_to_markdown.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+PDF to Markdown conversion using PyMuPDF (best quality).
+Called by arxiv.ts for convert command.
+"""
+
+import sys
+
+def convert_to_markdown(pdf_path: str, md_path: str) -> str:
+    try:
+        import fitz  # PyMuPDF
+        
+        # Try pymupdf4llm first (best quality)
+        try:
+            from pymupdf4llm import to_markdown
+            md = to_markdown(pdf_path)
+        except ImportError:
+            # Fallback: basic PyMuPDF
+            doc = fitz.open(pdf_path)
+            md = ""
+            for page_num in range(len(doc)):
+                page = doc[page_num]
+                md += f"\n\n--- Page {page_num + 1} ---\n\n"
+                md += page.get_text()
+            doc.close()
+    except ImportError:
+        raise ImportError("PyMuPDF not installed. Run: pip3 install PyMuPDF")
+    
+    with open(md_path, "w") as f:
+        f.write(md)
+    
+    return md
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: convert_to_markdown.py <pdf_path> <md_path>", file=sys.stderr)
+        sys.exit(1)
+    
+    pdf_path = sys.argv[1]
+    md_path = sys.argv[2]
+    convert_to_markdown(pdf_path, md_path)

--- a/Community/arxiv-research/scripts/extract_text.py
+++ b/Community/arxiv-research/scripts/extract_text.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+PDF text extraction fallback using PyPDF2.
+Called by arxiv.ts when pdftotext is not available.
+"""
+
+import sys
+from PyPDF2 import PdfReader
+
+def extract_text(pdf_path: str, with_page_markers: bool = False) -> str:
+    reader = PdfReader(pdf_path)
+    text = ""
+    for i, page in enumerate(reader.pages, 1):
+        if with_page_markers:
+            text += f"\n--- Page {i} ---\n"
+        page_text = page.extract_text()
+        if page_text:
+            text += page_text + "\n"
+    return text
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: extract_text.py <pdf_path> [with_page_markers]", file=sys.stderr)
+        sys.exit(1)
+    
+    pdf_path = sys.argv[1]
+    with_markers = len(sys.argv) > 2 and sys.argv[2].lower() == "true"
+    
+    print(extract_text(pdf_path, with_markers))


### PR DESCRIPTION
ArXiv paper research tools for Zo Computer.

Implements the same functionality as [arxiv-mcp-server](https://github.com/blazickjp/arxiv-mcp-server) — but as a native Zo skill instead of an MCP server. Both tools use arXiv's public API (`export.arxiv.org`).

## Why a native skill?
- MCP servers require running a separate Python process with JSON-RPC communication overhead
- Zo skills run natively with Bun/TypeScript — no extra processes, no protocol translation
- Same storage path (`~/.arxiv-mcp-server/papers/`), same results, zero additional setup

## Features
- `search_papers`: Search arXiv with date/category filters
- `download_paper`: Download papers by ID
- `convert_paper`: PDF → Markdown with page markers for citations
- `list_papers`: List downloaded papers with [MD] indicator
- `read_paper`: Auto-detects format (markdown if available, else text)
- `deep-paper-analysis`: One-command analysis workflow

## Usage
```bash
bun arxiv.ts search "transformer architecture" --max 5
bun arxiv.ts download 2401.12345
bun arxiv.ts convert 2401.12345  # Creates markdown
bun arxiv.ts read 2401.12345     # Reads markdown if converted
```