### PR TITLE
Add minecraft-server skill

### DIFF
--- a/Community/minecraft-server/SKILL.md
+++ b/Community/minecraft-server/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: minecraft-server
+description: Set up, configure, and manage a Minecraft Java Edition server on Zo Computer. Use when the user wants to run a Minecraft server, change server settings, manage whitelists/ops, or check server status.
+compatibility: Created for Zo Computer
+metadata:
+  author: hatsunemiku.zo.computer
+---
+# Minecraft Server Skill
+
+Sets up and manages a Minecraft Java Edition server as a persistent Zo user service.
+
+## Setup
+
+Setup is a two-step process:
+
+### Step 1: Run the setup script
+
+```bash
+bash Skills/minecraft-server/scripts/minecraft.sh setup
+```
+
+This will:
+
+1. Detect the required Java version for the latest Minecraft release
+2. Install the correct Java via Adoptium (if not already installed or too old)
+3. Create `/home/workspace/minecraft-server/` with the latest Minecraft server JAR
+4. Accept the EULA
+5. Generate a default `server.properties`
+6. Create the `start.sh` wrapper with JVM flags tuned to the system's available RAM
+
+### Step 2: Register as a Zo user service
+
+After the setup script completes, you MUST register a persistent Zo user service using the `register_user_service` tool:
+
+```markdown
+register_user_service(
+  label="minecraft-server",
+  protocol="tcp",
+  local_port=25565,
+  entrypoint="bash /home/workspace/minecraft-server/start.sh",
+  workdir="/home/workspace/minecraft-server"
+)
+```
+
+This creates a **TCP service** (not a proxy link) that:
+
+- Persists across Zo reboots
+- Auto-restarts on crash via supervisor
+- Has a stable `tcp_addr` (e.g. `ts4.zocomputer.io:10578`) for players to connect to
+
+After registration, share the `tcp_addr` from the service response with players — that's the Minecraft server address.
+
+### If the service already exists
+
+Check with `list_user_services`. If a `minecraft-server` service is already registered, skip registration. Use `update_user_service(service_id=...)` to restart it if the entrypoint or config changed.
+
+### Post-setup recommendations
+
+After the server is running, recommend these steps to the user and offer to execute them for the user:
+
+1. **Enable whitelist** for security (especially important with `online-mode=false`):
+
+   ```bash
+   bash Skills/minecraft-server/scripts/minecraft.sh set white-list true
+   bash Skills/minecraft-server/scripts/minecraft.sh whitelist <their-username>
+   bash Skills/minecraft-server/scripts/minecraft.sh restart
+   ```
+
+2. **Op themselves** so they have admin commands in-game:
+
+   ```bash
+   bash Skills/minecraft-server/scripts/minecraft.sh op <their-username>
+   ```
+
+3. **Create an initial backup** once the world generates and they've verified it works.
+
+## Commands
+
+All commands are run via the management script:
+
+```bash
+bash Skills/minecraft-server/scripts/minecraft.sh <command>
+```
+
+| Command | Description |
+| --- | --- |
+| `setup` | Full first-time setup (Java, JAR, EULA, start script) |
+| `status` | Check if the server is running and show connection info |
+| `logs` | Show recent server logs |
+| `properties` | Print current server.properties |
+| `set <key> <value>` | Change a server.properties value (e.g. `set difficulty hard`) |
+| `whitelist <player>` | Add a player to the whitelist |
+| `op <player>` | Give a player operator privileges |
+| `restart` | Restart the server (kills process, supervisor auto-restarts) |
+| `backup` | Create a backup of the world in minecraft-server/backups/ |
+| `update` | Download the latest server JAR and restart |
+
+## Configuration
+
+Edit `/home/workspace/minecraft-server/server.properties` directly or use the `set` command.
+
+Common settings:
+
+- `difficulty` — peaceful, easy, normal, hard
+- `gamemode` — survival, creative, adventure, spectator
+- `max-players` — default 20
+- `motd` — server message shown in the server list
+- `white-list` — true/false to enforce whitelist
+- `pvp` — true/false
+- `view-distance` — chunk render distance (default 10)
+- `level-seed` — world seed
+
+After changing properties, run `restart` to apply.
+
+## File Locations
+
+- Server directory: `/home/workspace/minecraft-server/`
+- Server JAR: `/home/workspace/minecraft-server/server.jar`
+- World data: `/home/workspace/minecraft-server/world/`
+- Properties: `/home/workspace/minecraft-server/server.properties`
+- Backups: `/home/workspace/minecraft-server/backups/`
+- Start script: `/home/workspace/minecraft-server/start.sh`
+- Logs: `/dev/shm/minecraft-server.log` and `/dev/shm/minecraft-server_err.log`
+
+## Caveats
+
+### online-mode is set to false
+
+The server defaults to `online-mode=false` to avoid issues with the server IP being blocked from reaching Mojang's session authentication servers (`sessionserver.mojang.com` returns 403). With `online-mode=true`, players might get "Invalid session" errors and cannot connect.
+
+**What this means:**
+
+- The server does NOT verify player identities with Mojang/Microsoft
+- Anyone who knows the server address can join with any username
+- Player UUIDs are offline-mode UUIDs (different from their Mojang UUIDs)
+
+**Mitigation:** Always enable the whitelist (`white-list=true`) and only add trusted players. This is the primary access control when online-mode is off.
+
+**Offline UUIDs:** Because `online-mode=false`, the server uses offline UUIDs instead of Mojang UUIDs. Entries in `whitelist.json` and `ops.json` **must** include the correct offline UUID or the server will reject players even if their name is listed. The offline UUID is computed as `UUID v3(MD5("OfflinePlayer:" + username))`. The `whitelist` and `op` commands in the management script generate these automatically — but if you ever edit these JSON files by hand, you must include the UUID. Example entry:
+
+```json
+{"uuid": "87c5c7bc-81a1-30a4-81c3-7d1746521b14", "name": "PlayerName"}
+```
+
+### Java version auto-detection
+
+The setup and update commands auto-detect the Java version required by the latest Minecraft release and install it via Adoptium. Minecraft's Java requirements have been increasing rapidly (Java 21 → 25 in recent versions). If Adoptium hasn't packaged a new major Java version yet, the setup will fail — in that case, pin to the latest supported MC version manually.
+
+### Server port
+
+The server binds to the `PORT` environment variable injected by Zo's service manager, not necessarily port 25565 locally. The external-facing address and port are provided by the TCP service's `tcp_addr` — that's what players use.
+
+## Notes
+
+- The server MUST be registered as a Zo user service (TCP protocol) — not a proxy link. This ensures persistence, auto-restart, and a stable address.
+- Players connect using the `tcp_addr` from the registered service.
+- Heap size is auto-detected based on available RAM:
+  - <2GB RAM: 512MB max heap (tight — small player count, reduced view distance)
+  - 2-4GB: 1GB max heap
+  - 4-8GB: 2GB max heap
+  - 8-16GB: 4GB max heap
+  - 16GB+: 8GB max heap
+  - View distance is also scaled down on low-RAM systems (6 chunks at <2GB vs 12 at 8GB+)
+  - The generated `start.sh` bakes in the heap values at setup time. Re-run `setup` after a hardware change to recalculate, or edit `start.sh` manually.
+- The restart command kills the Java process; the supervisor automatically restarts it.
+- **Free plan compatibility:** The skill works on free-tier Zo plans with reduced RAM. The server will run but with lower heap and view distance, which means fewer concurrent players and shorter render range. For a playable experience with 1-3 players, even 512MB-1GB heap is viable. It is recommended to upgrade the plan though otherwise.

