### PR TITLE
Add official MoonPay and OKX partner skills

### DIFF
--- a/Official/_shared/preflight.md
+++ b/Official/_shared/preflight.md
@@ -1,0 +1,29 @@
+# OKX CLI Preflight
+
+Execute these steps **once per session**, before running any OKX skill command.
+
+## Step 1 — CLI auto-upgrade (12 h throttle)
+
+```bash
+okx upgrade
+```
+
+This command:
+- Silently skips if the last check was fewer than 12 hours ago
+- Queries `dist-tags.latest` from the npm registry if the cache has expired
+- Installs `@okx_ai/okx-trade-mcp` and `@okx_ai/okx-trade-cli` if a newer stable version is found
+- Updates `~/.okx/last_check` after a successful check
+
+## Step 2 — Skill version drift check
+
+```bash
+okx --version
+```
+
+1. If the output contains a prerelease suffix (e.g. `-beta`, `-alpha`, `-rc`), **skip this step entirely** — the stable release has not yet shipped, so no drift exists.
+2. Otherwise (pure stable version, e.g. `1.2.8`), compare against this skill's `metadata.version` (from the calling SKILL.md frontmatter).
+3. If CLI stable version **>** skill `metadata.version`, show the following warning **once per session**:
+
+   > ⚠️ CLI version is ahead of this skill. Some new commands may not be documented here. Consider refreshing your skill.
+
+4. If already warned this session, skip.

--- a/Official/zo-moonpay-auth/SKILL.md
+++ b/Official/zo-moonpay-auth/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: moonpay-auth
+description: Set up the MoonPay CLI on Zo, authenticate the current user, and create or inspect local wallets. Use when MoonPay commands fail because the user is not logged in, when a wallet is missing, or when a MoonPay flow needs login completed before continuing.
+compatibility: Created for Zo Computer
+metadata:
+  author: Zo
+  category: Official
+  display-name: MoonPay Auth
+---
+
+# MoonPay Auth
+
+Set up MoonPay on Zo so later wallet, buy, swap, or virtual-account flows can run cleanly.
+
+## What Zo Uses
+
+- [Terminal](/?t=terminal) for `mp` CLI commands
+- [Browser](/browser) for any verification or continuation links
+- Optional Gmail connection only if OTP retrieval is explicitly appropriate and available
+
+## Prerequisites
+
+- Node.js and npm available on Zo
+- A MoonPay account email address
+
+## Zo-Native Setup
+
+1. Install the MoonPay CLI in the terminal:
+
+```bash
+npm i -g @moonpay/cli
+```
+
+2. Verify the install:
+
+```bash
+mp --version
+mp --help
+```
+
+3. Check whether the user is already authenticated:
+
+```bash
+mp user retrieve
+```
+
+4. If not authenticated, start login:
+
+```bash
+mp login --email user@example.com
+```
+
+`mp login` generates a sign-in link and attempts to open it in a browser. On Zo, treat that as a Zo browser step, not a local-desktop browser step.
+
+5. If MoonPay returns a sign-in link or asks for browser continuation, move the user to Zo browser and complete that step there.
+
+6. Complete verification:
+
+```bash
+mp verify --email user@example.com --code 123456
+```
+
+7. Inspect available wallets:
+
+```bash
+mp wallet list
+```
+
+8. If no wallet exists, create one:
+
+```bash
+mp wallet create --name "default"
+```
+
+## Wallet Operations
+
+```bash
+# Create a new wallet
+mp wallet create --name "default"
+
+# Import from mnemonic
+mp wallet import --name "restored" --mnemonic "word1 word2 ..."
+
+# Import from private key for a single chain
+mp wallet import --name "imported" --key <hex-key> --chain ethereum
+
+# List wallets
+mp wallet list
+
+# Retrieve one wallet
+mp wallet retrieve --wallet "default"
+```
+
+## Config and Storage Notes
+
+- Wallets: `~/.config/moonpay/wallets.json`
+- Credentials: `~/.config/moonpay/credentials.json`
+- General config: `~/.config/moonpay/config.json`
+
+These are local to the Zo machine. Do not assume the user is on a desktop with local MoonPay state elsewhere.
+
+## Failure Handling
+
+- If `mp` is missing, install it and verify again.
+- If `mp user retrieve` fails, do not continue to buy, swap, or virtual-account flows until login is complete.
+- If `mp login` produces a sign-in link or browser continuation step, move the user to Zo browser rather than describing local-browser steps.
+- If the user has no wallet, create or import one before balance or swap flows.
+
+## Safety Notes
+
+- Do not ask the user to paste private keys, mnemonics, or secrets into chat.
+- `mp wallet export` is interactive and should not be used as part of a normal Zo agent flow.
+- Only retrieve OTP codes from Gmail if the user has Gmail connected and the flow clearly requires it.
+
+## Related Skills
+
+- `moonpay-check-wallet`
+- `moonpay-buy-crypto`
+- `moonpay-swap-tokens`
+- `moonpay-virtual-account`

--- a/Official/zo-moonpay-buy-crypto/SKILL.md
+++ b/Official/zo-moonpay-buy-crypto/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: moonpay-buy-crypto
+description: Generate a MoonPay fiat-to-crypto checkout flow on Zo. Use when the user wants to buy crypto with card or bank transfer and then complete the purchase in the Zo browser.
+compatibility: Created for Zo Computer
+metadata:
+  author: Zo
+  category: Official
+  display-name: MoonPay Buy Crypto
+---
+
+# MoonPay Buy Crypto
+
+Create a MoonPay checkout flow on Zo for fiat-to-crypto purchases.
+
+## What Zo Uses
+
+- [Terminal](/?t=terminal) for `mp buy`
+- [Browser](/browser) for the returned checkout URL and any KYC or payment completion
+
+## Prerequisites
+
+- MoonPay CLI installed
+- User authenticated
+- Destination wallet available
+- Token, amount, and destination chain are known
+
+## Workflow
+
+1. Verify auth:
+
+```bash
+mp user retrieve
+```
+
+2. Find or confirm the destination wallet:
+
+```bash
+mp wallet list
+```
+
+3. Generate the checkout flow:
+
+```bash
+mp buy \
+  --token <currency-code> \
+  --amount <usd-amount> \
+  --wallet <destination-address> \
+  --email <buyer-email>
+```
+
+4. Tell the user that the next step is in Zo browser.
+
+5. Open or guide the user to open the returned checkout URL in Zo browser.
+
+## Supported Token Codes
+
+`btc`, `sol`, `eth`, `trx`, `pol_polygon`, `usdc`, `usdc_sol`, `usdc_base`, `usdc_arbitrum`, `usdc_optimism`, `usdc_polygon`, `usdt_trx`, `eth_polygon`, `eth_optimism`, `eth_base`, `eth_arbitrum`
+
+## Failure Handling
+
+- If auth is missing, switch to `moonpay-auth`.
+- If destination wallet is unclear, stop and confirm before generating the checkout.
+- If the token code is unclear, clarify it before running the command.
+
+## Safety Notes
+
+- Treat this as a write / payment flow. Require explicit confirmation if the amount, token, or destination wallet is ambiguous.
+- Do not describe the returned URL as if it opens on the user's local machine. The correct next step is Zo browser.
+- Completion may require identity verification or payment steps that the user must handle in browser.
+
+## Related Skills
+
+- `moonpay-auth`
+- `moonpay-check-wallet`
+- `moonpay-swap-tokens`

--- a/Official/zo-moonpay-check-wallet/SKILL.md
+++ b/Official/zo-moonpay-check-wallet/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: moonpay-check-wallet
+description: Check MoonPay wallet balances, token holdings, and portfolio breakdown on Zo. Use when the user asks what is in their wallet, wants a portfolio summary, or needs balances before a MoonPay swap or buy flow.
+compatibility: Created for Zo Computer
+metadata:
+  author: Zo
+  category: Official
+  display-name: MoonPay Wallet Check
+---
+
+# MoonPay Wallet Check
+
+Inspect a MoonPay wallet on Zo and summarize balances cleanly for chat.
+
+## What Zo Uses
+
+- [Terminal](/?t=terminal) for `mp` wallet and balance commands
+
+## Prerequisites
+
+- MoonPay CLI installed
+- User authenticated
+- At least one MoonPay wallet exists, or the user is ready to create one
+
+## Workflow
+
+1. Confirm the user can access MoonPay:
+
+```bash
+mp user retrieve
+```
+
+2. Find available wallets:
+
+```bash
+mp wallet list
+```
+
+3. If no wallet exists, stop and switch to `moonpay-auth`.
+
+4. Retrieve balances on the relevant chain:
+
+```bash
+mp token balance list --wallet <address> --chain solana
+mp token balance list --wallet <address> --chain ethereum
+mp token balance list --wallet <address> --chain base
+```
+
+5. For Bitcoin wallets:
+
+```bash
+mp bitcoin balance retrieve --wallet <btc-address>
+```
+
+6. Summarize the result in chat:
+- total value if available
+- major holdings ordered by value
+- dust / near-zero holdings only if relevant
+- any obvious missing funds for a planned action
+
+## Supported Chains
+
+`solana`, `ethereum`, `base`, `polygon`, `arbitrum`, `optimism`, `bnb`, `avalanche`, `tron`, `bitcoin`, `ton`
+
+## Failure Handling
+
+- If the user is not authenticated, use `moonpay-auth`.
+- If the wallet name or address is unclear, list wallets first and ask which one to inspect.
+- If a chain is unclear, ask which chain the user expects funds on before checking multiple chains blindly.
+
+## Output Rules
+
+- Do not dump raw CLI output unless the user explicitly wants it.
+- Prefer a concise portfolio summary.
+- Mention when the wallet appears empty on the requested chain.
+
+## Safety Notes
+
+- This is a read-only skill. No extra confirmation is needed.
+- Do not move into swap or transfer execution without handing off to the appropriate write skill.
+
+## Related Skills
+
+- `moonpay-auth`
+- `moonpay-buy-crypto`
+- `moonpay-swap-tokens`

--- a/Official/zo-moonpay-swap-tokens/SKILL.md
+++ b/Official/zo-moonpay-swap-tokens/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: moonpay-swap-tokens
+description: Swap tokens or bridge assets with MoonPay on Zo. Use when the user wants to swap one token for another, bridge between supported chains, or move crypto through a MoonPay wallet workflow.
+compatibility: Created for Zo Computer
+metadata:
+  author: Zo
+  category: Official
+  display-name: MoonPay Swap Tokens
+---
+
+# MoonPay Swap Tokens
+
+Swap assets on the same chain or bridge them across supported chains using MoonPay on Zo.
+
+## What Zo Uses
+
+- [Terminal](/?t=terminal) for `mp token swap`, `mp token bridge`, and balance checks
+
+## Prerequisites
+
+- MoonPay CLI installed
+- User authenticated
+- Source wallet available
+- Source balance available on the intended chain
+- Token addresses or symbols resolved
+
+## Preflight
+
+Before any write action:
+
+1. Confirm auth:
+
+```bash
+mp user retrieve
+```
+
+2. Confirm the wallet:
+
+```bash
+mp wallet list
+```
+
+3. Check source balance:
+
+```bash
+mp token balance list --wallet <address> --chain <chain>
+```
+
+4. If the user gave token names instead of addresses, resolve them first:
+
+```bash
+mp token search --query "USDC" --chain solana
+```
+
+5. Generate a quote before execution:
+
+```bash
+mp token quote \
+  --from-chain <from-chain> \
+  --from-token <from-token> \
+  --from-amount <from-amount> \
+  --to-chain <to-chain> \
+  --to-token <to-token>
+```
+
+6. Summarize back to the user:
+- source wallet
+- source chain
+- source token and amount
+- destination token and chain
+- quoted output amount
+- quoted fees / route timing if available
+
+Then require explicit confirmation before executing the swap or bridge.
+
+## Swap Command
+
+```bash
+mp token swap \
+  --wallet <wallet-name> \
+  --chain <chain> \
+  --from-token <token-address> \
+  --from-amount <amount> \
+  --to-token <token-address>
+```
+
+## Bridge Command
+
+```bash
+mp token bridge \
+  --from-wallet <wallet-name> \
+  --from-chain <chain> \
+  --from-token <token-address> \
+  --from-amount <amount> \
+  --to-chain <chain> \
+  --to-token <token-address> \
+  --to-wallet <wallet-name>
+```
+
+## Notes
+
+- Same-chain swaps use `mp token swap`
+- Cross-chain movements use `mp token bridge`
+- Native tokens use chain-specific native-token placeholders
+
+## Failure Handling
+
+- If the wallet is missing, switch to `moonpay-auth`
+- If the balance is insufficient, stop before execution
+- If token identification is unclear, resolve it before execution
+- If the quote step fails, do not execute the swap or bridge blindly
+- If the user does not clearly confirm the write action, do not proceed
+
+## Safety Notes
+
+- This is a write skill. Explicit confirmation is required before execution.
+- Never infer a destination token or chain if the user did not specify it clearly.
+- Present the planned route and amount in plain language before running the command.
+
+## Related Skills
+
+- `moonpay-auth`
+- `moonpay-check-wallet`
+- `moonpay-buy-crypto`

