### PR TITLE
feat: add honcho-memory skill

### DIFF
--- a/Community/honcho-memory/DISPLAY.json
+++ b/Community/honcho-memory/DISPLAY.json
@@ -1,0 +1,6 @@
+{
+  "specVersion": "0.1.0",
+  "icon": "brain",
+  "tags": ["memory", "ai", "personalization"],
+  "integrations": ["honcho"]
+}

--- a/Community/honcho-memory/README.md
+++ b/Community/honcho-memory/README.md
@@ -1,0 +1,147 @@
+# Honcho Memory Skill for Zo Computer
+
+Give your AI persistent memory across conversations using [Honcho](https://honcho.dev).
+
+## Features
+
+- **Auto-Memory**: Save user and assistant messages to Honcho with one call
+- **Query Memory**: Ask natural language questions about what Honcho remembers ("What are my hobbies?")
+- **Context Injection**: Retrieve conversation context formatted for direct LLM use
+- **Multi-Workspace Support**: Manage separate memory spaces via `HONCHO_WORKSPACE_ID`
+
+## Installation
+
+```bash
+pip install honcho-ai python-dotenv
+```
+
+Or with uv:
+
+```bash
+uv add honcho-ai python-dotenv
+```
+
+## Environment Variables
+
+Create a `.env` file:
+
+```env
+HONCHO_API_KEY=your-api-key-here
+HONCHO_WORKSPACE_ID=default
+```
+
+Get your API key at [honcho.dev](https://honcho.dev).
+
+## Quick Start
+
+```python
+from scripts.save_memory import save_memory
+from scripts.query_memory import query_memory
+from scripts.get_context import get_context
+
+# Save a conversation turn
+save_memory("alice", "I love hiking in the mountains", "user", "session-1")
+save_memory("alice", "That sounds wonderful!", "assistant", "session-1")
+
+# Query what Honcho remembers
+answer = query_memory("alice", "What are my hobbies?", "session-1")
+print(answer)  # "Alice enjoys hiking in the mountains."
+
+# Get context ready for an LLM call
+messages = get_context("alice", "session-1", "assistant", tokens=4000)
+# messages is a list of {"role": ..., "content": ...} dicts
+```
+
+## Tool Reference
+
+### `save_memory(user_id, content, role, session_id, assistant_id="assistant")`
+
+Saves a message to Honcho memory.
+
+| Param | Type | Description |
+|---|---|---|
+| `user_id` | `str` | Unique user identifier |
+| `content` | `str` | Message text |
+| `role` | `str` | `"user"` or `"assistant"` |
+| `session_id` | `str` | Session/conversation identifier |
+| `assistant_id` | `str` | Peer ID for the assistant. Defaults to `"assistant"` |
+
+Returns a confirmation string.
+
+---
+
+### `query_memory(user_id, query, session_id=None)`
+
+Queries stored memory using Honcho's Dialectic API.
+
+| Param | Type | Description |
+|---|---|---|
+| `user_id` | `str` | Unique user identifier |
+| `query` | `str` | Natural language question |
+| `session_id` | `str \| None` | Optional: scope to a specific session. Defaults to `None` (global memory) |
+
+Returns a natural language answer.
+
+> **Note:** In shared workspaces, `query_memory` may return data from other peers if the queried user has no stored memory yet. The Dialectic API draws from workspace-level context as a fallback. Use unique `HONCHO_WORKSPACE_ID` values per user group in production to prevent cross-peer data leakage.
+
+---
+
+### `get_context(user_id, session_id, assistant_id, tokens=4000)`
+
+Retrieves conversation context in OpenAI message format.
+
+| Param | Type | Description |
+|---|---|---|
+| `user_id` | `str` | Unique user identifier |
+| `session_id` | `str` | Session/conversation identifier |
+| `assistant_id` | `str` | Peer ID for the assistant |
+| `tokens` | `int` | Max tokens to include (default: 4000) |
+
+Returns a list of `{"role": ..., "content": ...}` dicts.
+
+## Concept Mapping
+
+| Zo Computer | Honcho |
+|---|---|
+| Account | Workspace |
+| User | Peer |
+| Conversation | Session |
+| Message | Message |
+
+## Running Tests
+
+Requires a running Honcho server. See the [main repo](../../README.md) for setup instructions.
+
+```bash
+uv run pytest tests/ -v
+```
+
+## Submitting to the Zo Skill Marketplace
+
+To publish this skill to the [Zo Skills Registry](https://github.com/zocomputer/skills):
+
+1. **Fork** the `zocomputer/skills` repository.
+2. **Copy** this directory into the `/Community` folder of your fork, naming it `honcho-memory`:
+
+   ```
+   Community/
+   └── honcho-memory/
+       ├── SKILL.md
+       ├── README.md
+       ├── pyproject.toml
+       └── scripts/
+   ```
+
+3. **Validate** your skill:
+
+   ```bash
+   bun validate
+   ```
+
+4. **Submit a pull request** to the upstream registry repository.
+
+Once merged, the skill will be automatically added to the Zo marketplace `manifest.json`.
+
+## License
+
+AGPL-3.0-or-later

--- a/Community/honcho-memory/SKILL.md
+++ b/Community/honcho-memory/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: honcho-memory
+description: Gives AI agents persistent memory across conversations using Honcho. Automatically saves and retrieves user context so the AI remembers preferences, history, and facts between sessions. Use when you need the AI to remember past conversations, recall what a user has told it, inject relevant context into prompts, or manage separate memory spaces for different topics.
+license: AGPL-3.0
+compatibility: Requires Python 3.9+, honcho-ai>=2.1.0, and a Honcho API key from honcho.dev. Set HONCHO_API_KEY and optionally HONCHO_WORKSPACE_ID in your environment.
+metadata:
+  author: plastic-labs
+  version: "0.1.0"
+  honcho-sdk: "2.1.0"
+---
+
+# Honcho Memory Skill
+
+This skill provides three tools for storing and retrieving AI memory using [Honcho](https://honcho.dev).
+
+## Setup
+
+1. Get a Honcho API key at [honcho.dev](https://honcho.dev).
+2. Set environment variables:
+
+   ```
+   HONCHO_API_KEY=your-api-key
+   HONCHO_WORKSPACE_ID=default   # optional, defaults to "default"
+   ```
+
+3. Install dependencies:
+
+   ```
+   pip install honcho-ai python-dotenv
+   ```
+
+## Tools
+
+### `save_memory`
+
+Saves a conversation turn (user or assistant message) to Honcho.
+
+**When to use:** After every message exchange to build up the user's memory.
+
+```python
+from scripts.save_memory import save_memory
+
+save_memory(
+    user_id="alice",           # unique user identifier
+    content="I love hiking",   # message text
+    role="user",               # "user" or "assistant"
+    session_id="chat-1",       # conversation session ID
+    assistant_id="assistant"   # optional: assistant peer ID (default: "assistant")
+)
+```
+
+### `query_memory`
+
+Asks a natural language question against stored memory using Honcho's Dialectic API.
+
+**When to use:** When the user asks "do you remember...?", or when you need to recall facts about the user before responding.
+
+```python
+from scripts.query_memory import query_memory
+
+answer = query_memory(
+    user_id="alice",
+    query="What are Alice's hobbies?",
+    session_id="chat-1"   # optional: scope to a session
+)
+# Returns: "Alice enjoys hiking."
+```
+
+### `get_context`
+
+Retrieves recent conversation history formatted for direct use in an LLM API call.
+
+**When to use:** At the start of each LLM call to inject relevant context from past conversations.
+
+```python
+from scripts.get_context import get_context
+
+messages = get_context(
+    user_id="alice",
+    session_id="chat-1",
+    assistant_id="assistant",
+    tokens=4000              # max tokens to include
+)
+# Returns: [{"role": "user", "content": "..."}, ...]
+```
+
+## Concept Mapping
+
+| Zo Computer | Honcho |
+|---|---|
+| Account | Workspace |
+| User | Peer |
+| Conversation | Session |
+| Message | Message |
+
+## Example: Full Conversation Flow
+
+```python
+from scripts.save_memory import save_memory
+from scripts.query_memory import query_memory
+from scripts.get_context import get_context
+
+user_id = "alice"
+session_id = "session-1"
+
+# 1. Save user message
+save_memory(user_id, "I'm learning Rust and love rock climbing", "user", session_id)
+
+# 2. Save assistant reply
+save_memory(user_id, "That's great! Both require patience.", "assistant", session_id)
+
+# 3. In a later session, recall what you know
+print(query_memory(user_id, "What does Alice do in her free time?"))
+# → "Alice is learning Rust and enjoys rock climbing."
+
+# 4. Get context window for next LLM call
+messages = get_context(user_id, session_id, "assistant", tokens=4000)
+```

--- a/Community/honcho-memory/pyproject.toml
+++ b/Community/honcho-memory/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "honcho-zo-skill"
+version = "0.1.0"
+description = "Honcho persistent memory skill for Zo Computer"
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "honcho-ai>=2.1.0",
+    "python-dotenv>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["tools"]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/Community/honcho-memory/scripts/__init__.py
+++ b/Community/honcho-memory/scripts/__init__.py
@@ -1,0 +1,7 @@
+"""Honcho memory tools for Zo Computer."""
+
+from tools.get_context import get_context
+from tools.query_memory import query_memory
+from tools.save_memory import save_memory
+
+__all__ = ["get_context", "query_memory", "save_memory"]

--- a/Community/honcho-memory/scripts/client.py
+++ b/Community/honcho-memory/scripts/client.py
@@ -1,0 +1,32 @@
+"""Honcho client initialization for Zo Computer skill."""
+
+import os
+
+from dotenv import load_dotenv
+from honcho import Honcho
+
+load_dotenv()
+
+
+def get_client(workspace_id: str | None = None) -> Honcho:
+    """Initialize and return a Honcho client.
+
+    Reads HONCHO_API_KEY and HONCHO_WORKSPACE_ID from environment variables.
+    The workspace_id parameter overrides the environment variable if provided.
+
+    Args:
+        workspace_id: Optional workspace ID override. Falls back to the
+            HONCHO_WORKSPACE_ID env var, then to "default".
+
+    Returns:
+        Configured Honcho client instance.
+    """
+    api_key = os.getenv("HONCHO_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "HONCHO_API_KEY is required. Set it in your environment or .env file."
+        )
+
+    env_workspace = os.getenv("HONCHO_WORKSPACE_ID")
+    resolved_workspace = workspace_id or env_workspace or "default"
+    return Honcho(api_key=api_key, workspace_id=resolved_workspace)

--- a/Community/honcho-memory/scripts/get_context.py
+++ b/Community/honcho-memory/scripts/get_context.py
@@ -1,0 +1,42 @@
+"""Retrieve conversation context from Honcho formatted for LLM use."""
+
+from __future__ import annotations
+
+from .client import get_client
+
+
+def get_context(
+    user_id: str,
+    session_id: str,
+    assistant_id: str,
+    tokens: int = 4000,
+) -> list[dict[str, str]]:
+    """Retrieve conversation context ready for injection into an LLM prompt.
+
+    Fetches recent messages from a Honcho session within the given token
+    budget and converts them to OpenAI-compatible message format. Use the
+    returned list directly as the ``messages`` parameter in an LLM API call.
+
+    Args:
+        user_id: Unique identifier for the user peer. Used to ensure the
+            peer is registered in the session before fetching context.
+        session_id: Identifier for the conversation session.
+        assistant_id: Peer ID representing the assistant. This determines
+            which role is mapped to ``"assistant"`` in the output.
+        tokens: Maximum number of tokens to include in the context window.
+            Defaults to 4000.
+
+    Returns:
+        A list of message dicts in OpenAI format:
+        ``[{"role": "user" | "assistant", "content": "..."}]``.
+        Returns an empty list if the session has no messages.
+    """
+    honcho = get_client()
+    user_peer = honcho.peer(user_id)
+    assistant_peer = honcho.peer(assistant_id)
+    session = honcho.session(session_id)
+
+    session.add_peers([user_peer, assistant_peer])
+
+    context = session.context(tokens=tokens)
+    return context.to_openai(assistant=assistant_id)

--- a/Community/honcho-memory/scripts/query_memory.py
+++ b/Community/honcho-memory/scripts/query_memory.py
@@ -1,0 +1,37 @@
+"""Query a user's Honcho memory using the Dialectic API."""
+
+from __future__ import annotations
+
+from .client import get_client
+
+
+def query_memory(user_id: str, query: str, session_id: str | None = None) -> str:
+    """Query stored memory for a user using Honcho's Dialectic API.
+
+    Sends a natural language question to Honcho and returns an answer
+    grounded in the peer's long-term representation and stored observations.
+
+    Args:
+        user_id: Unique identifier for the user peer.
+        query: Natural language question, e.g. "What are my hobbies?".
+        session_id: Optional session ID to scope the query to a specific
+            conversation. If omitted, the query draws from global memory.
+
+    Returns:
+        A natural language answer from Honcho's Dialectic API, or a
+        default message if no relevant information was found.
+
+    Raises:
+        ValueError: If query is empty.
+    """
+    if not query:
+        raise ValueError("query must not be empty")
+
+    honcho = get_client()
+    peer = honcho.peer(user_id)
+
+    response = peer.chat(query=query, session=session_id)
+
+    if response:
+        return str(response)
+    return "No relevant information found in memory."

--- a/Community/honcho-memory/scripts/save_memory.py
+++ b/Community/honcho-memory/scripts/save_memory.py
@@ -1,0 +1,45 @@
+"""Save a conversation message to Honcho memory."""
+
+from .client import get_client
+
+
+def save_memory(
+    user_id: str,
+    content: str,
+    role: str,
+    session_id: str,
+    assistant_id: str = "assistant",
+) -> str:
+    """Save a single conversation turn to Honcho memory.
+
+    Creates the peer and session if they do not already exist. Registers
+    the peer in the session on first use, then persists the message.
+
+    Args:
+        user_id: Unique identifier for the user peer.
+        content: Text content of the message to save.
+        role: Either "user" or "assistant". Determines which peer sends
+            the message. Any value other than "assistant" is treated as "user".
+        session_id: Identifier for the conversation session.
+        assistant_id: Peer ID for the assistant. Defaults to "assistant".
+
+    Returns:
+        A confirmation string describing what was saved.
+
+    Raises:
+        ValueError: If content is empty.
+    """
+    if not content:
+        raise ValueError("content must not be empty")
+
+    honcho = get_client()
+    user_peer = honcho.peer(user_id)
+    assistant_peer = honcho.peer(assistant_id)
+    session = honcho.session(session_id)
+
+    session.add_peers([user_peer, assistant_peer])
+
+    sender = assistant_peer if role == "assistant" else user_peer
+    session.add_messages([sender.message(content)])
+
+    return f"Saved {role} message to session '{session_id}' for user '{user_id}'."

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "skills",


### PR DESCRIPTION
Adds a new community skill that gives AI agents persistent memory across conversations
   using https://honcho.dev.
                                                                                        
  What it does    
                                                                                       
  Three ready-to-use tools:
  - save_memory — saves user/assistant messages to Honcho
  - query_memory — asks natural language questions about what the AI remembers ("What   
  are my hobbies?")                                                                  
  - get_context — retrieves conversation history formatted for direct LLM use           
                  
  Notes                                                                                 
                  
  - Tested live in Zo Computer                                                          
  - Already merged into the official https://github.com/plastic-labs/honcho repo as part
   of their examples                                                                    
  - Requires a free Honcho API key from https://honcho.dev