--- a/Community/minecraft-server/scripts/minecraft.sh
+++ b/Community/minecraft-server/scripts/minecraft.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVER_DIR="/home/workspace/minecraft-server"
+JAR_PATH="$SERVER_DIR/server.jar"
+BACKUP_DIR="$SERVER_DIR/backups"
+SERVICE_LABEL="minecraft-server"
+SERVICE_PORT=25565
+LOG_FILE="/dev/shm/${SERVICE_LABEL}.log"
+ERR_LOG="/dev/shm/${SERVICE_LABEL}_err.log"
+
+MANIFEST_URL="https://launchermeta.mojang.com/mc/game/version_manifest_v2.json"
+
+get_latest_server_info() {
+    curl -fsSL "$MANIFEST_URL" | python3 -c "
+import sys, json, urllib.request
+d = json.load(sys.stdin)
+for v in d['versions']:
+    if v['type'] != 'release':
+        continue
+    meta = json.loads(urllib.request.urlopen(v['url']).read())
+    java_ver = meta.get('javaVersion', {}).get('majorVersion', 0)
+    print(meta['downloads']['server']['url'])
+    print(v['id'])
+    print(java_ver)
+    break
+"
+}
+
+cmd_setup() {
+    echo "=== Minecraft Server Setup ==="
+
+    # 1. Find latest MC version to determine required Java
+    echo "[1/7] Finding latest Minecraft server..."
+    local info server_url mc_version required_java
+    info=$(get_latest_server_info)
+    server_url=$(echo "$info" | sed -n '1p')
+    mc_version=$(echo "$info" | sed -n '2p')
+    required_java=$(echo "$info" | sed -n '3p')
+    echo "    Latest version: $mc_version (requires Java $required_java)"
+
+    # 2. Install required Java via Adoptium
+    local current_java=0
+    if command -v java &>/dev/null; then
+        current_java=$(java -version 2>&1 | grep -oP '(?<=version ")(\d+)' | head -1 || echo "0")
+        current_java=${current_java//[^0-9]/}
+        : "${current_java:=0}"
+    fi
+    if [ "$current_java" -lt "$required_java" ]; then
+        echo "[2/7] Installing Java $required_java (Adoptium Temurin)..."
+        if [ ! -f /usr/share/keyrings/adoptium.gpg ]; then
+            curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor -o /usr/share/keyrings/adoptium.gpg 2>/dev/null
+            echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb bookworm main" > /etc/apt/sources.list.d/adoptium.list
+            apt-get update -qq
+        fi
+        apt-get install -y -qq "temurin-${required_java}-jre" 2>&1 | tail -1
+    else
+        echo "[2/7] Java $current_java already installed (>= $required_java): $(java -version 2>&1 | head -1)"
+    fi
+
+    # 3. Create server directory
+    echo "[3/7] Creating server directory..."
+    mkdir -p "$SERVER_DIR" "$BACKUP_DIR"
+
+    # 4. Download server JAR
+    echo "[4/7] Downloading Minecraft $mc_version server..."
+    curl -fsSL -o "$JAR_PATH" "$server_url"
+    echo "    Downloaded to $JAR_PATH"
+
+    # 5. Accept EULA
+    echo "[5/7] Accepting EULA..."
+    echo "eula=true" > "$SERVER_DIR/eula.txt"
+
+    # 6. Detect available RAM and compute heap sizes
+    local total_mb max_heap min_heap view_dist
+    total_mb=$(awk '/MemTotal/ {print int($2/1024)}' /proc/meminfo)
+    if [ "$total_mb" -lt 2048 ]; then
+        max_heap="512M"; min_heap="256M"; view_dist=6
+    elif [ "$total_mb" -lt 4096 ]; then
+        max_heap="1G"; min_heap="512M"; view_dist=8
+    elif [ "$total_mb" -lt 8192 ]; then
+        max_heap="2G"; min_heap="1G"; view_dist=10
+    elif [ "$total_mb" -lt 16384 ]; then
+        max_heap="4G"; min_heap="2G"; view_dist=12
+    else
+        max_heap="8G"; min_heap="4G"; view_dist=12
+    fi
+    echo "[6/7] Detected ${total_mb}MB RAM → heap: ${min_heap}-${max_heap}, view-distance: ${view_dist}"
+
+    # 7. Generate default server.properties if missing
+    if [ ! -f "$SERVER_DIR/server.properties" ]; then
+        echo "[7/7] Generating default server.properties..."
+        local zo_handle="${ZO_USER:-zo}"
+        cat > "$SERVER_DIR/server.properties" << PROPS
+server-port=25565
+motd=\\u00A7b\\u00A7lZo Minecraft Server \\u00A7r\\u00A77| ${zo_handle}
+difficulty=normal
+gamemode=survival
+max-players=20
+view-distance=${view_dist}
+simulation-distance=$((view_dist > 8 ? 10 : view_dist - 2))
+white-list=false
+pvp=true
+enable-command-block=true
+spawn-protection=0
+online-mode=false
+PROPS
+    else
+        echo "[7/7] server.properties already exists, keeping existing config."
+    fi
+
+    # Create the startup wrapper script
+    cat > "$SERVER_DIR/start.sh" << STARTUP
+#!/usr/bin/env bash
+cd /home/workspace/minecraft-server
+
+# Sync server-port in server.properties to match the PORT env var from Zo's service manager.
+# The --port CLI flag is unreliable in newer MC versions, so we set it in properties directly.
+MC_PORT="\${PORT:-25565}"
+if [ -f server.properties ]; then
+    if grep -q "^server-port=" server.properties; then
+        sed -i "s/^server-port=.*/server-port=\${MC_PORT}/" server.properties
+    else
+        echo "server-port=\${MC_PORT}" >> server.properties
+    fi
+fi
+
+exec java -Xmx${max_heap} -Xms${min_heap} \\
+  -XX:+UseG1GC \\
+  -XX:+ParallelRefProcEnabled \\
+  -XX:MaxGCPauseMillis=200 \\
+  -XX:+UnlockExperimentalVMOptions \\
+  -XX:+DisableExplicitGC \\
+  -XX:G1NewSizePercent=30 \\
+  -XX:G1MaxNewSizePercent=40 \\
+  -XX:G1HeapRegionSize=8M \\
+  -XX:G1ReservePercent=20 \\
+  -XX:G1MixedGCCountTarget=4 \\
+  -XX:InitiatingHeapOccupancyPercent=15 \\
+  -XX:G1MixedGCLiveThresholdPercent=90 \\
+  -XX:SurvivorRatio=32 \\
+  -XX:MaxTenuringThreshold=1 \\
+  -jar server.jar --nogui
+STARTUP
+    chmod +x "$SERVER_DIR/start.sh"
+
+    echo ""
+    echo "=== Setup Complete ==="
+    echo "Server directory: $SERVER_DIR"
+    echo "Server JAR: $JAR_PATH"
+    echo "Minecraft version: $mc_version"
+    echo ""
+    echo "=== SERVICE REGISTRATION REQUIRED ==="
+    echo "Register as a Zo user service with these parameters:"
+    echo "  label: minecraft-server"
+    echo "  protocol: tcp"
+    echo "  local_port: 25565"
+    echo "  entrypoint: bash /home/workspace/minecraft-server/start.sh"
+    echo "  workdir: /home/workspace/minecraft-server"
+    echo ""
+    echo "Use the register_user_service tool to create the service."
+    echo "The server will auto-start, persist across reboots, and restart on crash."
+}
+
+cmd_status() {
+    echo "=== Minecraft Server Status ==="
+    if pgrep -f "server.jar" > /dev/null 2>&1; then
+        echo "Status: RUNNING"
+        echo "PID: $(pgrep -f 'server.jar')"
+        echo "Uptime: $(ps -o etime= -p "$(pgrep -f 'server.jar' | head -1)" 2>/dev/null || echo 'unknown')"
+    else
+        echo "Status: STOPPED"
+    fi
+    echo ""
+    if [ -f "$SERVER_DIR/server.properties" ]; then
+        local motd difficulty gamemode max_players
+        motd=$(grep "^motd=" "$SERVER_DIR/server.properties" | cut -d= -f2-)
+        difficulty=$(grep "^difficulty=" "$SERVER_DIR/server.properties" | cut -d= -f2-)
+        gamemode=$(grep "^gamemode=" "$SERVER_DIR/server.properties" | cut -d= -f2-)
+        max_players=$(grep "^max-players=" "$SERVER_DIR/server.properties" | cut -d= -f2-)
+        echo "MOTD: $motd"
+        echo "Difficulty: $difficulty"
+        echo "Gamemode: $gamemode"
+        echo "Max Players: $max_players"
+    fi
+}
+
+cmd_logs() {
+    echo "=== Recent Server Logs ==="
+    if [ -f "$LOG_FILE" ]; then
+        tail -50 "$LOG_FILE"
+    else
+        echo "No log file found at $LOG_FILE"
+    fi
+    if [ -f "$ERR_LOG" ] && [ -s "$ERR_LOG" ]; then
+        echo ""
+        echo "=== Recent Errors ==="
+        tail -20 "$ERR_LOG"
+    fi
+}
+
+cmd_properties() {
+    if [ -f "$SERVER_DIR/server.properties" ]; then
+        cat "$SERVER_DIR/server.properties"
+    else
+        echo "server.properties not found. Run setup first."
+        exit 1
+    fi
+}
+
+cmd_set() {
+    local key="$1" value="$2"
+    if [ -z "$key" ] || [ -z "$value" ]; then
+        echo "Usage: minecraft.sh set <key> <value>"
+        exit 1
+    fi
+    local props="$SERVER_DIR/server.properties"
+    if grep -q "^${key}=" "$props" 2>/dev/null; then
+        sed -i "s|^${key}=.*|${key}=${value}|" "$props"
+        echo "Updated: ${key}=${value}"
+    else
+        echo "${key}=${value}" >> "$props"
+        echo "Added: ${key}=${value}"
+    fi
+    echo "Restart the server to apply changes."
+}
+
+cmd_whitelist() {
+    local player="$1"
+    if [ -z "$player" ]; then
+        echo "Usage: minecraft.sh whitelist <player>"
+        exit 1
+    fi
+    local wl="$SERVER_DIR/whitelist.json"
+    if [ ! -f "$wl" ]; then
+        echo "[]" > "$wl"
+    fi
+    python3 -c "
+import json, uuid, hashlib
+def offline_uuid(name):
+    return str(uuid.UUID(bytes=hashlib.md5(('OfflinePlayer:' + name).encode()).digest()[:16], version=3))
+with open('$wl') as f:
+    wl = json.load(f)
+if not any(e['name'] == '$player' for e in wl):
+    wl.append({'uuid': offline_uuid('$player'), 'name': '$player'})
+    with open('$wl', 'w') as f:
+        json.dump(wl, f, indent=2)
+    print('Added $player to whitelist.')
+else:
+    print('$player is already whitelisted.')
+"
+}
+
+cmd_op() {
+    local player="$1"
+    if [ -z "$player" ]; then
+        echo "Usage: minecraft.sh op <player>"
+        exit 1
+    fi
+    local ops="$SERVER_DIR/ops.json"
+    if [ ! -f "$ops" ]; then
+        echo "[]" > "$ops"
+    fi
+    python3 -c "
+import json, uuid, hashlib
+def offline_uuid(name):
+    return str(uuid.UUID(bytes=hashlib.md5(('OfflinePlayer:' + name).encode()).digest()[:16], version=3))
+with open('$ops') as f:
+    ol = json.load(f)
+if not any(e['name'] == '$player' for e in ol):
+    ol.append({'uuid': offline_uuid('$player'), 'name': '$player', 'level': 4, 'bypassesPlayerLimit': True})
+    with open('$ops', 'w') as f:
+        json.dump(ol, f, indent=2)
+    print('Added $player as operator (level 4).')
+else:
+    print('$player is already an operator.')
+"
+}
+
+cmd_restart() {
+    echo "Restarting Minecraft server..."
+    local pid
+    pid=$(pgrep -f "server.jar" 2>/dev/null || true)
+    if [ -n "$pid" ]; then
+        kill "$pid" 2>/dev/null || true
+        echo "Killed server process (PID $pid). Supervisor will auto-restart it."
+        sleep 2
+        local new_pid
+        new_pid=$(pgrep -f "server.jar" 2>/dev/null || true)
+        if [ -n "$new_pid" ]; then
+            echo "Server restarted (new PID $new_pid)."
+        else
+            echo "Waiting for supervisor to restart..."
+            sleep 5
+            new_pid=$(pgrep -f "server.jar" 2>/dev/null || true)
+            if [ -n "$new_pid" ]; then
+                echo "Server restarted (new PID $new_pid)."
+            else
+                echo "Server not yet restarted. Check logs with: minecraft.sh logs"
+            fi
+        fi
+    else
+        echo "Server is not running. Check service status."
+    fi
+}
+
+cmd_backup() {
+    if [ ! -d "$SERVER_DIR/world" ]; then
+        echo "No world directory found. Has the server been started?"
+        exit 1
+    fi
+    local timestamp
+    timestamp=$(date +%Y%m%d-%H%M%S)
+    local backup_file="$BACKUP_DIR/world-${timestamp}.tar.gz"
+    echo "Creating backup..."
+    tar -czf "$backup_file" -C "$SERVER_DIR" world
+    local size
+    size=$(du -h "$backup_file" | cut -f1)
+    echo "Backup created: $backup_file ($size)"
+}
+
+cmd_update() {
+    echo "Finding latest Minecraft server..."
+    local info server_url mc_version required_java
+    info=$(get_latest_server_info)
+    server_url=$(echo "$info" | sed -n '1p')
+    mc_version=$(echo "$info" | sed -n '2p')
+    required_java=$(echo "$info" | sed -n '3p')
+    echo "Version: $mc_version (requires Java $required_java)"
+
+    local current_java
+    current_java=$(java -version 2>&1 | head -1 | grep -oP '\d+' | head -1 || echo "0")
+    if [ "$current_java" -lt "$required_java" ]; then
+        echo "Upgrading Java to $required_java..."
+        apt-get install -y -qq "temurin-${required_java}-jre" 2>&1 | tail -1
+    fi
+
+    curl -fsSL -o "$JAR_PATH" "$server_url"
+    echo "Updated server.jar to $mc_version"
+    echo "Restart the server to use the new version."
+}
+
+# Main dispatch
+case "${1:-help}" in
+    setup)      cmd_setup ;;
+    status)     cmd_status ;;
+    logs)       cmd_logs ;;
+    properties) cmd_properties ;;
+    set)        cmd_set "${2:-}" "${3:-}" ;;
+    whitelist)  cmd_whitelist "${2:-}" ;;
+    op)         cmd_op "${2:-}" ;;
+    restart)    cmd_restart ;;
+    backup)     cmd_backup ;;
+    update)     cmd_update ;;
+    help|*)
+        echo "Minecraft Server Management"
+        echo ""
+        echo "Usage: minecraft.sh <command> [args]"
+        echo ""
+        echo "Commands:"
+        echo "  setup              Full first-time setup"
+        echo "  status             Check server status"
+        echo "  logs               Show recent logs"
+        echo "  properties         Show server.properties"
+        echo "  set <key> <value>  Change a server property"
+        echo "  whitelist <player> Add player to whitelist"
+        echo "  op <player>        Make player an operator"
+        echo "  restart            Restart the server"
+        echo "  backup             Backup the world"
+        echo "  update             Download latest server JAR"
+        echo "  help               Show this help"
+        ;;
+esac