--- a/Official/zo-moonpay-virtual-account/SKILL.md
+++ b/Official/zo-moonpay-virtual-account/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: moonpay-virtual-account
+description: Set up and operate MoonPay virtual accounts on Zo for fiat onramp and offramp flows. Use when the user wants to complete KYC, register payout or deposit details, or move between fiat and supported stablecoins.
+compatibility: Created for Zo Computer
+metadata:
+  author: Zo
+  category: Official
+  display-name: MoonPay Virtual Account
+---
+
+# MoonPay Virtual Account
+
+Run MoonPay virtual-account flows on Zo for fiat onramp and offramp workflows.
+
+## What Zo Uses
+
+- [Terminal](/?t=terminal) for `mp virtual-account` commands
+- [Browser](/browser) for KYC, agreement review, and continuation links
+
+## Prerequisites
+
+- MoonPay CLI installed
+- User authenticated
+- A wallet available for registration if the flow needs one
+
+## Workflow
+
+### 1. Create or inspect the account
+
+```bash
+mp virtual-account create
+mp virtual-account retrieve
+```
+
+Use `retrieve` to summarize current status before deciding the next step.
+
+### 2. Continue or restart KYC
+
+```bash
+mp virtual-account kyc continue
+mp virtual-account kyc restart
+```
+
+If MoonPay returns a URL or continuation step, move the user to Zo browser.
+
+### 3. Review agreements
+
+```bash
+mp virtual-account agreement list
+```
+
+Show the user the agreement name and URL. Do not accept an agreement until the user explicitly confirms they reviewed it.
+
+```bash
+mp virtual-account agreement accept --contentId <content-id>
+```
+
+### 4. Register a wallet if needed
+
+```bash
+mp virtual-account wallet register --wallet main --chain solana
+mp virtual-account wallet list
+```
+
+### 5. Run onramp or offramp flows
+
+Examples:
+
+```bash
+mp virtual-account onramp create \
+  --name "My Onramp" \
+  --fiat USD \
+  --stablecoin USDC \
+  --wallet <registered-wallet-address> \
+  --chain solana
+
+mp virtual-account onramp retrieve --onrampId <id>
+```
+
+For bank-account registration or payout/offramp flows, keep the user informed about which steps are informational and which steps will create or move financial rails.
+
+## Failure Handling
+
+- If auth is missing, switch to `moonpay-auth`
+- If KYC is incomplete, do not continue to onramp or offramp execution
+- If agreements are pending, stop and get user confirmation after review
+- If a wallet is required but missing, register one first
+
+## Safety Notes
+
+- Treat agreement acceptance and money-movement steps as explicit user-approval boundaries.
+- KYC, agreement review, and some legal disclosures are browser-dependent. Use Zo browser, not local-browser assumptions.
+- Explain clearly which parts Zo can complete and which parts the user must finish directly.
+
+## Related Skills
+
+- `moonpay-auth`
+- `moonpay-check-wallet`
+- `moonpay-buy-crypto`
+- `moonpay-swap-tokens`

--- a/Official/zo-okx-cex-market/SKILL.md
+++ b/Official/zo-okx-cex-market/SKILL.md
@@ -6,11 +6,18 @@ metadata:
   author: Zo
   category: Official
   display-name: OKX Market Data
+  version: "1.2.8"
+  homepage: "https://www.okx.com"
 ---
 
 # OKX Market Data
 
 Use the OKX CLI on Zo for read-only market data and technical indicator queries.
+
+## Preflight
+
+Before running any OKX command in this session, follow `../_shared/preflight.md`.
+Use `metadata.version` from this file as the comparison version for drift checks.
 
 ## What Zo Uses
 
@@ -47,6 +54,16 @@ okx market open-interest --instType SWAP --instId BTC-USDT-SWAP
 okx market instruments --instType SPOT
 okx market indicator rsi BTC-USDT --bar 1Dutc
 ```
+
+## Reference Files
+
+Load the matching reference file before running less-obvious commands or multi-step workflows:
+
+- price, candles, order book, trades: `references/price-data-commands.md`
+- indicators: `references/indicator-commands.md`
+- funding, mark price, open interest, price limits, index data: `references/derivatives-commands.md`
+- instrument discovery and non-crypto categories: `references/instrument-commands.md`
+- cross-skill workflows and MCP mappings: `references/workflows.md`
 
 ## Workflow
 

--- a/Official/zo-okx-cex-market/SKILL.md
+++ b/Official/zo-okx-cex-market/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: okx-cex-market
+description: Query OKX market data on Zo, including prices, candles, order books, funding rates, open interest, instruments, and technical indicators. Use for read-only market questions and never for account or trading actions.
+compatibility: Created for Zo Computer
+metadata:
+  author: Zo
+  category: Official
+  display-name: OKX Market Data
+---
+
+# OKX Market Data
+
+Use the OKX CLI on Zo for read-only market data and technical indicator queries.
+
+## What Zo Uses
+
+- [Terminal](/?t=terminal) for `okx market ...` commands
+
+## Prerequisites
+
+- OKX CLI installed:
+
+```bash
+npm install -g @okx_ai/okx-trade-cli
+```
+
+- Verify:
+
+```bash
+okx market ticker BTC-USDT
+```
+
+No API credentials are required for this skill.
+
+## Read-Only Rule
+
+All commands in this skill are read-only. No confirmation is needed unless the requested historical pull is unusually large.
+
+## Common Commands
+
+```bash
+okx market ticker BTC-USDT
+okx market orderbook BTC-USDT --sz 20
+okx market candles BTC-USDT --bar 1H --limit 100
+okx market funding-rate BTC-USDT-SWAP
+okx market open-interest --instType SWAP --instId BTC-USDT-SWAP
+okx market instruments --instType SPOT
+okx market indicator rsi BTC-USDT --bar 1Dutc
+```
+
+## Workflow
+
+1. Identify whether the user wants:
+- spot price / ticker
+- candles / OHLCV
+- order book / recent trades
+- funding, mark price, open interest
+- instrument discovery
+- indicators
+
+2. Run the minimal command that answers the question.
+
+3. Summarize the result in chat rather than dumping raw terminal output unless the user asked for raw output.
+
+## Historical Pull Guardrail
+
+Before large candle pulls with pagination or broad ranges, estimate the number of candles. If the request will produce more than roughly 500 rows, tell the user the estimate and ask before continuing.
+
+## Failure Handling
+
+- If the CLI is missing, install and verify it.
+- If an instrument is invalid, discover valid instruments first.
+- If the requested market is ambiguous, clarify the instrument ID before running multiple commands.
+
+## Safety Notes
+
+- This skill must not be used for balance, portfolio, or trading actions.
+- Use `okx-cex-portfolio` for account state.
+- Use `okx-cex-trade` for execution.
+
+## Related Skills
+
+- `okx-cex-portfolio`
+- `okx-cex-trade`

--- a/Official/zo-okx-cex-market/SKILL.md
+++ b/Official/zo-okx-cex-market/SKILL.md
@@ -52,7 +52,6 @@ okx market candles BTC-USDT --bar 1H --limit 100
 okx market funding-rate BTC-USDT-SWAP
 okx market open-interest --instType SWAP --instId BTC-USDT-SWAP
 okx market instruments --instType SPOT
-okx market indicator rsi BTC-USDT --bar 1Dutc
 ```
 
 ## Reference Files
@@ -75,9 +74,17 @@ Load the matching reference file before running less-obvious commands or multi-s
 - instrument discovery
 - indicators
 
-2. Run the minimal command that answers the question.
+2. If the user wants indicators, verify the subcommand exists before using any indicator reference:
 
-3. Summarize the result in chat rather than dumping raw terminal output unless the user asked for raw output.
+```bash
+okx market --help
+```
+
+Only continue with indicator commands if `indicator` appears in the available market subcommands. If it does not, stop and tell the user that this installed OKX CLI build does not expose indicator commands yet.
+
+3. Run the minimal command that answers the question.
+
+4. Summarize the result in chat rather than dumping raw terminal output unless the user asked for raw output.
 
 ## Historical Pull Guardrail
 