--- a/manifest.json
+++ b/manifest.json
@@ -280,7 +280,7 @@
         "author": "va.zo.computer",
         "category": "Community",
         "display-name": "Claude Code Window Primer",
-        "emoji": "⏰"
+        "emoji": "\u23f0"
       },
       "slug": "claude-code-window-primer",
       "path": "Community/claude-code-window-primer",
@@ -315,7 +315,7 @@
         "author": "rc2.zo.computer",
         "category": "Community",
         "display-name": "Tweetscape Narrator",
-        "emoji": "🎬"
+        "emoji": "\ud83c\udfac"
       },
       "slug": "tweetscape-narrator",
       "path": "Community/tweetscape-narrator",
@@ -351,7 +351,7 @@
         "author": "0.zo.computer",
         "category": "Community",
         "display-name": "Post to X (Twitter)",
-        "emoji": "🐦"
+        "emoji": "\ud83d\udc26"
       },
       "slug": "twitter-api",
       "path": "Community/twitter-api",
@@ -364,7 +364,7 @@
         "author": "Zo",
         "category": "Community",
         "display-name": "Texting positive affirmations daily",
-        "emoji": "✨"
+        "emoji": "\u2728"
       },
       "slug": "daily-affirmations",
       "path": "Community/daily-affirmations",
@@ -377,7 +377,7 @@
         "author": "tiff.zo.computer",
         "category": "Community",
         "display-name": "Create ideal dating profile",
-        "emoji": "💌"
+        "emoji": "\ud83d\udc8c"
       },
       "slug": "dating-profile",
       "path": "Community/dating-profile",
@@ -390,7 +390,7 @@
         "author": "0.zo.computer",
         "category": "Community",
         "display-name": "Find recent Craigslist missed connections",
-        "emoji": "💕"
+        "emoji": "\ud83d\udc95"
       },
       "slug": "find-missed-connections",
       "path": "Community/find-missed-connections",
@@ -403,7 +403,7 @@
         "author": "hatsunemiku.zo.computer",
         "category": "Community",
         "display-name": "Generate QR code with optional image",
-        "emoji": "📱"
+        "emoji": "\ud83d\udcf1"
       },
       "slug": "generate-custom-qr-code",
       "path": "Community/generate-custom-qr-code",
@@ -416,7 +416,7 @@
       "metadata": {
         "author": "rob.zo.computer",
         "category": "Community",
-        "emoji": "🅖"
+        "emoji": "\ud83c\udd56"
       },
       "slug": "google-calendar",
       "path": "Community/google-calendar",
@@ -429,7 +429,7 @@
         "author": "rob.zo.computer",
         "category": "Community",
         "display-name": "Genome Analysis",