--- a/Official/zo-okx-cex-market/references/derivatives-commands.md
+++ b/Official/zo-okx-cex-market/references/derivatives-commands.md
@@ -1,0 +1,112 @@
+# Derivatives & Contract Data Commands
+
+These commands apply to SWAP, FUTURES, and/or OPTION instruments. Not applicable to SPOT unless noted.
+
+---
+
+## funding-rate — Funding Rate
+
+```bash
+okx market funding-rate <instId> [--history] [--limit <n>] [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `instId` | Yes | - | SWAP instrument only (e.g., `BTC-USDT-SWAP`) |
+| `--history` | No | false | Return historical funding rates |
+| `--limit` | No | 100 | Number of historical records (only with `--history`) |
+
+**Current rate** (no `--history`):
+Returns: `fundingRate` · `nextFundingRate` · `fundingTime` · `nextFundingTime`
+
+**Historical** (`--history`):
+Returns table: `fundingRate` · `realizedRate` · `fundingTime`
+
+```bash
+okx market funding-rate BTC-USDT-SWAP
+okx market funding-rate BTC-USDT-SWAP --history --limit 10
+```
+
+> Funding rate applies to SWAP instruments only. Returns an error for SPOT or FUTURES.
+
+---
+
+## mark-price — Mark Price
+
+```bash
+okx market mark-price --instType <type> [--instId <id>] [--json]
+```
+
+| Param | Required | Values |
+|---|---|---|
+| `--instType` | Yes | `SWAP` `FUTURES` `OPTION` |
+| `--instId` | No | Filter to a single instrument |
+
+Returns: `instId` · `instType` · `markPx` · `ts`
+
+Used for liquidation price calculation and contract fair-value reference.
+
+```bash
+okx market mark-price --instType SWAP --instId BTC-USDT-SWAP
+okx market mark-price --instType FUTURES
+```
+
+---
+
+## price-limit — Upper / Lower Price Limits
+
+```bash
+okx market price-limit <instId> [--json]
+```
+
+Returns: `buyLmt` (max buy price) · `sellLmt` (min sell price)
+
+Applies to SWAP and FUTURES only. Used to check whether a limit order price is within allowed range.
+
+```bash
+okx market price-limit BTC-USDT-SWAP
+```
+
+---
+
+## open-interest — Open Interest
+
+```bash
+okx market open-interest --instType <type> [--instId <id>] [--json]
+```
+
+| Param | Required | Values |
+|---|---|---|
+| `--instType` | Yes | `SWAP` `FUTURES` `OPTION` |
+| `--instId` | No | Filter to a single instrument |
+
+Returns: `instId` · `oi` (contracts) · `oiCcy` (base currency amount) · `ts`
+
+```bash
+okx market open-interest --instType SWAP --instId BTC-USDT-SWAP
+okx market open-interest --instType SWAP
+```
+
+> For OPTION: use `--instId BTC-USD` (underlying, not a specific strike/expiry) to list all active option series OI.
+
+---
+
+## index-ticker — Index Price
+
+```bash
+okx market index-ticker [--instId <id>] [--quoteCcy <ccy>] [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--instId` | Cond. | - | Index ID (e.g., `BTC-USD`). Either this or `--quoteCcy` required. |
+| `--quoteCcy` | Cond. | - | Filter all indices by quote currency (e.g., `USD`, `USDT`) |
+
+Returns: `instId` · `idxPx` · `high24h` · `low24h`
+
+> Use `BTC-USD` format for index IDs (not `BTC-USDT`).
+
+```bash
+okx market index-ticker --instId BTC-USD
+okx market index-ticker --quoteCcy USD
+```

--- a/Official/zo-okx-cex-market/references/indicator-commands.md
+++ b/Official/zo-okx-cex-market/references/indicator-commands.md
@@ -1,0 +1,133 @@
+# Technical Indicator Command Reference
+
+## Command Syntax
+
+```bash
+okx market indicator <indicator> <instId> [--bar <bar>] [--params <n1,n2,...>] [--list] [--limit <n>] [--backtest-time <ms>] [--json]
+```
+
+> Argument order: `<indicator>` comes **before** `<instId>` — e.g., `okx market indicator rsi BTC-USDT`, not the reverse.
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `indicator` | Yes | - | Indicator name (case-insensitive). See table below. |
+| `instId` | Yes | - | Instrument ID (e.g., `BTC-USDT`, `ETH-USDT-SWAP`) |
+| `--bar` | No | `1H` | Timeframe. See supported values below. |
+| `--params` | No | indicator default | Comma-separated numeric params, no spaces — e.g., `--params 14` or `--params 5,20` |
+| `--list` | No | false | Return historical series instead of latest value only |
+| `--limit` | No | 10 | Number of records when `--list` is set (max 100) |
+| `--backtest-time` | No | - | Unix timestamp in ms; omit for real-time. Used for backtesting point-in-time values. |
+
+### `--bar` Supported Values
+
+`3m` `5m` `15m` `1H` `4H` `12Hutc` `1Dutc` `3Dutc` `1Wutc`
+
+> These differ from candle `--bar` values: daily is `1Dutc` not `1D`, weekly is `1Wutc` not `1W`.
+
+---
+
+## Supported Indicators
+
+| Category | Indicator name | Default `--params` | Notes |
+|---|---|---|---|
+| **Trend** | `ma` | `5,20,60` | Simple moving averages; one or more periods |
+| **Trend** | `ema` | `5,20` | Exponential moving averages |
+| **Trend** | `supertrend` | `10,3` | period, multiplier |
+| **Trend** | `alphatrend` | — | No params needed |
+| **Trend** | `halftrend` | — | No params needed |
+| **Trend** | `pmax` | — | No params needed |
+| **Momentum** | `rsi` | `14` | Period (default 14) |
+| **Momentum** | `macd` | `12,26,9` | fast, slow, signal |
+| **Momentum** | `kdj` | `9,3,3` | K, D, J periods |
+| **Momentum** | `tdi` | — | Traders Dynamic Index |
+| **Momentum** | `qqe` | — | Quantitative Qualitative Estimation |
+| **Momentum** | `stoch-rsi` | `14` | Stochastic RSI |
+| **Volatility** | `bb` (or `boll`) | `20,2` | period, stddev multiplier — Bollinger Bands |
+| **Volatility** | `envelope` | `20,0.1` | period, deviation |
+| **Volatility** | `range-filter` | — | No params needed |
+| **Volatility** | `waddah` | — | Waddah Attar Explosion |
+| **BTC Cycle** | `ahr999` | — | **BTC-USDT only.** <0.45 accumulate · 0.45–1.2 DCA · >1.2 bubble warning |
+| **BTC Cycle** | `rainbow` | — | **BTC-USDT only.** BTC Rainbow Chart valuation band |
+| **BTC Cycle** | `pi-cycle-top` | — | **BTC-USDT only.** 111-day MA vs 350-day MA×2 cross = historical cycle top |
+| **BTC Cycle** | `pi-cycle-bottom` | — | **BTC-USDT only.** Cycle bottom signal |
+| **BTC Cycle** | `mayer` | — | **BTC-USDT only.** Price / 200-day MA. >2.4 historically overvalued |
+
+> BTC Cycle indicators only work with `BTC-USDT`; applying to ETH or other assets returns no data or an error.
+> `boll` is accepted as an alias for `bb`.
+
+---
+
+## Return Fields
+
+All indicators return `ts` (Unix ms timestamp) plus indicator-specific fields:
+
+| Indicator | Return fields |
+|---|---|
+| `ma` | `ma5`, `ma20`, `ma60` (based on `--params`) |
+| `ema` | `ema5`, `ema20` (based on `--params`) |
+| `rsi` | `rsi` |
+| `macd` | `dif`, `dea`, `macd` (histogram) |
+| `kdj` | `k`, `d`, `j` |
+| `bb` / `boll` | `upper`, `middle`, `lower` |
+| `supertrend` | `supertrend`, `direction` (`buy`/`sell`) |
+| `ahr999` | `ahr999` |
+| `rainbow` | `band` (valuation zone label) |
+| `pi-cycle-top` | `ma111`, `ma350x2`, `cross` |
+| `mayer` | `mayer`, `ma200` |
+
+---
+
+## Examples
+
+```bash
+# Latest RSI on 4H
+okx market indicator rsi BTC-USDT --bar 4H --params 14
+
+# EMA 5 and EMA 20 trend check on 1H
+okx market indicator ema BTC-USDT --bar 1H --params 5,20
+# ts: 3/20/2026, 10:00 AM | ema5: 87420.5 | ema20: 86910.2
+
+# MACD on daily
+okx market indicator macd BTC-USDT --bar 1Dutc
+
+# Bollinger Bands on 1H
+okx market indicator bb ETH-USDT --bar 1H
+# upper: 2050 | middle: 2000 | lower: 1950
+
+# SuperTrend direction signal
+okx market indicator supertrend BTC-USDT --bar 4H
+# supertrend: 84200 | direction: buy
+
+# Historical RSI series (last 20 values)
+okx market indicator rsi ETH-USDT --bar 1H --params 14 --list --limit 20
+# → table: ts, rsi (20 rows, newest first)
+
+# BTC macro cycle check
+okx market indicator ahr999 BTC-USDT
+# ahr999: 0.87  (DCA zone: 0.45–1.2)
+
+okx market indicator rainbow BTC-USDT
+# band: "HODL"
+
+okx market indicator mayer BTC-USDT
+# mayer: 1.31 | ma200: 72500
+
+okx market indicator pi-cycle-top BTC-USDT
+# ma111: 88000 | ma350x2: 104000 | cross: false
+
+# Backtesting point-in-time value
+okx market indicator rsi BTC-USDT --bar 4H --params 14 --backtest-time 1711008000000
+```
+
+---
+
+## BTC Cycle Interpretation Guide
+
+| Indicator | Zone / Value | Interpretation |
+|---|---|---|
+| `ahr999` | < 0.45 | Accumulate zone |
+| `ahr999` | 0.45 – 1.2 | DCA zone |
+| `ahr999` | > 1.2 | Bubble warning |
+| `mayer` | > 2.4 | Historically overvalued |
+| `pi-cycle-top` | `cross: true` | Historical cycle top signal |
+| `rainbow` | band label | See OKX Rainbow Chart legend for zone |

--- a/Official/zo-okx-cex-market/references/indicator-commands.md
+++ b/Official/zo-okx-cex-market/references/indicator-commands.md
@@ -1,5 +1,15 @@
 # Technical Indicator Command Reference
 
+## Availability Gate
+
+Before using anything in this file, verify the installed CLI exposes the indicator subcommand:
+
+```bash
+okx market --help
+```
+
+Only continue if `indicator` appears in the listed market subcommands. If it is missing, stop and tell the user that the installed OKX CLI build does not currently support market indicators, even if newer partner docs mention them.
+
 ## Command Syntax
 
 ```bash

--- a/Official/zo-okx-cex-market/references/instrument-commands.md
+++ b/Official/zo-okx-cex-market/references/instrument-commands.md
@@ -1,0 +1,125 @@
+# Instrument Discovery Commands
+
+## instruments — List Tradeable Instruments
+
+```bash
+okx market instruments --instType <type> [--instId <id>] [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--instType` | Yes | - | `SPOT` `SWAP` `FUTURES` `OPTION` |
+| `--instId` | No | - | Filter to a single instrument |
+| `--uly` | Cond. | - | Required for `OPTION` (e.g., `--uly BTC-USD`) |
+
+Returns: `instId` · `ctVal` · `lotSz` · `minSz` · `tickSz` · `state`. Displays up to 50 rows.
+
+```bash
+okx market instruments --instType SPOT
+okx market instruments --instType SWAP --instId BTC-USDT-SWAP --json
+okx market instruments --instType OPTION --uly BTC-USD
+```
+
+> **OPTION instruments cannot be listed without `--uly`**. If the underlying is unknown, use `open-interest --instType OPTION` first to discover active instIds, then query instruments with the known underlying.
+
+---
+
+## stock-tokens — List All Stock Token Perpetuals *(Deprecated)*
+
+> **Deprecated**: use `okx market instruments-by-category --instCategory 3` instead. This command is kept for backward compatibility and will be removed in a future major version.
+
+```bash
+okx market stock-tokens [--json]
+```
+
+Returns: `instId` · `ctVal` · `lotSz` · `minSz` · `tickSz` · `state` for all active stock token SWAP instruments (`instCategory=3`).
+
+Examples: `TSLA-USDT-SWAP`, `NVDA-USDT-SWAP`, `AAPL-USDT-SWAP`, `MSFT-USDT-SWAP`
+
+```bash
+okx market stock-tokens
+```
+
+> **Fallback** (if command not yet available):
+> ```bash
+> okx market instruments --instType SWAP --json | jq '[.[] | select(.instCategory == "3")]'
+> ```
+> Requires `jq` installed.
+
+---
+
+## instruments-by-category — Discover Metals, Commodities, Forex, and Bond Instruments
+
+OKX supports non-crypto asset categories distinguished by the `instCategory` field:
+
+| instCategory | Asset Class | Examples |
+|---|---|---|
+| `3` | Stock tokens | Apple (AAPL-USDT-SWAP), Tesla (TSLA-USDT-SWAP), Nvidia (NVDA-USDT-SWAP) |
+| `4` | Metals | Gold (XAUUSDT-USDT-SWAP), Silver (XAGUSDT-USDT-SWAP) |
+| `5` | Commodities | Crude Oil (OIL-USDT-SWAP), Natural Gas (GAS-USDT-SWAP) |
+| `6` | Forex | EUR/USD (EURUSDT-USDT-SWAP), GBP/USD (GBPUSDT-USDT-SWAP) |
+| `7` | Bonds | US 30Y Treasury (US30Y-USDT-SWAP) |
+
+```bash
+okx market instruments-by-category --instCategory <3|4|5|6|7> [--instType <SPOT|SWAP>] [--instId <id>] [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--instCategory` | Yes | - | `3`=Stock tokens `4`=Metals `5`=Commodities `6`=Forex `7`=Bonds |
+| `--instType` | No | SWAP | `SPOT` or `SWAP` |
+| `--instId` | No | - | Filter to a specific instrument |
+
+Returns: `instId` · `instCategory` · `ctVal` · `lotSz` · `minSz` · `tickSz` · `state`.
+
+```bash
+# Discover stock token perpetuals (replaces the deprecated stock-tokens command)
+okx market instruments-by-category --instCategory 3
+
+# Discover all gold/silver instruments
+okx market instruments-by-category --instCategory 4
+
+# Discover all forex perpetuals
+okx market instruments-by-category --instCategory 6
+
+# Discover commodities
+okx market instruments-by-category --instCategory 5
+
+# Inspect a specific bond instrument
+okx market instruments-by-category --instCategory 7 --instId US30Y-USDT-SWAP --json
+```
+
+> **Fallback** (if command not yet available):
+> ```bash
+> okx market instruments --instType SWAP --json | jq '[.[] | select(.instCategory == "3")]'
+> ```
+> Replace `"3"` with `"4"`, `"5"`, `"6"`, or `"7"` as needed. Requires `jq` installed.
+
+> **Discovery workflow**: always run `instruments-by-category` first to get valid instIds, then use `ticker` / `orderbook` / `candles` to get price data.
+
+### Trading Hours Notes
+
+- **Forex** (category 6): follows FX market hours (Mon 00:00 – Fri 22:00 UTC, closed weekends)
+- **Metals** (category 4): generally trades with FX hours; verify with `ticker` before placing orders
+- **Commodities** (category 5): session-based hours; check `state=live` in instruments list
+- **Bonds** (category 7): US bond instruments follow US market hours
+
+Always run `okx market ticker <instId>` to confirm a live last price before placing any order on these instruments.
+
+---
+
+## Notes
+
+- `ctVal` — contract value (e.g., 0.01 BTC per contract for BTC-USDT-SWAP). Required for sz ↔ coin quantity conversion.
+- `lotSz` — order size increment. sz must be a multiple of lotSz.
+- `minSz` — minimum order size.
+- `tickSz` — minimum price increment.
+- `state` — `live` means currently tradeable.
+
+### Stock Token Trading Hours
+
+Stock tokens follow underlying exchange hours:
+- US stocks (TSLA, NVDA, AAPL, etc.): Mon–Fri ~09:30–16:00 ET
+- Orders outside trading hours may be queued or rejected
+
+Always run `okx market ticker <instId>` to confirm a live last price before placing any stock token order.

--- a/Official/zo-okx-cex-market/references/price-data-commands.md
+++ b/Official/zo-okx-cex-market/references/price-data-commands.md
@@ -1,0 +1,128 @@
+# Price & Market Data Commands
+
+## ticker — Single Instrument
+
+```bash
+okx market ticker <instId> [--json]
+```
+
+| Param | Required | Description |
+|---|---|---|
+| `instId` | Yes | Instrument ID (e.g., `BTC-USDT`, `BTC-USDT-SWAP`) |
+
+Returns: `last` · `high24h` · `low24h` · `vol24h` (base currency) · `sodUtc8` (24h change %)
+
+```bash
+okx market ticker BTC-USDT
+# instId: BTC-USDT | last: 95000.5 | 24h change%: +1.2% | high: 96000 | low: 93000
+```
+
+---
+
+## tickers — All Instruments of a Type
+
+```bash
+okx market tickers <instType> [--json]
+```
+
+| Param | Required | Values |
+|---|---|---|
+| `instType` | Yes | `SPOT` `SWAP` `FUTURES` `OPTION` |
+
+Returns table: `instId` · `last` · `high24h` · `low24h` · `vol24h`
+
+```bash
+okx market tickers SWAP
+# → table of all perpetual contracts
+```
+
+---
+
+## orderbook — Order Book Depth
+
+```bash
+okx market orderbook <instId> [--sz <n>] [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `instId` | Yes | - | Instrument ID |
+| `--sz` | No | 5 | Depth levels per side (1–400) |
+
+Returns: top asks (ascending) and bids (descending) with price and size. Display shows top 5 per side regardless of `--sz`.
+
+```bash
+okx market orderbook BTC-USDT-SWAP --sz 20
+# Asks: 95100.0 / 2.5 · 95050.0 / 1.2 ...
+# Bids: 95000.0 / 3.1 · 94950.0 / 0.8 ...
+```
+
+---
+
+## trades — Recent Public Trades
+
+```bash
+okx market trades <instId> [--limit <n>] [--json]
+```
+
+| Param | Required | Default |
+|---|---|---|
+| `instId` | Yes | - |
+| `--limit` | No | 100 |
+
+Returns: `tradeId` · `px` · `sz` · `side` (`buy`/`sell`) · `ts`
+
+```bash
+okx market trades BTC-USDT --limit 20
+```
+
+---
+
+## candles — OHLCV Candlestick Data
+
+```bash
+okx market candles <instId> [--bar <bar>] [--limit <n>] [--after <ts>] [--before <ts>] [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `instId` | Yes | - | Instrument ID |
+| `--bar` | No | `1m` | Time granularity (see values below) |
+| `--limit` | No | 100 | Number of candles |
+| `--after` | No | - | Return candles **before** this timestamp (ms) — paginate backward in time |
+| `--before` | No | - | Return candles **after** this timestamp (ms) — paginate forward in time |
+
+`--bar` values: `1m` `3m` `5m` `15m` `30m` `1H` `2H` `4H` `6H` `12H` `1D` `1W` `1M`
+
+> Use uppercase for hour/day/week/month — `1H` not `1h`.
+
+The command automatically routes to the historical endpoint when `--after` is older than ~2 days, supporting data back to 2021.
+
+> **OKX API pagination direction**: `--after <ts>` returns candles with timestamp **earlier** than `ts` (go further back in time). `--before <ts>` returns candles with timestamp **later** than `ts` (go toward the present).
+
+Returns columns: `time` · `open` · `high` · `low` · `close` · `vol` (base currency). Sorted newest-first.
+
+```bash
+okx market candles BTC-USDT --bar 4H --limit 30
+okx market candles ETH-USDT-SWAP --bar 1H --limit 100
+okx market candles BTC-USDT --bar 1D --after 1672531200000   # candles before 2023-01-01
+```
+
+---
+
+## index-candles — Index OHLCV
+
+```bash
+okx market index-candles <instId> [--bar <bar>] [--limit <n>] [--history] [--json]
+```
+
+Same params as `candles`. Use index instrument IDs: `BTC-USD` (not `BTC-USDT`).
+
+`--history`: return historical candles beyond the default 1440-candle window.
+
+Returns: same columns as `candles`.
+
+```bash
+okx market index-candles BTC-USD --bar 1Dutc --limit 50
+okx market index-candles BTC-USD --bar 1Wutc --history --limit 200
+```

--- a/Official/zo-okx-cex-market/references/workflows.md
+++ b/Official/zo-okx-cex-market/references/workflows.md
@@ -1,0 +1,144 @@
+# Cross-Skill Workflows & MCP Tool Reference
+
+## Cross-Skill Workflows
+
+All market commands are read-only. Decisions and order placement remain with the user.
+
+---
+
+### Price lookup before order placement
+
+```
+okx market ticker BTC-USDT                    → last price, 24h range
+okx-cex-portfolio: okx account balance USDT   → available funds
+okx-cex-trade: okx spot place ...             → user decides px/sz
+```
+
+---
+
+### Funding rate analysis for perp positions
+
+```
+okx market funding-rate BTC-USDT-SWAP          → current rate + next funding time
+okx market funding-rate BTC-USDT-SWAP --history --limit 10  → recent trend
+okx-cex-portfolio: okx account positions       → check existing exposure
+```
+
+---
+
+### Market data lookup before grid bot setup
+
+```
+okx market candles BTC-USDT --bar 4H --limit 50   → recent OHLCV for range estimation
+okx market ticker BTC-USDT                         → current price
+okx market orderbook BTC-USDT --sz 20              → liquidity check
+okx-cex-bot: okx bot grid create ...               → user decides minPx/maxPx
+```
+
+---
+
+### Spot vs perp price comparison (premium check)
+
+```
+okx market ticker BTC-USDT
+okx market ticker BTC-USDT-SWAP
+okx market mark-price --instType SWAP --instId BTC-USDT-SWAP
+```
+
+---
+
+### Non-crypto asset discovery before trading (Metals / Commodities / Forex / Bonds)
+
+```
+# Step 1 — discover valid instIds for the asset class
+okx market instruments-by-category --instCategory 4   → Metals: find XAUUSDT-USDT-SWAP, XAGUSDT-USDT-SWAP
+okx market instruments-by-category --instCategory 5   → Commodities: find OIL-USDT-SWAP, GAS-USDT-SWAP
+okx market instruments-by-category --instCategory 6   → Forex: find EURUSDT-USDT-SWAP, GBPUSDT-USDT-SWAP
+okx market instruments-by-category --instCategory 7   → Bonds: find US30Y-USDT-SWAP
+
+# Step 2 — verify live price and check trading session is open
+okx market ticker XAUUSDT-USDT-SWAP                   → last price, 24h range (state must show active)
+okx market orderbook XAUUSDT-USDT-SWAP                → bid/ask spread and liquidity
+
+# Step 3 — get instrument specs for order sizing
+okx market instruments --instType SWAP --instId XAUUSDT-USDT-SWAP --json
+                                                       → ctVal, minSz, lotSz for quantity conversion
+
+# okx-cex-trade: user places order after confirming market is open
+```
+
+> **Important**: non-crypto instruments have trading-hour restrictions. Always confirm `state=live` in the instruments response and a non-zero last price in `ticker` before proceeding to order placement.
+
+---
+
+### Stock token discovery before trading
+
+```
+okx market instruments-by-category --instCategory 3            → list instIds and specs (preferred)
+okx market ticker TSLA-USDT-SWAP                               → current price and 24h range
+okx market instruments --instType SWAP --instId TSLA-USDT-SWAP --json
+                                                                → ctVal, minSz, lotSz for sz conversion
+```
+
+> `okx market stock-tokens` is deprecated — use `instruments-by-category --instCategory 3` instead.
+
+---
+
+### Option discovery and pricing
+
+```
+okx market open-interest --instType OPTION --instId BTC-USD    → find active option instIds
+okx market ticker BTC-USD-250328-95000-C                       → option last price and stats
+okx market orderbook BTC-USD-250328-95000-C                    → bid/ask spread
+```
+
+---
+
+### Multi-indicator trend analysis
+
+Run in parallel — no ordering dependency:
+
+```
+okx market indicator ema BTC-USDT --bar 4H --params 5,20       → EMA5 vs EMA20 alignment
+okx market indicator macd BTC-USDT --bar 4H                    → MACD histogram + DIF/DEA cross
+okx market indicator rsi BTC-USDT --bar 4H --params 14         → RSI overbought/oversold
+okx market indicator bb BTC-USDT --bar 4H                      → Bollinger Bands position
+okx market indicator supertrend BTC-USDT --bar 4H              → direction signal (buy/sell)
+```
+
+---
+
+### BTC macro cycle analysis
+
+Run in parallel — no ordering dependency:
+
+```
+okx market indicator ahr999 BTC-USDT        → accumulate / DCA / bubble zone
+okx market indicator rainbow BTC-USDT       → Rainbow Chart valuation band
+okx market indicator pi-cycle-top BTC-USDT  → 111-day MA vs 350-day MA×2 cross signal
+okx market indicator mayer BTC-USDT         → price / 200-day MA ratio
+```
+
+---
+
+## MCP Tool Reference
+
+When using MCP tools directly (instead of CLI), the tool names map as follows:
+
+| CLI subcommand | MCP tool name |
+|---|---|
+| `market ticker` | `market_get_ticker` |
+| `market tickers` | `market_get_tickers` |
+| `market instruments` | `market_get_instruments` |
+| `market orderbook` | `market_get_orderbook` |
+| `market candles` | `market_get_candles` |
+| `market index-candles` | `market_get_index_candles` |
+| `market funding-rate` | `market_get_funding_rate` |
+| `market trades` | `market_get_trades` |
+| `market mark-price` | `market_get_mark_price` |
+| `market index-ticker` | `market_get_index_ticker` |
+| `market price-limit` | `market_get_price_limit` |
+| `market open-interest` | `market_get_open_interest` |
+| `market stock-tokens` | `market_get_stock_tokens` |
+| `market instruments-by-category` | `market_get_instruments_by_category` |
+| `market indicator` | `market_get_indicator` |

--- a/Official/zo-okx-cex-portfolio/SKILL.md
+++ b/Official/zo-okx-cex-portfolio/SKILL.md
@@ -6,11 +6,18 @@ metadata:
   author: Zo
   category: Official
   display-name: OKX Portfolio
+  version: "1.2.8"
+  homepage: "https://www.okx.com"
 ---
 
 # OKX Portfolio
 
 Inspect OKX account state on Zo, including balances, positions, PnL, bills, fees, and selected account operations.
+
+## Preflight
+
+Before running any OKX command in this session, follow `../_shared/preflight.md`.
+Use `metadata.version` from this file as the comparison version for drift checks.
 
 ## What Zo Uses
 

--- a/Official/zo-okx-cex-portfolio/SKILL.md
+++ b/Official/zo-okx-cex-portfolio/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: okx-cex-portfolio
+description: Inspect OKX account balances, positions, PnL, bills, fee levels, and related account state on Zo. Use when the user asks about holdings, positions, realized or unrealized PnL, transfers, or account configuration.
+compatibility: Created for Zo Computer
+metadata:
+  author: Zo
+  category: Official
+  display-name: OKX Portfolio
+---
+
+# OKX Portfolio
+
+Inspect OKX account state on Zo, including balances, positions, PnL, bills, fees, and selected account operations.
+
+## What Zo Uses
+
+- [Terminal](/?t=terminal) for `okx account ...` commands
+- [Settings > Advanced](/?t=settings&s=advanced) for storing OKX credentials as Zo secrets
+
+## Credential Model
+
+Zo secrets are the source of truth for:
+- `OKX_API_KEY`
+- `OKX_SECRET_KEY`
+- `OKX_PASSPHRASE`
+
+If local OKX config is needed, generate it from those secrets on the Zo machine instead of asking the user to paste credentials into chat.
+
+## Prerequisites
+
+1. Install the CLI:
+
+```bash
+npm install -g @okx_ai/okx-trade-cli
+```
+
+2. Ensure OKX secrets exist in [Settings > Advanced](/?t=settings&s=advanced).
+
+3. Generate local config from Zo secrets if required by the CLI flow:
+
+```bash
+mkdir -p /root/.okx
+cat > /root/.okx/config.toml <<EOF
+default_profile = "demo"
+
+[profiles.demo]
+api_key = "${OKX_API_KEY}"
+secret_key = "${OKX_SECRET_KEY}"
+passphrase = "${OKX_PASSPHRASE}"
+demo = true
+
+[profiles.live]
+api_key = "${OKX_API_KEY}"
+secret_key = "${OKX_SECRET_KEY}"
+passphrase = "${OKX_PASSPHRASE}"
+EOF
+```
+
+4. Verify configuration status:
+
+```bash
+okx config show
+```
+
+## Profile Rule
+
+Authenticated commands must always use an explicit profile:
+- `demo`
+- `live`
+
+If the user has not specified a profile and none is clearly established in the conversation, ask before proceeding.
+
+## Common Commands
+
+```bash
+okx --profile demo account balance
+okx --profile demo account positions
+okx --profile demo account positions-history
+okx --profile demo account bills
+okx --profile demo account fee-rates
+okx --profile demo account config
+```
+
+## Workflow
+
+1. Verify the CLI is available.
+2. Verify credentials are configured and masked correctly.
+3. Confirm the profile.
+4. Run the smallest account command that answers the user’s question.
+5. Summarize the output in chat and append the active profile.
+
+## Failure Handling
+
+- If credentials are missing or invalid, stop and direct the user to [Settings > Advanced](/?t=settings&s=advanced).
+- If config generation fails, do not proceed with authenticated account calls.
+- If the profile is unclear, ask before continuing.
+
+## Output Rules
+
+- Prefer concise portfolio summaries over raw output dumps.
+- Mention whether the result came from `demo` or `live`.
+- Disclose scope when the result is partial, for example one currency or one position set.
+
+## Safety Notes
+
+- Read-only portfolio queries do not require extra confirmation.
+- If the action becomes a write action such as a transfer or account-setting change, confirm profile and intent first.
+
+## Related Skills
+
+- `okx-cex-market`
+- `okx-cex-trade`

--- a/Official/zo-okx-cex-portfolio/SKILL.md
+++ b/Official/zo-okx-cex-portfolio/SKILL.md
@@ -84,7 +84,7 @@ okx --profile demo account balance
 okx --profile demo account positions
 okx --profile demo account positions-history
 okx --profile demo account bills
-okx --profile demo account fee-rates
+okx --profile demo account fees --instType SPOT
 okx --profile demo account config
 ```
 

--- a/Official/zo-okx-cex-trade/SKILL.md
+++ b/Official/zo-okx-cex-trade/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: okx-cex-trade
+description: Execute and manage OKX spot, perpetual, futures, and supported options trades on Zo. Use when the user wants to place, cancel, amend, or inspect tradable orders, but require explicit same-thread confirmation before any live execution.
+compatibility: Created for Zo Computer
+metadata:
+  author: Zo
+  category: Official
+  display-name: OKX Trade
+---
+
+# OKX Trade
+
+Execute OKX trades on Zo with a strict quote, validate, confirm, execute flow.
+
+## What Zo Uses
+
+- [Terminal](/?t=terminal) for `okx` trading commands
+- [Settings > Advanced](/?t=settings&s=advanced) for OKX credentials stored as Zo secrets
+
+## Credential Model
+
+Zo secrets are the source of truth for:
+- `OKX_API_KEY`
+- `OKX_SECRET_KEY`
+- `OKX_PASSPHRASE`
+
+Generate local OKX config from those secrets if the CLI requires it. Do not ask the user to paste credentials into chat.
+
+If the CLI needs a local config file, generate it from Zo secrets:
+
+```bash
+mkdir -p /root/.okx
+cat > /root/.okx/config.toml <<EOF
+default_profile = "demo"
+
+[profiles.demo]
+api_key = "${OKX_API_KEY}"
+secret_key = "${OKX_SECRET_KEY}"
+passphrase = "${OKX_PASSPHRASE}"
+demo = true
+
+[profiles.live]
+api_key = "${OKX_API_KEY}"
+secret_key = "${OKX_SECRET_KEY}"
+passphrase = "${OKX_PASSPHRASE}"
+EOF
+```
+
+## Non-Negotiable Safety Rules
+
+- Never place a live trade without explicit same-thread confirmation.
+- If the user’s profile is ambiguous, default to asking whether they mean `demo` or `live`.
+- Always report which profile was executed.
+- For derivatives, validate contract value before execution.
+
+## Profiles
+
+- `demo`: simulated funds
+- `live`: real funds
+
+If the user has not clearly specified one, ask.
+
+## Required Execution Pattern
+
+### 1. Quote / Validate
+
+Before any write action:
+- confirm market and side
+- confirm amount or contract count
+- confirm profile
+- for derivatives, fetch contract information and validate sizing
+- summarize back exactly what will happen
+
+### 2. Confirm
+
+Require explicit confirmation in the current conversation before executing any live write action.
+
+For demo writes, still confirm if the order details are ambiguous.
+
+### 3. Execute
+
+Only after confirmation, run the specific command.
+
+## Common Command Shapes
+
+### Spot
+
+```bash
+okx --profile demo spot place --instId BTC-USDT --side buy --ordType market --sz 0.01
+okx --profile demo spot cancel --instId BTC-USDT --ordId <ordId>
+okx --profile demo spot amend --instId BTC-USDT --ordId <ordId> --newPx 100000
+```
+
+### Perpetual / Futures
+
+```bash
+okx --profile demo swap place --instId BTC-USDT-SWAP --side buy --ordType market --sz 1 --tdMode cross --posSide long
+okx --profile demo swap close --instId BTC-USDT-SWAP --mgnMode cross --posSide long
+okx --profile demo swap leverage --instId BTC-USDT-SWAP --lever 10 --mgnMode cross
+```
+
+### Algo / TP / SL
+
+```bash
+okx --profile demo swap algo trail --instId BTC-USDT-SWAP --side sell --sz 1 --tdMode cross --posSide long --callbackRatio 0.02
+```
+
+## Derivatives Validation Rule
+
+Before placing SWAP, FUTURES, or OPTION orders, retrieve instrument details and validate contract face value. Do not assume contract sizing.
+
+Examples:
+
+```bash
+okx market instruments --instType SWAP --instId BTC-USDT-SWAP
+okx market instruments --instType FUTURES --instId BTC-USDT-250328
+okx market instruments --instType OPTION --instId BTC-USD-250328-95000-C
+```
+
+Use the validated contract value to explain:
+- contract count
+- approximate notional size
+- relevant margin implications
+
+## Failure Handling
+
+- If credentials are missing or invalid, stop and direct the user to [Settings > Advanced](/?t=settings&s=advanced).
+- If profile is unclear, ask before proceeding.
+- If the requested amount is ambiguous, do not infer.
+- If contract information cannot be validated for a derivatives order, do not execute.
+
+## Output Rules
+
+- After execution, state what happened in plain language.
+- Always append the executed profile.
+- If the command failed, summarize the failure and the next fix, not just raw stderr.
+
+## Scope Limits
+
+- This v1 skill covers spot, swap, futures, and supported options execution basics.
+- Do not introduce OKX bots here.
+- Keep advanced options workflows out unless the user clearly requests them and the inputs are complete.
+
+## Related Skills
+
+- `okx-cex-market`
+- `okx-cex-portfolio`

--- a/Official/zo-okx-cex-trade/SKILL.md
+++ b/Official/zo-okx-cex-trade/SKILL.md
@@ -6,11 +6,18 @@ metadata:
   author: Zo
   category: Official
   display-name: OKX Trade
+  version: "1.2.8"
+  homepage: "https://www.okx.com"
 ---
 
 # OKX Trade
 
 Execute OKX trades on Zo with a strict quote, validate, confirm, execute flow.
+
+## Preflight
+
+Before running any OKX command in this session, follow `../_shared/preflight.md`.
+Use `metadata.version` from this file as the comparison version for drift checks.
 
 ## What Zo Uses
 
@@ -104,6 +111,17 @@ okx --profile demo swap leverage --instId BTC-USDT-SWAP --lever 10 --mgnMode cro
 ```bash
 okx --profile demo swap algo trail --instId BTC-USDT-SWAP --side sell --sz 1 --tdMode cross --posSide long --callbackRatio 0.02
 ```
+
+## Reference Files
+
+Load the matching reference file before running anything beyond the simplest spot or swap flow:
+
+- spot orders and spot algo commands: `references/spot-commands.md`
+- perpetual swap execution and swap algo commands: `references/swap-commands.md`
+- delivery futures execution: `references/futures-commands.md`
+- options contracts, Greeks, and premium conversion: `references/options-commands.md`
+- MCP mappings, output rules, and amount safety rules: `references/templates.md`
+- cross-skill workflows and example execution sequences: `references/workflows.md`
 
 ## Derivatives Validation Rule
 

--- a/Official/zo-okx-cex-trade/references/futures-commands.md
+++ b/Official/zo-okx-cex-trade/references/futures-commands.md
@@ -1,0 +1,228 @@
+# Futures / Delivery Command Reference
+
+## Futures — Place Order
+
+```bash
+okx futures place --instId <id> --side <buy|sell> --ordType <type> --sz <n> \
+  --tdMode <cross|isolated> \
+  [--tgtCcy <base_ccy|quote_ccy>] \
+  [--posSide <long|short>] [--px <price>] [--reduceOnly] \
+  [--tpTriggerPx <p>] [--tpOrdPx <p|-1>] \
+  [--slTriggerPx <p>] [--slOrdPx <p|-1>] \
+  [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--instId` | Yes | - | Futures instrument (format: `BTC-USDT-<YYMMDD>`, e.g. `BTC-USDT-260328`) |
+| `--side` | Yes | - | `buy` or `sell` |
+| `--ordType` | Yes | - | `market`, `limit`, `post_only`, `fok`, `ioc` |
+| `--sz` | Yes | - | Order size — unit depends on `--tgtCcy` |
+| `--tdMode` | Yes | - | `cross` or `isolated` |
+| `--tgtCcy` | No | base_ccy | `base_ccy`: sz in contracts; `quote_ccy`: sz in USDT amount |
+| `--posSide` | Cond. | - | `long` or `short` — required in hedge mode |
+| `--px` | Cond. | - | Price — required for limit orders |
+| `--reduceOnly` | No | false | Close-only; will not open a new position |
+| `--tpTriggerPx` | No | - | Attached take-profit trigger price |
+| `--tpOrdPx` | No | - | TP order price; use `-1` for market execution |
+| `--slTriggerPx` | No | - | Attached stop-loss trigger price |
+| `--slOrdPx` | No | - | SL order price; use `-1` for market execution |
+
+`--instId` format: `BTC-USDT-<YYMMDD>` (delivery date suffix).
+
+---
+
+## Futures — Cancel Order
+
+```bash
+okx futures cancel --instId <id> --ordId <id> [--json]
+```
+
+---
+
+## Futures — Amend Order
+
+```bash
+okx futures amend --instId <id> [--ordId <id>] [--clOrdId <id>] \
+  [--newSz <n>] [--newPx <p>] [--json]
+```
+
+Must provide at least one of `--newSz` or `--newPx`.
+
+---
+
+## Futures — Close Position
+
+```bash
+okx futures close --instId <id> --mgnMode <cross|isolated> \
+  [--posSide <long|short>] [--autoCxl] [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--instId` | Yes | - | Futures instrument (e.g., `BTC-USDT-260328`) |
+| `--mgnMode` | Yes | - | `cross` or `isolated` |
+| `--posSide` | Cond. | - | `long` or `short` — required in hedge mode |
+| `--autoCxl` | No | false | Auto-cancel pending orders before closing |
+
+Closes the **entire** position at market price.
+
+---
+
+## Futures — Set Leverage
+
+```bash
+okx futures leverage --instId <id> --lever <n> --mgnMode <cross|isolated> \
+  [--posSide <long|short>] [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--instId` | Yes | - | Futures instrument |
+| `--lever` | Yes | - | Leverage multiplier (e.g., `10`) |
+| `--mgnMode` | Yes | - | `cross` or `isolated` |
+| `--posSide` | Cond. | - | `long` or `short` — required for isolated mode in hedge mode |
+
+---
+
+## Futures — Get Leverage
+
+```bash
+okx futures get-leverage --instId <id> --mgnMode <cross|isolated> [--json]
+```
+
+Returns table: `instId`, `mgnMode`, `posSide`, `lever`.
+
+---
+
+## Futures — List Orders
+
+```bash
+okx futures orders [--instId <id>] [--status <open|history|archive>] [--json]
+```
+
+| `--status` | Effect |
+|---|---|
+| `open` | Active/pending orders (default) |
+| `history` | Recent completed/cancelled |
+| `archive` | Older history |
+
+---
+
+## Futures — Positions
+
+```bash
+okx futures positions [<instId>] [--json]
+```
+
+Returns: `instId`, `side`, `pos`, `avgPx`, `upl`, `lever`.
+
+---
+
+## Futures — Fills
+
+```bash
+okx futures fills [--instId <id>] [--ordId <id>] [--archive] [--json]
+```
+
+---
+
+## Futures — Get Order
+
+```bash
+okx futures get --instId <id> [--ordId <id>] [--json]
+```
+
+---
+
+## Futures — Place Algo (TP/SL / Trail)
+
+```bash
+okx futures algo place --instId <id> --side <buy|sell> \
+  --ordType <oco|conditional|move_order_stop> --sz <n> \
+  --tdMode <cross|isolated> \
+  [--tgtCcy <base_ccy|quote_ccy>] \
+  [--posSide <long|short>] [--reduceOnly] \
+  [--tpTriggerPx <p>] [--tpOrdPx <p|-1>] \
+  [--slTriggerPx <p>] [--slOrdPx <p|-1>] \
+  [--callbackRatio <r>] [--callbackSpread <s>] [--activePx <p>] \
+  [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--instId` | Yes | - | Futures instrument (e.g., `BTC-USDT-<YYMMDD>`) |
+| `--side` | Yes | - | `buy` or `sell` |
+| `--ordType` | Yes | - | `oco`, `conditional`, or `move_order_stop` |
+| `--sz` | Yes | - | Number of contracts |
+| `--tdMode` | Yes | - | `cross` or `isolated` |
+| `--tgtCcy` | No | base_ccy | `base_ccy`: sz in contracts; `quote_ccy`: sz in USDT amount |
+| `--posSide` | Cond. | - | `long` or `short` — required in hedge mode |
+| `--reduceOnly` | No | false | Close-only; will not open a new position if one doesn't exist |
+| `--tpTriggerPx` | Cond. | - | Take-profit trigger price |
+| `--tpOrdPx` | Cond. | - | TP order price; use `-1` for market execution |
+| `--slTriggerPx` | Cond. | - | Stop-loss trigger price |
+| `--slOrdPx` | Cond. | - | SL order price; use `-1` for market execution |
+| `--callbackRatio` | Cond. | - | Trailing callback as a ratio (e.g., `0.02` = 2%); cannot be combined with `--callbackSpread` |
+| `--callbackSpread` | Cond. | - | Trailing callback as fixed price distance; cannot be combined with `--callbackRatio` |
+| `--activePx` | No | - | Price at which trailing stop becomes active |
+
+`--instId` format: `BTC-USDT-<YYMMDD>` (e.g., `BTC-USDT-250328`). For `move_order_stop`: provide `--callbackRatio` or `--callbackSpread` (one required).
+
+---
+
+## Futures — Place Trailing Stop
+
+```bash
+okx futures algo trail --instId <id> --side <buy|sell> --sz <n> \
+  --tdMode <cross|isolated> \
+  [--posSide <long|short>] [--reduceOnly] \
+  [--callbackRatio <ratio>] [--callbackSpread <spread>] \
+  [--activePx <price>] \
+  [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--callbackRatio` | Cond. | - | Trailing callback as a ratio (e.g., `0.02` = 2%); cannot be combined with `--callbackSpread` |
+| `--callbackSpread` | Cond. | - | Trailing callback as fixed price distance; cannot be combined with `--callbackRatio` |
+| `--activePx` | No | - | Price at which trailing stop becomes active |
+
+---
+
+## Futures — Amend Algo
+
+```bash
+okx futures algo amend --instId <id> --algoId <id> \
+  [--newSz <n>] [--newTpTriggerPx <p>] [--newTpOrdPx <p>] \
+  [--newSlTriggerPx <p>] [--newSlOrdPx <p>] [--json]
+```
+
+---
+
+## Futures — Cancel Algo
+
+```bash
+okx futures algo cancel --instId <id> --algoId <id> [--json]
+```
+
+---
+
+## Futures — Algo Orders
+
+```bash
+okx futures algo orders [--instId <id>] [--history] [--ordType <type>] [--json]
+```
+
+---
+
+## Edge Cases — Futures / Delivery
+
+- **sz unit**: number of contracts, or a USDT amount when using `--tgtCcy quote_ccy`. If the user specifies a USDT amount, pass it directly as `--sz` with `--tgtCcy quote_ccy` — do NOT manually convert to contracts
+- **Linear vs inverse**: `BTC-USDT-<YYMMDD>` is linear; `BTC-USD-<YYMMDD>` is inverse (USD face value, BTC settlement). For inverse, use `--tgtCcy quote_ccy` to specify a USD amount (note: `quote_ccy` = USD, not USDT for inverse instruments); warn the user that margin and P&L are settled in BTC
+- **instId format**: delivery futures use date suffix: `BTC-USDT-<YYMMDD>` (e.g., `BTC-USDT-260328` for March 28, 2026 expiry)
+- **Expiry**: futures expire on the delivery date — all positions auto-settle; do not hold through expiry unless intended
+- **Close position**: use `futures close` to close the **entire** position at market price — same semantics as `swap close`; to partial close, use `futures place` with `--reduceOnly`
+- **Leverage**: `futures leverage` sets leverage for a futures instrument, same constraints as swap; max leverage varies by instrument and account level
+- **Trailing stop**: use either `--callbackRatio` (relative, e.g., `0.02`) or `--callbackSpread` (absolute price), not both; same parameters as swap — `--tdMode` and `--posSide` required in hedge mode
+- **Algo on close side**: always set `--side` opposite to position (e.g., long position → `sell` algo)

--- a/Official/zo-okx-cex-trade/references/options-commands.md
+++ b/Official/zo-okx-cex-trade/references/options-commands.md
@@ -1,0 +1,196 @@
+# Options Command Reference
+
+## USDT-to-Contracts Conversion (Options Only)
+
+Options (`*-USD-YYMMDD-strike-C/P`) do **NOT** support `tgtCcy`. When the user specifies a USDT amount for options, you must convert manually:
+
+### Step 1 — Fetch contract parameters
+
+```bash
+okx market instruments --instType OPTION --instId <instId> --json
+okx option greeks --uly <BTC-USD> --expTime <YYMMDD> --json  → markPx (BTC)
+okx market ticker BTC-USDT --json                            → last price (btcPx)
+```
+
+### Step 2 — Convert USDT to contracts
+
+```
+markPx unit: base currency (e.g. BTC per contract)
+ctVal unit: base currency (e.g. 0.1 BTC)
+
+Formula (buyer cost):
+  sz = floor(usdtAmt / (markPx_BTC × btcPx × ctVal))
+
+Example — BTC-USD-250328-95000-C (markPx=0.005 BTC, btcPx=95000, ctVal=0.1 BTC):
+  200 USDT → floor(200 / (0.005 × 95000 × 0.1))
+           = floor(200 / 47.5) = floor(4.21) = 4 contracts
+  Total premium ≈ 4 × 0.005 × 0.1 = 0.002 BTC ≈ 190 USDT
+
+⚠ Always show both BTC and USDT premium cost to the buyer.
+⚠ Seller margin is also in BTC — remind user of liquidation risk.
+```
+
+### Step 3 — Validate before placing
+
+```
+After computing sz:
+
+1. sz == 0 or sz < minSz
+   → Reject. Inform user:
+     "Amount too small: minimum order is {minSz} contract(s),
+      equivalent to ~{minSz × markPx × ctVal × btcPx} USDT."
+
+2. sz not a multiple of lotSz
+   → Round down to the nearest valid multiple:
+     sz = floor(sz / lotSz) × lotSz
+
+3. sz ≥ minSz
+   → Show conversion summary and wait for user confirmation before placing:
+
+     Conversion summary:
+       Input:    {usdtAmt} USDT
+       markPx:   {markPx}  |  ctVal: {ctVal}  |  btcPx: {btcPx}
+       Raw:      {rawResult}
+       Rounded:  {sz} contracts  (~{actual USDT value})
+     Confirm order with sz={sz}?
+```
+
+---
+
+## Option — Get Instruments (Option Chain)
+
+```bash
+okx option instruments --uly <underlying> [--expTime <YYMMDD>] [--json]
+```
+
+| Param | Required | Description |
+|---|---|---|
+| `--uly` | Yes | Underlying, e.g. `BTC-USD` or `ETH-USD` |
+| `--expTime` | No | Filter by expiry date, e.g. `250328` |
+
+Returns: `instId`, `uly`, `expTime`, `stk` (strike), `optType` (C/P), `state`.
+
+Run this **before placing any option order** to get the exact `instId`.
+
+---
+
+## Option — Get Greeks
+
+```bash
+okx option greeks --uly <underlying> [--expTime <YYMMDD>] [--json]
+```
+
+Returns IV (`markVol`) and BS Greeks (`deltaBS`, `gammaBS`, `thetaBS`, `vegaBS`) plus `markPx` for each contract.
+
+---
+
+## Option — Place Order
+
+```bash
+okx option place --instId <id> --side <buy|sell> --ordType <type> \
+  --tdMode <cash|cross|isolated> --sz <n> \
+  [--px <price>] [--reduceOnly] [--clOrdId <id>] [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--instId` | Yes | - | e.g. `BTC-USD-250328-95000-C` (call) or `...-P` (put) |
+| `--side` | Yes | - | `buy` or `sell` |
+| `--ordType` | Yes | - | `market`, `limit`, `post_only`, `fok`, `ioc` |
+| `--tdMode` | Yes | - | `cash` = buyer (full premium); `cross`/`isolated` = seller (margin) |
+| `--sz` | Yes | - | Number of contracts |
+| `--px` | Cond. | - | Required for `limit`, `post_only`, `fok`, `ioc` |
+| `--reduceOnly` | No | false | Close-only; do not open a new position |
+
+**tdMode rules:**
+- Buyer (`side=buy`): always use `cash` — pay full premium, no margin call risk
+- Seller (`side=sell`): use `cross` or `isolated` — margin required, liquidation risk
+
+---
+
+## Option — Cancel Order
+
+```bash
+okx option cancel --instId <id> [--ordId <id>] [--clOrdId <id>] [--json]
+```
+
+---
+
+## Option — Amend Order
+
+```bash
+okx option amend --instId <id> [--ordId <id>] [--clOrdId <id>] \
+  [--newSz <n>] [--newPx <p>] [--json]
+```
+
+Must provide at least one of `--newSz` or `--newPx`.
+
+---
+
+## Option — Batch Cancel
+
+```bash
+okx option batch-cancel --orders '<JSON>' [--json]
+```
+
+`--orders` is a JSON array of up to 20 objects, each `{"instId":"...","ordId":"..."}`:
+
+```bash
+okx option batch-cancel --orders '[{"instId":"BTC-USD-250328-95000-C","ordId":"123"},{"instId":"BTC-USD-250328-90000-P","ordId":"456"}]'
+```
+
+---
+
+## Option — List Orders
+
+```bash
+okx option orders [--instId <id>] [--uly <underlying>] [--history] [--archive] [--json]
+```
+
+| Flag | Effect |
+|---|---|
+| *(default)* | Live/pending orders |
+| `--history` | Historical (7d) |
+| `--archive` | Older archive (3mo) |
+
+---
+
+## Option — Get Order
+
+```bash
+okx option get --instId <id> [--ordId <id>] [--clOrdId <id>] [--json]
+```
+
+Returns: `ordId`, `instId`, `side`, `ordType`, `px`, `sz`, `fillSz`, `avgPx`, `state`, `cTime`.
+
+---
+
+## Option — Positions
+
+```bash
+okx option positions [--instId <id>] [--uly <underlying>] [--json]
+```
+
+Returns: `instId`, `posSide`, `pos`, `avgPx`, `upl`, `deltaPA`, `gammaPA`, `thetaPA`, `vegaPA`. Only non-zero positions shown.
+
+---
+
+## Option — Fills
+
+```bash
+okx option fills [--instId <id>] [--ordId <id>] [--archive] [--json]
+```
+
+`--archive`: access fills beyond the default 3-day window (up to 3 months).
+
+---
+
+## Edge Cases — Options
+
+- **sz unit**: always number of contracts — Options do NOT support `--tgtCcy`, so manually convert when user gives a USDT amount. For inverse options (BTC-USD), premium is quoted in BTC; convert via `sz = floor(usdtAmt / (markPx_BTC × btcPx × ctVal))`
+- **instId format**: `{uly}-{YYMMDD}-{strike}-{C|P}` — e.g. `BTC-USD-250328-95000-C`; always run `okx option instruments --uly BTC-USD` first to confirm the exact contract exists
+- **tdMode**: buyers always use `cash` (full premium paid upfront, no liquidation); sellers use `cross` or `isolated` (margin required, liquidation risk)
+- **px unit**: quoted in base currency for inverse options (e.g. `0.005` = 0.005 BTC premium per contract); always show equivalent USDT value to the user
+- **Expiry**: options expire at 08:00 UTC on the expiry date; in-the-money options are auto-exercised; do not hold through expiry unless intended
+- **No TP/SL algo on options**: the `swap algo` / `spot algo` commands do not apply to option positions; manage risk by cancelling/amending option orders directly
+- **Greeks in positions**: `okx option positions` returns live portfolio Greeks (`deltaPA`, `gammaPA`, etc.) from the account's position-level calculation, while `okx option greeks` returns BS model Greeks per contract

--- a/Official/zo-okx-cex-trade/references/spot-commands.md
+++ b/Official/zo-okx-cex-trade/references/spot-commands.md
@@ -1,0 +1,184 @@
+# Spot Command Reference
+
+## Order Type Reference
+
+| `--ordType` | Description | Requires `--px` |
+|---|---|---|
+| `market` | Fill immediately at best price | No |
+| `limit` | Fill at specified price or better | Yes |
+| `post_only` | Limit order; cancelled if it would be a taker | Yes |
+| `fok` | Fill entire order immediately or cancel | Yes |
+| `ioc` | Fill what's available immediately, cancel rest | Yes |
+| `conditional` | Algo: single TP or SL trigger | No (set trigger px) |
+| `oco` | Algo: TP + SL together (one cancels other) | No (set both trigger px) |
+| `move_order_stop` | Trailing stop (spot/swap/futures) | No (set callback) |
+
+---
+
+## Spot — Place Order
+
+```bash
+okx spot place --instId <id> --side <buy|sell> --ordType <type> --sz <n> \
+  [--tgtCcy <base_ccy|quote_ccy>] [--px <price>] \
+  [--tpTriggerPx <p>] [--tpOrdPx <p|-1>] \
+  [--slTriggerPx <p>] [--slOrdPx <p|-1>] \
+  [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--instId` | Yes | - | Spot instrument (e.g., `BTC-USDT`) |
+| `--side` | Yes | - | `buy` or `sell` |
+| `--ordType` | Yes | - | `market`, `limit`, `post_only`, `fok`, `ioc` |
+| `--sz` | Yes | - | Order size — unit depends on `--tgtCcy` |
+| `--tgtCcy` | No | base_ccy | `base_ccy`: sz in base currency (e.g. SOL amount); `quote_ccy`: sz in quote currency (e.g. USDT amount) |
+| `--px` | Cond. | - | Price — required for `limit`, `post_only`, `fok`, `ioc` |
+| `--tpTriggerPx` | No | - | Attached take-profit trigger price |
+| `--tpOrdPx` | No | - | TP order price; use `-1` for market execution |
+| `--slTriggerPx` | No | - | Attached stop-loss trigger price |
+| `--slOrdPx` | No | - | SL order price; use `-1` for market execution |
+
+---
+
+## Spot — Cancel Order
+
+```bash
+okx spot cancel --instId <id> --ordId <id> [--json]
+```
+
+---
+
+## Spot — Amend Order
+
+```bash
+okx spot amend --instId <id> [--ordId <id>] [--clOrdId <id>] \
+  [--newSz <n>] [--newPx <p>] [--json]
+```
+
+Must provide at least one of `--newSz` or `--newPx`.
+
+---
+
+## Spot — Place Algo (TP/SL / Trail)
+
+```bash
+okx spot algo place --instId <id> --side <buy|sell> \
+  --ordType <oco|conditional|move_order_stop> --sz <n> \
+  [--tgtCcy <base_ccy|quote_ccy>] \
+  [--tpTriggerPx <p>] [--tpOrdPx <p|-1>] \
+  [--slTriggerPx <p>] [--slOrdPx <p|-1>] \
+  [--callbackRatio <r>] [--callbackSpread <s>] [--activePx <p>] \
+  [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--instId` | Yes | - | Spot instrument (e.g., `BTC-USDT`) |
+| `--side` | Yes | - | `buy` or `sell` |
+| `--ordType` | Yes | - | `oco`, `conditional`, or `move_order_stop` |
+| `--sz` | Yes | - | Order size in base currency |
+| `--tgtCcy` | No | base_ccy | `base_ccy`: sz in base currency; `quote_ccy`: sz in quote currency (e.g. USDT) |
+| `--tpTriggerPx` | Cond. | - | Take-profit trigger price |
+| `--tpOrdPx` | Cond. | - | TP order price; use `-1` for market execution |
+| `--slTriggerPx` | Cond. | - | Stop-loss trigger price |
+| `--slOrdPx` | Cond. | - | SL order price; use `-1` for market execution |
+| `--callbackRatio` | Cond. | - | Trailing callback as a ratio (e.g., `0.02` = 2%); cannot be combined with `--callbackSpread` |
+| `--callbackSpread` | Cond. | - | Trailing callback as fixed price distance; cannot be combined with `--callbackRatio` |
+| `--activePx` | No | - | Price at which trailing stop becomes active |
+
+For `oco`: provide both TP and SL params. For `conditional`: provide only TP or only SL. For `move_order_stop`: provide `--callbackRatio` or `--callbackSpread` (one required).
+
+---
+
+## Spot — Amend Algo
+
+```bash
+okx spot algo amend --instId <id> --algoId <id> \
+  [--newSz <n>] [--newTpTriggerPx <p>] [--newTpOrdPx <p>] \
+  [--newSlTriggerPx <p>] [--newSlOrdPx <p>] [--json]
+```
+
+---
+
+## Spot — Cancel Algo
+
+```bash
+okx spot algo cancel --instId <id> --algoId <id> [--json]
+```
+
+---
+
+## Spot — Place Trailing Stop
+
+```bash
+okx spot algo trail --instId <id> --side <buy|sell> --sz <n> \
+  [--callbackRatio <ratio>] [--callbackSpread <spread>] \
+  [--activePx <price>] \
+  [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--instId` | Yes | - | Spot instrument (e.g., `BTC-USDT`) |
+| `--side` | Yes | - | `buy` or `sell` — use `sell` to protect a long spot position |
+| `--sz` | Yes | - | Order size in base currency |
+| `--callbackRatio` | Cond. | - | Trailing callback as a ratio (e.g., `0.02` = 2%); cannot be combined with `--callbackSpread` |
+| `--callbackSpread` | Cond. | - | Trailing callback as fixed price distance; cannot be combined with `--callbackRatio` |
+| `--activePx` | No | - | Price at which trailing stop becomes active |
+
+> Spot trailing stop does not require `--tdMode` or `--posSide` (spot has no margin mode or position side concept).
+
+---
+
+## Spot — List Orders
+
+```bash
+okx spot orders [--instId <id>] [--history] [--json]
+```
+
+| Flag | Effect |
+|---|---|
+| *(default)* | Open/pending orders |
+| `--history` | Historical (filled, cancelled) orders |
+
+---
+
+## Spot — Get Order
+
+```bash
+okx spot get --instId <id> [--ordId <id>] [--clOrdId <id>] [--json]
+```
+
+Returns: `ordId`, `instId`, `side`, `ordType`, `px`, `sz`, `fillSz`, `avgPx`, `state`, `cTime`.
+
+---
+
+## Spot — Fills
+
+```bash
+okx spot fills [--instId <id>] [--ordId <id>] [--json]
+```
+
+Returns: `instId`, `side`, `fillPx`, `fillSz`, `fee`, `ts`.
+
+---
+
+## Spot — Algo Orders
+
+```bash
+okx spot algo orders [--instId <id>] [--history] [--ordType <type>] [--json]
+```
+
+Returns: `algoId`, `instId`, type, `side`, `sz`, `tpTrigger`, `slTrigger`, `state`.
+
+---
+
+## Edge Cases — Spot
+
+- **Market order size**: default `--sz` is in base currency (e.g., BTC amount). If user specifies a USDT amount, use `--tgtCcy quote_ccy` and pass the USDT value as `--sz` directly — do NOT manually convert
+- **Insufficient balance**: check `okx-cex-portfolio account balance` before placing
+- **Price not required**: `market` orders don't need `--px`; `limit` / `post_only` / `fok` / `ioc` do
+- **Algo oco**: provide both `tpTriggerPx` and `slTriggerPx`; price `-1` means market execution at trigger
+- **Fills vs orders**: `fills` shows executed trades; `orders --history` shows all orders including cancelled
+- **Trailing stop**: use either `--callbackRatio` (relative, e.g., `0.02`) or `--callbackSpread` (absolute price), not both; `--tdMode` and `--posSide` are not required for spot
+- **Algo on close side**: always set `--side` opposite to position direction (e.g., long spot holding → `sell` algo, short spot → `buy` algo)

--- a/Official/zo-okx-cex-trade/references/swap-commands.md
+++ b/Official/zo-okx-cex-trade/references/swap-commands.md
@@ -1,0 +1,231 @@
+# Swap / Perpetual Command Reference
+
+## Swap — Place Order
+
+```bash
+okx swap place --instId <id> --side <buy|sell> --ordType <type> --sz <n> \
+  --tdMode <cross|isolated> \
+  [--tgtCcy <base_ccy|quote_ccy>] \
+  [--posSide <long|short>] [--px <price>] \
+  [--tpTriggerPx <p>] [--tpOrdPx <p|-1>] \
+  [--slTriggerPx <p>] [--slOrdPx <p|-1>] \
+  [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--instId` | Yes | - | Swap instrument (e.g., `BTC-USDT-SWAP`) |
+| `--side` | Yes | - | `buy` or `sell` |
+| `--ordType` | Yes | - | `market`, `limit`, `post_only`, `fok`, `ioc` |
+| `--sz` | Yes | - | Order size — unit depends on `--tgtCcy` |
+| `--tdMode` | Yes | - | `cross` or `isolated` |
+| `--tgtCcy` | No | base_ccy | `base_ccy`: sz in contracts; `quote_ccy`: sz in USDT amount |
+| `--posSide` | Cond. | - | `long` or `short` — required in hedge mode |
+| `--px` | Cond. | - | Price — required for limit orders |
+| `--tpTriggerPx` | No | - | Attached take-profit trigger price |
+| `--tpOrdPx` | No | - | TP order price; use `-1` for market execution |
+| `--slTriggerPx` | No | - | Attached stop-loss trigger price |
+| `--slOrdPx` | No | - | SL order price; use `-1` for market execution |
+
+---
+
+## Swap — Cancel Order
+
+```bash
+okx swap cancel --instId <id> --ordId <id> [--json]
+```
+
+---
+
+## Swap — Amend Order
+
+```bash
+okx swap amend --instId <id> [--ordId <id>] [--clOrdId <id>] \
+  [--newSz <n>] [--newPx <p>] [--json]
+```
+
+---
+
+## Swap — Close Position
+
+```bash
+okx swap close --instId <id> --mgnMode <cross|isolated> \
+  [--posSide <long|short>] [--autoCxl] [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--instId` | Yes | - | Swap instrument |
+| `--mgnMode` | Yes | - | `cross` or `isolated` |
+| `--posSide` | Cond. | - | `long` or `short` — required in hedge mode |
+| `--autoCxl` | No | false | Auto-cancel pending orders before closing |
+
+Closes the **entire** position at market price.
+
+---
+
+## Swap — Set Leverage
+
+```bash
+okx swap leverage --instId <id> --lever <n> --mgnMode <cross|isolated> \
+  [--posSide <long|short>] [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--instId` | Yes | - | Swap instrument |
+| `--lever` | Yes | - | Leverage multiplier (e.g., `10`) |
+| `--mgnMode` | Yes | - | `cross` or `isolated` |
+| `--posSide` | Cond. | - | `long` or `short` — required for isolated mode in hedge mode |
+
+> ⚠ **Stock tokens** (e.g., `TSLA-USDT-SWAP`): maximum leverage is **5x**. The exchange will reject `--lever` values above 5 for stock token instruments.
+
+---
+
+## Swap — Get Leverage
+
+```bash
+okx swap get-leverage --instId <id> --mgnMode <cross|isolated> [--json]
+```
+
+Returns table: `instId`, `mgnMode`, `posSide`, `lever`.
+
+---
+
+## Swap — Place Algo (TP/SL / Trail)
+
+```bash
+okx swap algo place --instId <id> --side <buy|sell> \
+  --ordType <oco|conditional|move_order_stop> --sz <n> \
+  --tdMode <cross|isolated> \
+  [--tgtCcy <base_ccy|quote_ccy>] \
+  [--posSide <long|short>] [--reduceOnly] \
+  [--tpTriggerPx <p>] [--tpOrdPx <p|-1>] \
+  [--slTriggerPx <p>] [--slOrdPx <p|-1>] \
+  [--callbackRatio <r>] [--callbackSpread <s>] [--activePx <p>] \
+  [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--instId` | Yes | - | Swap instrument (e.g., `BTC-USDT-SWAP`) |
+| `--side` | Yes | - | `buy` or `sell` |
+| `--ordType` | Yes | - | `oco`, `conditional`, or `move_order_stop` |
+| `--sz` | Yes | - | Number of contracts |
+| `--tdMode` | Yes | - | `cross` or `isolated` |
+| `--tgtCcy` | No | base_ccy | `base_ccy`: sz in contracts; `quote_ccy`: sz in USDT amount |
+| `--posSide` | Cond. | - | `long` or `short` — required in hedge mode |
+| `--reduceOnly` | No | false | Close-only; will not open a new position if one doesn't exist |
+| `--tpTriggerPx` | Cond. | - | Take-profit trigger price |
+| `--tpOrdPx` | Cond. | - | TP order price; use `-1` for market execution |
+| `--slTriggerPx` | Cond. | - | Stop-loss trigger price |
+| `--slOrdPx` | Cond. | - | SL order price; use `-1` for market execution |
+| `--callbackRatio` | Cond. | - | Trailing callback as a ratio (e.g., `0.02` = 2%); cannot be combined with `--callbackSpread` |
+| `--callbackSpread` | Cond. | - | Trailing callback as fixed price distance; cannot be combined with `--callbackRatio` |
+| `--activePx` | No | - | Price at which trailing stop becomes active |
+
+For `move_order_stop`: provide `--callbackRatio` or `--callbackSpread` (one required).
+
+**Example — TP/SL worth 500 USDT on BTC perp (auto-convert to contracts):**
+```bash
+okx swap algo place --instId BTC-USDT-SWAP --side sell --ordType conditional \
+  --sz 500 --tgtCcy quote_ccy --tdMode cross --posSide long \
+  --slTriggerPx 60000 --slOrdPx -1
+```
+
+---
+
+## Swap — Place Trailing Stop
+
+```bash
+okx swap algo trail --instId <id> --side <buy|sell> --sz <n> \
+  --tdMode <cross|isolated> \
+  [--posSide <long|short>] [--reduceOnly] \
+  [--callbackRatio <ratio>] [--callbackSpread <spread>] \
+  [--activePx <price>] \
+  [--json]
+```
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `--callbackRatio` | Cond. | - | Trailing callback as a ratio (e.g., `0.02` = 2%); cannot be combined with `--callbackSpread` |
+| `--callbackSpread` | Cond. | - | Trailing callback as fixed price distance; cannot be combined with `--callbackRatio` |
+| `--activePx` | No | - | Price at which trailing stop becomes active |
+
+---
+
+## Swap — Amend Algo
+
+```bash
+okx swap algo amend --instId <id> --algoId <id> \
+  [--newSz <n>] [--newTpTriggerPx <p>] [--newTpOrdPx <p>] \
+  [--newSlTriggerPx <p>] [--newSlOrdPx <p>] [--json]
+```
+
+---
+
+## Swap — Cancel Algo
+
+```bash
+okx swap algo cancel --instId <id> --algoId <id> [--json]
+```
+
+---
+
+## Swap — List Orders
+
+```bash
+okx swap orders [--instId <id>] [--history] [--json]
+```
+
+---
+
+## Swap — Get Order
+
+```bash
+okx swap get --instId <id> [--ordId <id>] [--clOrdId <id>] [--json]
+```
+
+Returns: `ordId`, `instId`, `side`, `posSide`, `ordType`, `px`, `sz`, `fillSz`, `avgPx`, `state`, `cTime`.
+
+---
+
+## Swap — Positions
+
+```bash
+okx swap positions [<instId>] [--json]
+```
+
+Returns: `instId`, `side`, `size`, `avgPx`, `upl`, `uplRatio`, `lever`. Only non-zero positions.
+
+---
+
+## Swap — Fills
+
+```bash
+okx swap fills [--instId <id>] [--ordId <id>] [--archive] [--json]
+```
+
+`--archive`: access older fills beyond the default window.
+
+---
+
+## Swap — Algo Orders
+
+```bash
+okx swap algo orders [--instId <id>] [--history] [--ordType <type>] [--json]
+```
+
+---
+
+## Edge Cases — Swap / Perpetual
+
+- **sz unit**: number of contracts, or a USDT amount when using `--tgtCcy quote_ccy`. If the user specifies a USDT amount, pass it directly as `--sz` with `--tgtCcy quote_ccy` — do NOT manually convert to contracts
+- **Linear vs inverse**: `BTC-USDT-SWAP` is linear (USDT-margined); `BTC-USD-SWAP` is inverse (BTC-margined). For inverse, warn the user that margin and P&L are settled in BTC
+- **posSide**: required in hedge mode (`long_short_mode`); omit in net mode. Check `okx account config` for `posMode`
+- **tdMode**: use `cross` for cross-margin, `isolated` for isolated margin
+- **Close position**: `swap close` closes the **entire** position; to partial close, use `swap place` with a reduce-only algo
+- **Leverage**: max leverage varies by instrument and account level; exchange rejects if exceeded
+- **Trailing stop**: use either `--callbackRatio` (relative, e.g., `0.02`) or `--callbackSpread` (absolute price), not both
+- **Algo on close side**: always set `--side` opposite to position (e.g., long position → sell algo)
+- **Stock tokens (instCategory=3)**: instruments like `TSLA-USDT-SWAP`, `NVDA-USDT-SWAP` follow the same linear SWAP flow (USDT-margined, sz in contracts). Key differences: (1) max leverage **5x** — check with `swap get-leverage` before placing, set with `swap leverage --lever <n≤5>`; (2) `--posSide` is always required; (3) trading restricted to stock market hours (US stocks: Mon–Fri ~09:30–16:00 ET) — confirm live ticker before placing. Use `okx market stock-tokens` to list available instruments

--- a/Official/zo-okx-cex-trade/references/templates.md
+++ b/Official/zo-okx-cex-trade/references/templates.md
@@ -1,0 +1,73 @@
+# MCP Tool Reference & Output Conventions
+
+## MCP Tool Reference
+
+| Tool | Description |
+|---|---|
+| `spot_place_order` | Place spot order |
+| `spot_cancel_order` | Cancel spot order |
+| `spot_amend_order` | Amend spot order |
+| `spot_place_algo_order` | Place spot TP/SL algo |
+| `spot_amend_algo_order` | Amend spot algo |
+| `spot_cancel_algo_order` | Cancel spot algo |
+| `spot_get_orders` | List spot orders |
+| `spot_get_order` | Get single spot order |
+| `spot_get_fills` | Spot fill history |
+| `spot_get_algo_orders` | List spot algo orders |
+| `swap_place_order` | Place swap order |
+| `swap_cancel_order` | Cancel swap order |
+| `swap_amend_order` | Amend swap order |
+| `swap_close_position` | Close swap position |
+| `swap_set_leverage` | Set swap leverage |
+| `swap_place_algo_order` | Place swap TP/SL algo |
+| `swap_place_move_stop_order` | Place trailing stop (swap/futures) |
+| `swap_amend_algo_order` | Amend swap algo |
+| `swap_cancel_algo_orders` | Cancel swap algo |
+| `swap_get_positions` | Swap positions |
+| `swap_get_orders` | List swap orders |
+| `swap_get_order` | Get single swap order |
+| `swap_get_fills` | Swap fill history |
+| `swap_get_leverage` | Get swap leverage |
+| `swap_get_algo_orders` | List swap algo orders |
+| `futures_place_order` | Place futures order |
+| `futures_cancel_order` | Cancel futures order |
+| `futures_amend_order` | Amend futures order |
+| `futures_close_position` | Close futures position |
+| `futures_set_leverage` | Set futures leverage |
+| `futures_place_algo_order` | Place futures TP/SL algo |
+| `futures_place_move_stop_order` | Place futures trailing stop |
+| `futures_amend_algo_order` | Amend futures algo |
+| `futures_cancel_algo_orders` | Cancel futures algo |
+| `futures_get_orders` | List futures orders |
+| `futures_get_positions` | Futures positions |
+| `futures_get_fills` | Futures fill history |
+| `futures_get_order` | Get single futures order |
+| `futures_get_leverage` | Get futures leverage |
+| `futures_get_algo_orders` | List futures algo orders |
+| `option_get_instruments` | Option chain (list available contracts) |
+| `option_get_greeks` | IV and Greeks by underlying |
+| `option_place_order` | Place option order |
+| `option_cancel_order` | Cancel option order |
+| `option_amend_order` | Amend option order |
+| `option_batch_cancel` | Batch cancel up to 20 option orders |
+| `option_get_orders` | List option orders |
+| `option_get_order` | Get single option order |
+| `option_get_positions` | Option positions with live Greeks |
+| `option_get_fills` | Option fill history |
+
+---
+
+## Output Conventions
+
+- Always pass `--json` to list/query commands and render results as a Markdown table — never paste raw terminal output
+- Every command result includes a `[profile: <name>]` tag for audit reference
+- `--json` returns raw OKX API v5 response
+
+## tgtCcy Rule
+
+**Spot / Swap / Futures**: when user specifies a quote-currency amount (e.g. "30 USDT worth"), MUST use `--tgtCcy quote_ccy` and pass the USDT amount as `--sz`. Do NOT manually calculate base currency quantity or contract count — let the API handle the conversion. When user specifies base currency quantity or contract count, omit `--tgtCcy` (defaults to `base_ccy`). Options do NOT support `--tgtCcy` — manual conversion required (see `{baseDir}/references/options-commands.md`).
+
+## Order Amount Safety Rules
+
+- **Order amount mismatch**: If the order would execute at a significantly different amount than the user requested (e.g. due to minSz or conversion), STOP and inform the user. Never auto-adjust order size without explicit user confirmation.
+- **No follow-up orders**: After an order executes, if the filled amount materially differs from what the user requested (beyond normal rounding or minimum lot size differences), STOP immediately. Inform the user of the actual filled amount and the discrepancy. Do NOT place any additional orders to compensate for the shortfall or overfill. Wait for explicit user instruction before taking further action.

--- a/Official/zo-okx-cex-trade/references/workflows.md
+++ b/Official/zo-okx-cex-trade/references/workflows.md
@@ -1,0 +1,323 @@
+# Trade Workflows & Examples
+
+## Cross-Skill Workflows
+
+### Spot market buy
+> User: "Buy $500 worth of ETH at market"
+
+```
+1. okx-cex-portfolio okx account balance USDT               → confirm available funds ≥ $500
+        ↓ user approves
+2. okx-cex-trade     okx spot place --instId ETH-USDT --side buy --ordType market --sz 500 --tgtCcy quote_ccy
+3. okx-cex-trade     okx spot fills --instId ETH-USDT        → confirm fill price and size
+```
+
+### Open long BTC perp with TP/SL
+> User: "Long 5 contracts BTC perp at market, TP at $105k, SL at $88k"
+
+```
+1. okx-cex-portfolio okx account balance USDT               → confirm margin available
+2. okx-cex-portfolio okx account max-size --instId BTC-USDT-SWAP --tdMode cross → confirm size ok
+        ↓ user approves
+3. okx-cex-trade     okx swap place --instId BTC-USDT-SWAP --side buy \
+                       --ordType market --sz 5 --tdMode cross --posSide long \
+                       --tpTriggerPx 105000 --tpOrdPx -1 \
+                       --slTriggerPx 88000 --slOrdPx -1
+4. okx-cex-trade     okx swap positions                     → confirm position opened
+```
+
+> **Note:** TP/SL is attached directly to the order via `--tpTriggerPx`/`--slTriggerPx` — no separate `swap algo place` step needed. Use `swap algo place` only when adding TP/SL to an **existing** position.
+
+### Adjust leverage then place order
+> User: "Set BTC perp to 5x leverage then go long 10 contracts"
+
+```
+1. okx-cex-trade     okx swap get-leverage --instId BTC-USDT-SWAP --mgnMode cross → check current lever
+        ↓ user approves change
+2. okx-cex-trade     okx swap leverage --instId BTC-USDT-SWAP --lever 5 --mgnMode cross
+3. okx-cex-trade     okx swap place --instId BTC-USDT-SWAP --side buy \
+                       --ordType market --sz 10 --tdMode cross --posSide long
+4. okx-cex-trade     okx swap positions                     → confirm position + leverage
+```
+
+### Place trailing stop on open position
+> User: "Set a 3% trailing stop on my open position"
+
+Spot example (no margin mode needed):
+```
+1. okx-cex-portfolio okx account balance BTC               → confirm spot BTC holdings
+2. okx-cex-market    okx market ticker BTC-USDT            → current price reference
+        ↓ user approves
+3. okx-cex-trade     okx spot algo trail --instId BTC-USDT --side sell \
+                       --sz <spot_sz> --callbackRatio 0.03
+4. okx-cex-trade     okx spot algo orders --instId BTC-USDT → confirm trail order placed
+```
+
+Swap/Perpetual example:
+```
+1. okx-cex-trade     okx swap positions                     → confirm size of open long
+2. okx-cex-market    okx market ticker BTC-USDT-SWAP        → current price reference
+        ↓ user approves
+3. okx-cex-trade     okx swap algo trail --instId BTC-USDT-SWAP --side sell \
+                       --sz <pos_size> --tdMode cross --posSide long --callbackRatio 0.03
+4. okx-cex-trade     okx swap algo orders --instId BTC-USDT-SWAP → confirm trail order placed
+```
+
+Futures/Delivery example:
+```
+1. okx-cex-trade     okx futures positions                  → confirm size of open long
+2. okx-cex-market    okx market ticker BTC-USDT-<YYMMDD>      → current price reference
+        ↓ user approves
+3. okx-cex-trade     okx futures algo trail --instId BTC-USDT-<YYMMDD> --side sell \
+                       --sz <pos_size> --tdMode cross --posSide long --callbackRatio 0.03
+4. okx-cex-trade     okx futures algo orders --instId BTC-USDT-<YYMMDD> → confirm trail order placed
+```
+
+### Trade a stock token (TSLA / NVDA / AAPL)
+> User: "I want to long TSLA with 500 USDT"
+
+```
+1. okx-cex-market   okx market stock-tokens              → confirm TSLA-USDT-SWAP is available
+2. okx-cex-market   okx market ticker TSLA-USDT-SWAP     → current price (e.g., markPx=310 USDT)
+3. okx-cex-market   okx market instruments --instType SWAP --instId TSLA-USDT-SWAP --json
+                    → ctVal=1, minSz=1, lotSz=1
+   Agent computes:  sz = floor(500 / (310 × 1)) = 1 contract (~310 USDT)
+   Agent shows conversion summary and asks to confirm
+
+        ↓ user confirms
+
+4. okx-cex-portfolio okx account balance USDT            → confirm margin available
+5. okx-cex-trade    okx swap get-leverage --instId TSLA-USDT-SWAP --mgnMode cross
+                    → check current leverage; must be ≤ 5x
+   (if not set or > 5x) okx swap leverage --instId TSLA-USDT-SWAP --lever 5 --mgnMode cross
+6. okx-cex-trade    okx swap place --instId TSLA-USDT-SWAP --side buy --ordType market \
+                      --sz 1 --tdMode cross --posSide long
+7. okx-cex-trade    okx swap positions TSLA-USDT-SWAP    → confirm position opened
+```
+
+> ⚠ **Stock token constraints**: max leverage **5x** (exchange rejects > 5x). `--posSide` is required. Trading follows stock market hours — confirm live ticker before placing.
+
+---
+
+### Open linear swap by USDT amount
+> User: "用 200 USDT 做多 ETH 永续 (cross margin)"
+
+```
+1. okx-cex-market  okx market instruments --instType SWAP --instId ETH-USDT-SWAP --json
+                   → ctVal=0.1 ETH, minSz=1, lotSz=1
+
+2. okx-cex-market  okx market mark-price --instType SWAP --instId ETH-USDT-SWAP --json
+                   → markPx=2000 USDT
+
+3. Agent computes:  sz = floor(200 / (2000 × 0.1)) = 1 contract (~200 USDT)
+   Agent informs user of conversion summary and asks to confirm
+
+        ↓ user confirms
+
+4. okx-cex-trade   okx swap place --instId ETH-USDT-SWAP --side buy --ordType market \
+                     --sz 1 --tdMode cross --posSide long
+
+5. okx-cex-trade   okx swap positions ETH-USDT-SWAP    → confirm position opened
+```
+
+### Open inverse swap by USDT amount
+> User: "用 500 USDT 开一个 BTC 币本位永续多单"
+
+```
+1. okx-cex-market  okx market instruments --instType SWAP --instId BTC-USD-SWAP --json
+                   → ctVal=100 USD, minSz=1
+
+2. Agent computes:  sz = floor(500 / 100) = 5 contracts
+   Agent warns:    "BTC-USD-SWAP 是币本位合约，保证金和盈亏以 BTC 结算，非 USDT。
+                    请确认账户有足够 BTC 作为保证金。"
+   Agent shows conversion summary and asks to confirm
+
+        ↓ user confirms
+
+3. okx-cex-trade   okx swap place --instId BTC-USD-SWAP --side buy --ordType market \
+                     --sz 5 --tdMode cross --posSide long
+
+4. okx-cex-trade   okx swap positions BTC-USD-SWAP    → confirm position opened
+```
+
+### Cancel all open spot orders
+> User: "Cancel all my open BTC spot orders"
+
+```
+1. okx-cex-trade     okx spot orders                        → list open orders
+2. okx-cex-trade     (for each ordId) okx spot cancel --instId BTC-USDT --ordId <id>
+3. okx-cex-trade     okx spot orders                        → confirm all cancelled
+```
+
+### Buy a BTC call option
+> User: "Buy 2 BTC call options at strike 95000 expiring end of March"
+
+```
+1. okx-cex-trade     okx option instruments --uly BTC-USD --expTime 250328
+                     → find exact instId (e.g. BTC-USD-250328-95000-C)
+2. okx-cex-trade     okx option greeks --uly BTC-USD --expTime 250328
+                     → check IV, delta, and markPx to assess fair value
+3. okx-cex-portfolio okx account balance                    → confirm enough USDT/BTC for premium
+        ↓ user approves
+4. okx-cex-trade     okx option place --instId BTC-USD-250328-95000-C \
+                       --side buy --ordType limit --tdMode cash --sz 2 --px 0.005
+5. okx-cex-trade     okx option orders                      → confirm order is live
+```
+
+### Check option portfolio Greeks
+> User: "What's my total delta exposure from options?"
+
+```
+1. okx-cex-trade     okx option positions                   → live positions with per-contract Greeks
+2. okx-cex-market    okx market ticker BTC-USD              → current spot price for context
+```
+
+---
+
+## Input / Output Examples
+
+**"Buy 0.05 BTC at market"**
+```bash
+okx spot place --instId BTC-USDT --side buy --ordType market --sz 0.05
+# → Order placed: 7890123456 (OK)
+```
+
+**"Set a limit sell for 0.1 ETH at $3500"**
+```bash
+okx spot place --instId ETH-USDT --side sell --ordType limit --sz 0.1 --px 3500
+# → Order placed: 7890123457 (OK)
+```
+
+**"Show my open spot orders"**
+```bash
+okx spot orders
+# → table: ordId, instId, side, type, price, size, filled, state
+```
+
+**"Long 10 contracts BTC perp at market (cross margin)"**
+```bash
+okx swap place --instId BTC-USDT-SWAP --side buy --ordType market --sz 10 \
+  --tdMode cross --posSide long
+# → Order placed: 7890123458 (OK)
+```
+
+**"Long 10 contracts BTC perp with TP at $105k and SL at $88k"**
+```bash
+okx swap place --instId BTC-USDT-SWAP --side buy --ordType market --sz 10 \
+  --tdMode cross --posSide long \
+  --tpTriggerPx 105000 --tpOrdPx -1 --slTriggerPx 88000 --slOrdPx -1
+# → Order placed: 7890123459 (OK) — TP/SL attached via attachAlgoOrds
+```
+
+**"Set take profit at $105k and stop loss at $88k on an existing BTC perp long"**
+```bash
+okx swap algo place --instId BTC-USDT-SWAP --side sell --ordType oco --sz 10 \
+  --tdMode cross --posSide long \
+  --tpTriggerPx 105000 --tpOrdPx -1 \
+  --slTriggerPx 88000 --slOrdPx -1
+# → Algo order placed: ALGO456789 (OK)
+```
+
+**"Close my ETH perp position"**
+```bash
+okx swap close --instId ETH-USDT-SWAP --mgnMode cross --posSide long
+# → Position closed: ETH-USDT-SWAP long
+```
+
+**"Set BTC perp leverage to 5x (cross)"**
+```bash
+okx swap leverage --instId BTC-USDT-SWAP --lever 5 --mgnMode cross
+# → Leverage set: 5x BTC-USDT-SWAP
+```
+
+**"Long 1 contract TSLA stock token at market (cross margin)"**
+```bash
+okx swap place --instId TSLA-USDT-SWAP --side buy --ordType market --sz 1 \
+  --tdMode cross --posSide long
+# → Order placed: 7890123461 (OK) [profile: live]
+```
+
+**"Open short on NVDA, 2 contracts"**
+```bash
+okx swap place --instId NVDA-USDT-SWAP --side sell --ordType market --sz 2 \
+  --tdMode cross --posSide short
+# → Order placed: 7890123462 (OK) [profile: live]
+```
+
+**"Place a 2% trailing stop on my BTC perp long"**
+```bash
+okx swap algo trail --instId BTC-USDT-SWAP --side sell --sz 10 \
+  --tdMode cross --posSide long --callbackRatio 0.02
+# → Trailing stop placed: TRAIL123 (OK)
+```
+
+**"Place a 3% trailing stop on my spot BTC"**
+```bash
+okx spot algo trail --instId BTC-USDT --side sell --sz 0.01 --callbackRatio 0.03
+# → Trailing stop placed: TRAIL456 (OK)
+```
+
+**"Place a 2% trailing stop on my BTC futures long"**
+```bash
+okx futures algo trail --instId BTC-USDT-<YYMMDD> --side sell --sz 5 \
+  --tdMode cross --posSide long --callbackRatio 0.02
+# → Trailing stop placed: TRAIL789 (OK)
+```
+
+**"Close my BTC futures long position"**
+```bash
+okx futures close --instId BTC-USDT-260328 --mgnMode cross --posSide long
+# → Position closed: BTC-USDT-260328 long
+```
+
+**"Set BTC futures leverage to 10x (cross)"**
+```bash
+okx futures leverage --instId BTC-USDT-260328 --lever 10 --mgnMode cross
+# → Leverage set: 10x BTC-USDT-260328
+```
+
+**"Place a TP at $105k and SL at $88k on my ETH futures long"**
+```bash
+okx futures algo place --instId ETH-USDT-260328 --side sell --ordType oco --sz 5 \
+  --tdMode cross --posSide long \
+  --tpTriggerPx 105000 --tpOrdPx -1 \
+  --slTriggerPx 88000 --slOrdPx -1
+# → Algo order placed: ALGO789012 (OK)
+```
+
+**"Show my open swap positions"**
+```bash
+okx swap positions
+# → table: instId, side, size, avgPx, upl, uplRatio, lever
+```
+
+**"What are my recent fill trades for BTC spot?"**
+```bash
+okx spot fills --instId BTC-USDT
+# → table: instId, side, fillPx, fillSz, fee, ts
+```
+
+**"Show me the BTC option chain expiring March 28"**
+```bash
+okx option instruments --uly BTC-USD --expTime 250328
+# → table: instId, expTime, stk, optType (C/P), state
+```
+
+**"What's the IV and delta for BTC options expiring March 28?"**
+```bash
+okx option greeks --uly BTC-USD --expTime 250328
+# → table: instId, delta, gamma, theta, vega, iv (markVol), markPx
+```
+
+**"Buy 1 BTC call at strike 95000 expiring March 28, limit at 0.005 BTC"**
+```bash
+okx option place --instId BTC-USD-250328-95000-C \
+  --side buy --ordType limit --tdMode cash --sz 1 --px 0.005
+# → Order placed: 7890123460 (OK)
+```
+
+**"Show my open option positions"**
+```bash
+okx option positions
+# → table: instId, posSide, pos, avgPx, upl, delta, gamma, theta, vega
+```


### PR DESCRIPTION
## Summary
- add official Zo-owned MoonPay skills for auth, wallet checks, buy, swap, and virtual-account flows
- add official Zo-owned OKX skills for market, portfolio, and trade flows
- include the upstream OKX support package shape with shared preflight and references, while keeping Zo-native workflow guidance

## Validation
- bun run index.ts validate
- smoke-checked MoonPay and OKX CLI command surfaces on Zo