-        "emoji": "🧬"
+        "emoji": "\ud83e\uddec"
       },
       "slug": "personal-genomics-analysis",
       "path": "Community/personal-genomics-analysis",
@@ -442,7 +442,7 @@
         "author": "ian.zo.computer",
         "category": "Community",
         "display-name": "Create Spotify playlist from Pitchfork Best New Tracks",
-        "emoji": "🎵"
+        "emoji": "\ud83c\udfb5"
       },
       "slug": "pitchfork-best-tracks",
       "path": "Community/pitchfork-best-tracks",
@@ -455,7 +455,7 @@
         "author": "0.zo.computer",
         "category": "Community",
         "display-name": "Plan code changes",
-        "emoji": "🧑🏻‍💻"
+        "emoji": "\ud83e\uddd1\ud83c\udffb\u200d\ud83d\udcbb"
       },
       "slug": "plan-code-changes",
       "path": "Community/plan-code-changes",
@@ -468,7 +468,7 @@
         "author": "hatsunemiku.zo.computer",
         "category": "Community",
         "display-name": "Plant Care Plan",
-        "emoji": "🪴"
+        "emoji": "\ud83e\udeb4"
       },
       "slug": "plant-care-plan",
       "path": "Community/plant-care-plan",
@@ -481,7 +481,7 @@
         "author": "rob.zo.computer",
         "category": "Community",
         "display-name": "Set up automated receipt processing system",
-        "emoji": "🧾"
+        "emoji": "\ud83e\uddfe"
       },
       "slug": "receipt-tracker-setup",
       "path": "Community/receipt-tracker-setup",
@@ -494,7 +494,7 @@
         "author": "ian.zo.computer",
         "category": "Community",
         "display-name": "Remove Photo Metadata",
-        "emoji": "🔒"
+        "emoji": "\ud83d\udd12"
       },
       "slug": "remove-photo-metadata",
       "path": "Community/remove-photo-metadata",
@@ -507,7 +507,7 @@
         "author": "0.zo.computer",
         "category": "Community",
         "display-name": "Summarize Hacker News front page",
-        "emoji": "🔶"
+        "emoji": "\ud83d\udd36"
       },
       "slug": "summarize-hacker-news",
       "path": "Community/summarize-hacker-news",
@@ -520,7 +520,7 @@
         "author": "hatsunemiku.zo.computer",
         "category": "Community",
         "display-name": "Create syllabus reminders",
-        "emoji": "🔖"
+        "emoji": "\ud83d\udd16"
       },
       "slug": "syllabus-reminders",
       "path": "Community/syllabus-reminders",
@@ -533,7 +533,7 @@
         "author": "ian.zo.computer",
         "category": "Community",
         "display-name": "Text commute travel time and route",
-        "emoji": "🚏"
+        "emoji": "\ud83d\ude8f"
       },
       "slug": "text-commute-info",
       "path": "Community/text-commute-info",
@@ -546,7 +546,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Automate something",
-        "emoji": "⚙️"
+        "emoji": "\u2699\ufe0f"
       },
       "slug": "zo-automate-something",
       "path": "Official/zo-automate-something",
@@ -559,7 +559,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Create a blog",
-        "emoji": "📝"
+        "emoji": "\ud83d\udcdd"
       },
       "slug": "zo-blog-site",
       "path": "Official/zo-blog-site",
@@ -572,7 +572,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Set up code-server (VS Code in browser)",
-        "emoji": "💻"
+        "emoji": "\ud83d\udcbb"
       },
       "slug": "zo-code-server-setup",
       "path": "Official/zo-code-server-setup",
@@ -585,7 +585,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Create a site",
-        "emoji": "⚡"
+        "emoji": "\u26a1"
       },
       "slug": "zo-create-site",
       "path": "Official/zo-create-site",
@@ -598,7 +598,7 @@
         "author": "rob.zo.computer",
         "category": "Official",
         "display-name": "Create a slide deck",
-        "emoji": "🎞️"
+        "emoji": "\ud83c\udf9e\ufe0f"
       },
       "slug": "zo-create-slidedeck",
       "path": "Official/zo-create-slidedeck",
@@ -611,7 +611,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Daily Linear digest",
-        "emoji": "📋"
+        "emoji": "\ud83d\udccb"
       },
       "slug": "zo-daily-linear-digest",
       "path": "Official/zo-daily-linear-digest",
@@ -624,7 +624,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Daily news digest",
-        "emoji": "📰"
+        "emoji": "\ud83d\udcf0"
       },
       "slug": "zo-daily-news-digest",
       "path": "Official/zo-daily-news-digest",
@@ -637,7 +637,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Enrich CSV with AI-generated columns",
-        "emoji": "📊"
+        "emoji": "\ud83d\udcca"
       },
       "slug": "zo-enrich-csv",
       "path": "Official/zo-enrich-csv",
@@ -650,7 +650,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Convert EPUB to Markdown",
-        "emoji": "📚"
+        "emoji": "\ud83d\udcda"
       },
       "slug": "zo-epub-to-markdown",
       "path": "Official/zo-epub-to-markdown",
@@ -663,7 +663,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Extract Text from Images (OCR)",
-        "emoji": "🔍"
+        "emoji": "\ud83d\udd0d"
       },
       "slug": "zo-extract-text-from-image",
       "path": "Official/zo-extract-text-from-image",
@@ -676,7 +676,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Process file line-by-line with script",
-        "emoji": "🔄"
+        "emoji": "\ud83d\udd04"
       },
       "slug": "zo-for-each-line",
       "path": "Official/zo-for-each-line",
@@ -689,7 +689,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Generate PDF from Markdown",
-        "emoji": "📑"
+        "emoji": "\ud83d\udcd1"
       },
       "slug": "zo-generate-pdf",
       "path": "Official/zo-generate-pdf",
@@ -702,7 +702,7 @@
       "metadata": {
         "author": "Zo",
         "category": "Official",
-        "emoji": "🅖"
+        "emoji": "\ud83c\udd56"
       },
       "slug": "zo-google-direct-oauth",
       "path": "Official/zo-google-direct-oauth",
@@ -715,7 +715,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Set up Grafana for log visualization",
-        "emoji": "📈"
+        "emoji": "\ud83d\udcc8"
       },
       "slug": "zo-grafana-setup",
       "path": "Official/zo-grafana-setup",
@@ -728,7 +728,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Create a guestbook",
-        "emoji": "📖"
+        "emoji": "\ud83d\udcd6"
       },
       "slug": "zo-guestbook-site",
       "path": "Official/zo-guestbook-site",
@@ -741,7 +741,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Text summary of important emails",
-        "emoji": "📧"
+        "emoji": "\ud83d\udce7"
       },
       "slug": "zo-important-email-digest",
       "path": "Official/zo-important-email-digest",
@@ -780,7 +780,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Set up n8n workflow automation",
-        "emoji": "🔗"
+        "emoji": "\ud83d\udd17"
       },
       "slug": "zo-n8n-setup",
       "path": "Official/zo-n8n-setup",
@@ -793,7 +793,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Organize my files",
-        "emoji": "🗂️"
+        "emoji": "\ud83d\uddc2\ufe0f"
       },
       "slug": "zo-organize-workspace",
       "path": "Official/zo-organize-workspace",
@@ -806,7 +806,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Convert PDF to Markdown",
-        "emoji": "📄"
+        "emoji": "\ud83d\udcc4"
       },
       "slug": "zo-pdf-to-markdown",
       "path": "Official/zo-pdf-to-markdown",
@@ -819,7 +819,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Create a portfolio site",
-        "emoji": "🎨"
+        "emoji": "\ud83c\udfa8"
       },
       "slug": "zo-portfolio-site",
       "path": "Official/zo-portfolio-site",
@@ -832,7 +832,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Research a topic",
-        "emoji": "🔬"
+        "emoji": "\ud83d\udd2c"
       },
       "slug": "zo-research-topic",
       "path": "Official/zo-research-topic",
@@ -845,7 +845,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Resize Images",
-        "emoji": "🖼️"
+        "emoji": "\ud83d\uddbc\ufe0f"
       },
       "slug": "zo-resize-image",
       "path": "Official/zo-resize-image",
@@ -858,7 +858,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Set up SSH server for remote access",
-        "emoji": "🔐"
+        "emoji": "\ud83d\udd10"
       },
       "slug": "zo-ssh-setup",
       "path": "Official/zo-ssh-setup",
@@ -884,7 +884,7 @@
         "author": "Zo",
         "category": "Official",
         "display-name": "Weekly meeting reminder",
-        "emoji": "🗓️"
+        "emoji": "\ud83d\uddd3\ufe0f"
       },
       "slug": "zo-weekly-meeting-reminder",
       "path": "Official/zo-weekly-meeting-reminder",
@@ -909,7 +909,7 @@
         "author": "rc2.zo.computer",
         "category": "Community",
         "display-name": "Generate flashcards from a webpage or document",
-        "emoji": "📇"
+        "emoji": "\ud83d\udcc7"
       },
       "slug": "add-flashcards",
       "path": "Community/add-flashcards",
@@ -948,7 +948,7 @@
         "author": "Clawdbot",
         "category": "External",
         "clawdbot": {
-          "emoji": "📰",
+          "emoji": "\ud83d\udcf0",
           "requires": {
             "bins": [
               "blogwatcher"
@@ -1033,7 +1033,7 @@
     },
     {
       "name": "copywriting",
-      "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \"write copy for,\" \"improve this copy,\" \"rewrite this page,\" \"marketing copy,\" \"headline help,\" or \"CTA copy.\" For email copy, see email-sequence. For popup copy, see popup-cro.",
+      "description": "When the user wants to write, rewrite, or improve marketing copy for any page \u2014 including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \"write copy for,\" \"improve this copy,\" \"rewrite this page,\" \"marketing copy,\" \"headline help,\" or \"CTA copy.\" For email copy, see email-sequence. For popup copy, see popup-cro.",
       "metadata": {
         "author": "Coreyhaines31",
         "category": "External",
@@ -1063,7 +1063,7 @@
         "author": "Clawdbot",
         "category": "External",
         "clawdbot": {
-          "emoji": "🎛️",
+          "emoji": "\ud83c\udf9b\ufe0f",
           "requires": {
             "bins": [
               "eightctl"
@@ -1100,7 +1100,7 @@
     },
     {
       "name": "form-cro",
-      "description": "When the user wants to optimize any form that is NOT signup/registration — including lead capture forms, contact forms, demo request forms, application forms, survey forms, or checkout forms. Also use when the user mentions \"form optimization,\" \"lead form conversions,\" \"form friction,\" \"form fields,\" \"form completion rate,\" or \"contact form.\" For signup/registration forms, see signup-flow-cro. For popups containing forms, see popup-cro.",
+      "description": "When the user wants to optimize any form that is NOT signup/registration \u2014 including lead capture forms, contact forms, demo request forms, application forms, survey forms, or checkout forms. Also use when the user mentions \"form optimization,\" \"lead form conversions,\" \"form friction,\" \"form fields,\" \"form completion rate,\" or \"contact form.\" For signup/registration forms, see signup-flow-cro. For popups containing forms, see popup-cro.",
       "metadata": {
         "author": "Coreyhaines31",
         "category": "External"
@@ -1111,7 +1111,7 @@
     },
     {
       "name": "free-tool-strategy",
-      "description": "When the user wants to plan, evaluate, or build a free tool for marketing purposes — lead generation, SEO value, or brand awareness. Also use when the user mentions \"engineering as marketing,\" \"free tool,\" \"marketing tool,\" \"calculator,\" \"generator,\" \"interactive tool,\" \"lead gen tool,\" \"build a tool for leads,\" or \"free resource.\" This skill bridges engineering and marketing — useful for founders and technical marketers.",
+      "description": "When the user wants to plan, evaluate, or build a free tool for marketing purposes \u2014 lead generation, SEO value, or brand awareness. Also use when the user mentions \"engineering as marketing,\" \"free tool,\" \"marketing tool,\" \"calculator,\" \"generator,\" \"interactive tool,\" \"lead gen tool,\" \"build a tool for leads,\" or \"free resource.\" This skill bridges engineering and marketing \u2014 useful for founders and technical marketers.",
       "metadata": {
         "author": "Coreyhaines31",
         "category": "External"
@@ -1140,7 +1140,7 @@
         "author": "Clawdbot",
         "category": "External",
         "clawdbot": {
-          "emoji": "🐙",
+          "emoji": "\ud83d\udc19",
           "requires": {
             "bins": [
               "gh"
@@ -1173,7 +1173,7 @@
         "author": "Clawdbot",
         "category": "External",
         "clawdbot": {
-          "emoji": "🎮",
+          "emoji": "\ud83c\udfae",
           "requires": {
             "bins": [
               "gog"
@@ -1204,7 +1204,7 @@
         "author": "rc2.zo.computer",
         "category": "Community",
         "display-name": "Set up hashcards spaced repetition system",
-        "emoji": "📇"
+        "emoji": "\ud83d\udcc7"
       },
       "slug": "hashcards-setup",
       "path": "Community/hashcards-setup",
@@ -1314,7 +1314,7 @@
         "author": "Clawdbot",
         "category": "External",
         "clawdbot": {
-          "emoji": "📦",
+          "emoji": "\ud83d\udce6",
           "requires": {
             "bins": [
               "mcporter"
@@ -1359,7 +1359,7 @@
         "author": "Clawdbot",
         "category": "External",
         "clawdbot": {
-          "emoji": "📝",
+          "emoji": "\ud83d\udcdd",
           "requires": {
             "env": [
               "NOTION_API_KEY"
@@ -1386,7 +1386,7 @@
     },
     {
       "name": "page-cro",
-      "description": "When the user wants to optimize, improve, or increase conversions on any marketing page — including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says \"CRO,\" \"conversion rate optimization,\" \"this page isn't converting,\" \"improve conversions,\" or \"why isn't this page working.\" For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro.",
+      "description": "When the user wants to optimize, improve, or increase conversions on any marketing page \u2014 including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says \"CRO,\" \"conversion rate optimization,\" \"this page isn't converting,\" \"improve conversions,\" or \"why isn't this page working.\" For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro.",
       "metadata": {
         "author": "Coreyhaines31",
         "category": "External"
@@ -1408,7 +1408,7 @@
     },
     {
       "name": "paywall-upgrade-cro",
-      "description": "When the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use when the user mentions \"paywall,\" \"upgrade screen,\" \"upgrade modal,\" \"upsell,\" \"feature gate,\" \"convert free to paid,\" \"freemium conversion,\" \"trial expiration screen,\" \"limit reached screen,\" \"plan upgrade prompt,\" or \"in-app pricing.\" Distinct from public pricing pages (see page-cro) — this skill focuses on in-product upgrade moments where the user has already experienced value.",
+      "description": "When the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use when the user mentions \"paywall,\" \"upgrade screen,\" \"upgrade modal,\" \"upsell,\" \"feature gate,\" \"convert free to paid,\" \"freemium conversion,\" \"trial expiration screen,\" \"limit reached screen,\" \"plan upgrade prompt,\" or \"in-app pricing.\" Distinct from public pricing pages (see page-cro) \u2014 this skill focuses on in-product upgrade moments where the user has already experienced value.",
       "metadata": {
         "author": "Coreyhaines31",
         "category": "External"
@@ -1724,7 +1724,7 @@
         "author": "Clawdbot",
         "category": "External",
         "clawdbot": {
-          "emoji": "🧵",
+          "emoji": "\ud83e\uddf5",
           "os": [
             "darwin",
             "linux"
@@ -1750,7 +1750,7 @@
         "author": "Clawdbot",
         "category": "External",
         "clawdbot": {
-          "emoji": "📋",
+          "emoji": "\ud83d\udccb",
           "requires": {
             "bins": [
               "jq"
@@ -1776,7 +1776,7 @@
         "author": "Clawdbot",
         "category": "External",
         "clawdbot": {
-          "emoji": "🎞️",
+          "emoji": "\ud83c\udf9e\ufe0f",
           "requires": {
             "bins": [
               "ffmpeg"
@@ -1809,7 +1809,7 @@
         "author": "Clawdbot",
         "category": "External",
         "clawdbot": {
-          "emoji": "🌤️",
+          "emoji": "\ud83c\udf24\ufe0f",
           "requires": {
             "bins": [
               "curl"
@@ -1845,6 +1845,17 @@
       "slug": "webapp-testing",
       "path": "External/webapp-testing",
       "date_added": "2026-01-26"
+    },
+    {
+      "name": "minecraft-server",
+      "description": "Set up, configure, and manage a Minecraft Java Edition server on Zo Computer. Use when the user wants to run a Minecraft server, change server settings, manage whitelists/ops, or check server status.",
+      "compatibility": "Created for Zo Computer",
+      "metadata": {
+        "author": "hatsunemiku.zo.computer"
+      },
+      "slug": "minecraft-server",
+      "path": "Community/minecraft-server",
+      "date_added": "2026-04-03"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a new community skill for setting up and managing a Minecraft Java Edition server on Zo Computer
- Includes a comprehensive bash management script (`scripts/minecraft.sh`) with commands for setup, status, logs, config, whitelist, op, restart, backup, and update
- Auto-detects required Java version from Mojang's manifest and installs via Adoptium
- RAM-aware heap tuning for compatibility from free-tier (~512MB) to large instances (8GB+)
- Handles offline-mode UUID generation for whitelist/ops (server runs `online-mode=false` due to session server blocks)
- Registers as a persistent Zo TCP user service with auto-restart

## Test plan
- [ ] Install skill via registry manifest and verify files land correctly
- [ ] Run `minecraft.sh setup` on a fresh Zo instance
- [ ] Verify Java auto-detection and installation
- [ ] Register as TCP user service and confirm server starts
- [ ] Test whitelist/op commands generate correct offline UUIDs
- [ ] Test backup and update commands
- [ ] Verify heap sizing on different RAM tiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)