### PR TITLE
Update supermemory skill to use official npx CLI

### DIFF
--- a/Community/supermemory/SKILL.md
+++ b/Community/supermemory/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: supermemory
 description: >
-  Long-term memory that persists across conversations. Save facts, decisions,
-  and preferences to a knowledge graph that builds a living profile of the user
-  over time. Replaces static user docs with dynamic context that grows and
-  self-corrects.
-compatibility: Created for Zo Computer
+  Long-term memory for AI agents via Supermemory's knowledge graph API. Primary
+  CLI is `npx supermemory`; companion script covers conversation ingestion and
+  memory listing not yet in the official CLI.
+compatibility: Any machine with Node.js (npx) and SUPERMEMORY_API_KEY
 metadata:
   author: skeletorjs
   category: Community
@@ -16,155 +15,242 @@ metadata:
 1. Sign up at [supermemory.ai](https://supermemory.ai) and get an API key
 2. Add `SUPERMEMORY_API_KEY` to your Zo secrets at [Settings > Advanced](/?t=settings&s=advanced)
 3. Install this skill to `Skills/supermemory/`
-4. **Important**: Always run memory.py through the Zo shell (`run_bash_command` tool), not the local shell. The API key is only available in the Zo environment.
+4. (Optional) Install the CLI globally: `npm install -g supermemory`
+5. (Optional) Set a default container tag: `npx supermemory config --set tag=<your-tag>`
+
+**Important**: Always run commands through the Zo shell (`run_bash_command`), not the local shell. The API key is only available in the Zo environment.
 
 ## CLI
 
+Primary CLI (official):
 ```bash
-python3 /home/workspace/Skills/supermemory/scripts/memory.py <command> [options]
+npx supermemory <command> [options]
 ```
+
+Companion script (for commands not in the official CLI):
+```bash
+python3 Skills/supermemory/scripts/memory.py <command> [--container <name>] [options]
+```
+
+Container is set via `SUPERMEMORY_TAG` env var or `--tag` flag per command.
+
+### Primary Commands (npx supermemory)
 
 | Command | Purpose |
 |---------|---------|
-| save | Save a memory (--content, --tags, --id) |
-| search | Search memories (--query, --limit) |
-| profile | Get user profile (static facts + dynamic context) |
-| conversation | Ingest a conversation for extraction (--content, --id) |
-| list | List recent memories (--limit) |
-| forget | Delete a memory document (--id) |
-| close | Log conversation close protocol (--summary, --saves) |
+| remember | Save a memory directly (v4, immediately searchable) |
+| search | Search memories with hybrid mode + reranking (v4) |
+| profile | Get profile (static facts + dynamic context) |
+| forget | Soft-delete a memory (v4) |
+| update | Update a memory with versioning (v4) |
+| add | Ingest content (text, file, URL) via document pipeline |
+| tags | Manage container tags (list, info, create, delete, merge) |
+| docs | Manage documents (list, get, delete, chunks, status) |
 
-## Multiple Containers
+### Companion Commands (memory.py)
 
-The script supports multiple memory containers via the `--as` flag. This is useful for separating the user's context from the AI's own self-knowledge:
-
-```bash
-# Save to the default (user) container
-python3 memory.py save --content "User prefers dark mode"
-
-# Save to a custom container
-python3 memory.py save --as myai --content "I noticed a pattern in how I approach debugging"
-
-# Search a specific container
-python3 memory.py search --as myai --query "debugging patterns"
-
-# Get profile for a specific container
-python3 memory.py profile --as myai
-```
-
-To customize container names, edit the `CONTAINER_DEFAULT` and `CONTAINER_SELF` variables at the top of `memory.py`.
+| Command | Purpose |
+|---------|---------|
+| conversation | Ingest structured messages via v4/conversations (role-attributed, incremental) |
+| memories | List extracted memory entries with version history (v4/memories/list) |
 
 ## How Supermemory Works
 
 Supermemory is a knowledge graph, not a key-value store. When you save content, it:
 
-1. **Extracts facts**: AI analyzes the content and pulls out discrete memories
-2. **Builds relationships**: Each memory connects to existing ones via three relationship types:
-   - **Updates**: New fact contradicts old one. Old gets marked `isLatest=false`. Searches return current info.
-   - **Extends**: New fact enriches existing one. Both remain valid and searchable.
-   - **Derives**: System infers new facts from patterns across memories.
-3. **Maintains profiles**: The `/v4/profile` endpoint auto-generates a static/dynamic profile from all accumulated memories.
+1. **Extracts facts** from the content
+2. **Builds relationships** between memories:
+   - **Updates**: New fact contradicts old one. Old gets deprioritized. Searches return current info.
+   - **Extends**: New fact enriches existing one. Both remain valid.
+   - **Derives**: System infers new facts from patterns.
+3. **Maintains profiles** via `/v4/profile`, auto-generated from all accumulated memories.
 
-### Automatic Forgetting
+### Two ingestion paths
 
-Supermemory handles memory decay on its own:
+- **Direct (v4/memories)**: `remember` command. Bypasses document pipeline. Immediately searchable. Best for entity-centric facts, decisions, preferences.
+- **Pipeline (v3/documents)**: `add` command. Content goes through extraction, chunking, embedding. Best for URLs, long documents, files.
 
-- **Time-based**: Temporary facts ("meeting at 3pm today") are automatically forgotten after they expire.
-- **Contradiction resolution**: When new facts update old ones, searches return current info. History is preserved but deprioritized.
-- **Noise filtering**: Casual, non-meaningful content doesn't become permanent memories.
+### Static vs dynamic memories
 
-You do NOT need to manually delete stale temporal memories.
+- **Static** (`--static`): Permanent traits that don't decay. Name, role, hometown, core preferences. Use for facts that should always surface in profiles.
+- **Dynamic** (default): Normal memories subject to graph evolution, contradiction resolution, and time-based decay.
+
+### Automatic forgetting
+
+- **Contradiction resolution**: New facts supersede old ones in search results.
+- **Noise filtering**: Casual content doesn't become permanent.
+- **Soft delete**: `forget` marks memories as forgotten but preserves history.
+
+You do NOT need to manually delete stale memories. The graph handles it.
 
 ## How to Use It
 
 ### RECALL (search when you need context)
 
-Run `memory.py search` or `memory.py profile` whenever context would help:
+Run `search` or `profile` whenever context would help:
 
-- **Conversation start**: Profile for general context, search for topic-relevant memories.
-- **Mid-conversation**: When uncertain about prior decisions, past context, or preferences. Don't guess when you can check.
-- **Meeting prep**: Before calendar events, search for context about attendees, company, or topic.
-- **"Do you remember"**: Any time the user asks about past context.
+- **Conversation start**: Profile for general context, search for topic-specific memories.
+- **Mid-conversation**: When uncertain about prior decisions or preferences. Don't guess when you can check.
+- **First mention of a person/company/project**: Search for existing context before responding.
+
+Search modes:
+- **memories** (default): Searches extracted memory entries only. Fast, low latency.
+- **hybrid**: Searches both memories and document chunks. Best when you need both extracted facts and raw context.
+- **documents**: Searches document chunks only. Use for RAG-style retrieval from ingested content.
+
+Use `--rerank` when precision matters more than speed (~100ms overhead).
+Use `--rewrite` to let Supermemory rewrite the query for better retrieval.
 
 ### CAPTURE (save when something worth remembering happens)
 
-Run `memory.py save` as things happen, not just at conversation end.
-
-Write content as **entity-centric facts**, not raw notes:
-- Good: "User decided to use DuckDB for task management"
+**For individual facts**: Use `remember`. Write entity-centric statements.
+- Good: "User decided to use DuckDB for task management because of embedded SQL and zero dependencies."
 - Bad: "We talked about databases and decided on DuckDB"
+
+**For conversations**: Use `conversation` (companion script). The graph extracts multiple connected memories from the conversation structure, preserving relationships between facts that individual saves would lose.
+
+**For URLs and documents**: Use `add`. Supermemory fetches the content, chunks it, extracts memories, and makes it searchable.
 
 What to save:
 - **Decisions** the moment they're made
 - **Preferences** about tools, workflow, communication
 - **Key facts** about people, companies, projects
-- **Meeting takeaways** after processing transcripts
-- **Significant project/architecture context**
+- **Corrections** when a previous decision changes (reference what changed from what)
 
 What NOT to save:
 - Trivial exchanges
-- Temporary/session-specific context (debugging steps, draft iterations)
+- Temporary/session-specific context
 - Raw data that belongs in files
+- Information already captured elsewhere
 
 ### Save Quality
 
-Saves should be useful cold, readable by a future version of you with zero context about the current conversation.
+Every save should be useful cold, readable with zero context about the current conversation.
 
-**Good saves:**
-- "User decided to use DataForSEO over SEMrush for client SEO work because of pay-as-you-go pricing and API flexibility."
-- "User prefers Bun over Node for new TypeScript projects. Confirmed across multiple sessions."
-
-**Bad saves:**
-- "User decided on DataForSEO." (no context on why or what it replaced)
-- "User likes Bun." (preferences need specificity)
-
-**Minimum bar:** Every save should include at least: who or what entity it's about, what the fact/decision/preference is, and enough context that the "why" is inferrable.
+Minimum bar: who/what entity, what the fact is, enough context that the "why" is inferrable. Under 15 words is probably too thin.
 
 ### Correction Saves
 
-When the user changes a previous decision or preference, save the correction with explicit supersession language:
+When a previous decision changes, use `update` for versioned corrections (preserves history), or save with explicit supersession language:
+- "User changed X from Y to Z because [reason]."
 
-- "User changed the pricing model from flat fee to hybrid. Previous model was $X/month flat."
-- "User no longer wants to use Redis for caching. Switched to in-memory caching for simplicity."
-
-The knowledge graph uses this language to mark old memories as stale.
+The graph uses this to mark old memories as stale.
 
 ### Tags
 
-Tags go in `--tags` as comma-separated values. Keep them simple:
+Optional. Pass as JSON metadata via `--metadata '{"tags":"a,b"}'`. Simple categories: decision, preference, fact, meeting, project, lesson.
 
-| Tag | Use for |
-|-----|---------|
-| decision | Choices made, approaches selected |
-| preference | Tool preferences, workflow habits |
-| fact | Stable facts about people, companies, projects |
-| meeting | Meeting outcomes and takeaways |
-| project | Architecture, strategy, planning context |
+### Containers
 
-### Using customId
-
-`customId` is for **document-level identity**, not memory-level dedup. Use it when:
-
-- You have a growing document you'll update over time (e.g., a conversation transcript)
-- You want to fully replace a previous version of the same content
-- You're ingesting something with a natural external ID (meeting ID, ticket ID)
-
-You do NOT need `customId` for every individual fact you save. The graph handles dedup through its relationship system.
+Use container tags to separate contexts (e.g., one for the user's personal context, another for a specific project or team). Set the default with `npx supermemory config --set tag=<name>` or override per command with `--tag <name>`.
 
 ## Conversation Ingestion
 
-For long or important conversations, use the `conversation` command:
+The most powerful capture method. Accepts structured messages with proper role attribution:
 
 ```bash
-python3 memory.py conversation --content "..." --id "conv-2026-02-16-topic"
+# From a JSON file with structured messages
+python3 memory.py conversation --file /path/to/messages.json --id "conv-2026-03-28-topic"
+
+# Piped JSON array of messages
+echo '[{"role":"user","content":"..."},{"role":"assistant","content":"..."}]' | python3 memory.py conversation
+
+# Raw text (wrapped as single user message, backward compatible)
+python3 memory.py conversation --content "Long conversation transcript..." --id "conv-id"
 ```
 
-Supermemory extracts multiple connected memories from a single conversation.
+Message format: `{"role": "user|assistant|system|tool", "content": "..."}`
 
-## Profile as Living Context
+Using `--id` enables incremental updates. Send the same conversation ID with additional messages and Supermemory updates its extraction without duplicating.
 
-Supermemory automatically builds the user's profile from all accumulated memories:
-- **Static**: Long-term stable facts (role, location, preferences)
-- **Dynamic**: Recent context and temporary states (current projects, active discussions)
+## Command Reference
 
-The profile is fully automatic. Run `memory.py profile` to check current state.
+### remember (npx supermemory)
+```
+npx supermemory remember "content" [options]
+  --tag          Container tag
+  --static       Mark as permanent trait
+  --metadata     JSON metadata to attach
+```
+
+### search (npx supermemory)
+```
+npx supermemory search "query" [options]
+  --tag          Filter by container tag
+  --limit N      Max results (default: 10)
+  --mode MODE    memories|hybrid|documents (default: memories)
+  --rerank       Enable reranking
+  --rewrite      Rewrite query for better retrieval
+  --threshold N  0-1, lower = more results (default: 0.6)
+  --include      Comma-separated: summaries,documents,relatedMemories,forgottenMemories
+  --filter       Metadata filter (JSON)
+```
+
+### profile (npx supermemory)
+```
+npx supermemory profile [options]
+  --tag          Container tag
+  --query        Also run a search within the profile
+```
+
+### forget (npx supermemory)
+```
+npx supermemory forget [ID] [options]
+  --tag          Container tag (required)
+  --reason       Reason for forgetting
+  --content      Find and forget by content match (instead of ID)
+```
+
+### update (npx supermemory)
+```
+npx supermemory update <ID> "new content" [options]
+  --tag          Container tag
+  --metadata     Updated metadata (JSON)
+  --reason       Reason for update
+```
+
+### add (npx supermemory)
+```
+npx supermemory add <content|file|url> [options]
+  --tag          Container tag
+  --stdin        Read content from stdin
+  --title        Document title
+  --metadata     JSON metadata to attach
+  --id           Custom document ID (for idempotency)
+  --batch        Read JSON array from stdin (batch mode)
+```
+
+### conversation (companion script)
+```
+python3 memory.py conversation [options]
+  --content "text"    Raw text or JSON messages (or pipe)
+  --file "path.json"  Load messages from JSON file
+  --id "conv-id"      Conversation ID (enables incremental updates)
+  --container <name>  Override target container
+```
+
+### memories (companion script)
+```
+python3 memory.py memories [options]
+  --limit N           Max results (default: 30)
+  --container <name>  Override target container
+```
+
+### tags (npx supermemory)
+```
+npx supermemory tags list
+npx supermemory tags info <tag>
+npx supermemory tags create <tag>
+npx supermemory tags delete <tag>
+npx supermemory tags context <tag> --set "context text"
+npx supermemory tags merge <source> --into <target>
+```
+
+### docs (npx supermemory)
+```
+npx supermemory docs list --tag <tag>
+npx supermemory docs get <id>
+npx supermemory docs delete <id>
+npx supermemory docs chunks <id>
+npx supermemory docs status <id>
+```

--- a/Community/supermemory/scripts/memory.py
+++ b/Community/supermemory/scripts/memory.py
@@ -1,3 +1,13 @@
+#!/usr/bin/env python3
+"""Supermemory companion CLI -- commands not covered by the official `npx supermemory` CLI.
+
+Only two commands live here:
+  conversation  - Ingest structured messages via v4/conversations (role-attributed, incremental)
+  memories      - List extracted memory entries with version history (v4/memories/list)
+
+For everything else, use `npx supermemory`:
+  remember, search, profile, forget, update, add, tags, docs, etc.
+"""
 import json
 import os
 import sys
@@ -5,19 +15,19 @@ import urllib.request
 import urllib.error
 from datetime import datetime, timezone
 
-BASE_URL = "https://api.supermemory.ai"
 
-# Customize these container names for your setup.
-# The default container is for the user's context.
-# The self container is for the AI's own self-knowledge (optional).
-CONTAINER_DEFAULT = "user"
-CONTAINER_SELF = "ai"
+BASE_URL = "https://api.supermemory.ai"
+DEFAULT_CONTAINER = os.environ.get("SUPERMEMORY_TAG", "default")
+
+
+def get_container(override=None):
+    return override or DEFAULT_CONTAINER
 
 
 def api(method, path, body=None):
     api_key = os.environ.get("SUPERMEMORY_API_KEY", "")
     if not api_key:
-        print("ERROR: SUPERMEMORY_API_KEY not set", file=sys.stderr)
+        print("ERROR: SUPERMEMORY_API_KEY not set.", file=sys.stderr)
         sys.exit(1)
 
     url = f"{BASE_URL}{path}"
@@ -28,329 +38,186 @@ def api(method, path, body=None):
         headers={
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
-            "User-Agent": "ZoSupermemory/1.0",
+            "User-Agent": "supermemory-companion/1.0",
         },
         method=method,
     )
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
-            body = resp.read()
-            if not body:
+            raw = resp.read()
+            if not raw:
                 return {}
-            return json.loads(body)
+            return json.loads(raw)
     except urllib.error.HTTPError as e:
         body_text = e.read().decode() if e.fp else ""
         print(f"ERROR: API returned {e.code}: {body_text}", file=sys.stderr)
         sys.exit(1)
 
 
-def cmd_save(args, container_tag=None):
-    if container_tag is None:
-        container_tag = CONTAINER_DEFAULT
-    content = None
-    tags = ""
-    metadata = {}
-    custom_id = None
+def _parse_args(args, spec):
+    result = {k: v[1] for k, v in spec.items()}
     i = 0
     while i < len(args):
-        if args[i] == "--content" and i + 1 < len(args):
-            content = args[i + 1]; i += 2
-        elif args[i] == "--tags" and i + 1 < len(args):
-            tags = args[i + 1]; i += 2
-        elif args[i] == "--id" and i + 1 < len(args):
-            custom_id = args[i + 1]; i += 2
-        else:
+        matched = False
+        for key, (typ, _) in spec.items():
+            flag = f"--{key.replace('_', '-')}"
+            if args[i] == flag:
+                if typ == "bool":
+                    result[key] = True
+                    i += 1
+                elif i + 1 < len(args):
+                    val = args[i + 1]
+                    if typ == "int":
+                        val = int(val)
+                    result[key] = val
+                    i += 2
+                else:
+                    i += 1
+                matched = True
+                break
+        if not matched:
             i += 1
-
-    if not content:
-        if not sys.stdin.isatty():
-            content = sys.stdin.read().strip()
-        if not content:
-            print("ERROR: --content required or pipe content via stdin", file=sys.stderr)
-            sys.exit(1)
-
-    if tags:
-        metadata["tags"] = tags
-
-    body = {
-        "content": content,
-        "containerTag": container_tag,
-    }
-    if metadata:
-        body["metadata"] = metadata
-    if custom_id:
-        body["customId"] = custom_id
-
-    result = api("POST", "/v3/documents", body)
-    print(f"Saved to [{container_tag}]. ID: {result.get('id', 'unknown')}, Status: {result.get('status', 'unknown')}")
+    for key, (typ, _) in spec.items():
+        if typ == "str_or_stdin" and result[key] is None:
+            if not sys.stdin.isatty():
+                result[key] = sys.stdin.read().strip()
     return result
 
 
-def cmd_search(args, container_tag=None):
-    if container_tag is None:
-        container_tag = CONTAINER_DEFAULT
-    query = None
-    limit = 10
-    i = 0
-    while i < len(args):
-        if args[i] in ("--query", "-q") and i + 1 < len(args):
-            query = args[i + 1]; i += 2
-        elif args[i] == "--limit" and i + 1 < len(args):
-            limit = int(args[i + 1]); i += 2
-        else:
-            i += 1
+def cmd_conversation(args, container_tag):
+    parsed = _parse_args(args, {
+        "content": ("str_or_stdin", None),
+        "id": ("str", None),
+        "file": ("str", None),
+    })
 
-    if not query:
-        print("ERROR: --query required", file=sys.stderr)
+    messages = None
+
+    if parsed["file"]:
+        with open(parsed["file"]) as f:
+            data = json.load(f)
+            if isinstance(data, list):
+                messages = data
+            elif isinstance(data, dict) and "messages" in data:
+                messages = data["messages"]
+            else:
+                print("ERROR: File must contain a JSON array of messages or {messages: [...]}", file=sys.stderr)
+                sys.exit(1)
+    elif parsed["content"]:
+        content = parsed["content"]
+        try:
+            data = json.loads(content)
+            if isinstance(data, list) and len(data) > 0 and isinstance(data[0], dict) and "role" in data[0]:
+                messages = data
+            elif isinstance(data, dict) and "messages" in data:
+                messages = data["messages"]
+        except (json.JSONDecodeError, TypeError):
+            pass
+        if messages is None:
+            messages = [{"role": "user", "content": content}]
+    else:
+        print("ERROR: --content, --file, or piped input required", file=sys.stderr)
         sys.exit(1)
 
+    valid_roles = {"user", "assistant", "system", "tool"}
+    for msg in messages:
+        if not isinstance(msg, dict) or "role" not in msg or "content" not in msg:
+            print("ERROR: Each message must have 'role' and 'content' fields", file=sys.stderr)
+            sys.exit(1)
+        if msg["role"] not in valid_roles:
+            print(f"ERROR: Invalid role '{msg['role']}'. Must be one of: {valid_roles}", file=sys.stderr)
+            sys.exit(1)
+
+    conversation_id = parsed["id"] or f"conv-{int(datetime.now(timezone.utc).timestamp())}"
+
     body = {
-        "q": query,
+        "conversationId": conversation_id,
+        "messages": messages,
         "containerTags": [container_tag],
     }
 
-    result = api("POST", "/v3/search", body)
-    results = result.get("results", [])
-    if not results:
-        print(f"No results found in [{container_tag}].")
+    result = api("POST", "/v4/conversations", body)
+    msg_count = len(messages)
+    roles = set(m["role"] for m in messages)
+    print(f"Conversation ingested to [{container_tag}]. ID: {conversation_id} ({msg_count} messages, roles: {', '.join(sorted(roles))})")
+    return result
+
+
+def cmd_memories(args, container_tag):
+    parsed = _parse_args(args, {
+        "limit": ("int", 30),
+    })
+
+    body = {"containerTags": [container_tag]}
+
+    result = api("POST", "/v4/memories/list", body)
+    memories = result.get("memories", result.get("results", []))
+    if not memories:
+        print(f"No memory entries found in [{container_tag}].")
         return
 
-    for idx, r in enumerate(results[:limit], 1):
-        doc_id = r.get("documentId", "")
-        score = r.get("score", "")
-        tags = r.get("metadata", {}).get("tags", "")
-        chunks = r.get("chunks", [])
-        content = chunks[0].get("content", "")[:300] if chunks else ""
-        created = r.get("createdAt", "")[:10]
+    limit = parsed["limit"]
+    for idx, mem in enumerate(memories[:limit], 1):
+        mem_id = mem.get("id") or ""
+        content = (mem.get("memory") or mem.get("content") or "")[:200]
+        is_static = mem.get("isStatic", False)
+        version = mem.get("version", 1)
+        updated = (mem.get("updatedAt") or mem.get("createdAt") or "")[:10]
+        forgotten = mem.get("isForgotten", False)
+        metadata = mem.get("metadata") or {}
+        tags = metadata.get("tags") or ""
 
-        print(f"\n--- Result {idx} (score: {score:.2f}) [id: {doc_id}] {created} ---")
+        static_label = " [static]" if is_static else ""
+        forgotten_label = " [forgotten]" if forgotten else ""
+        version_label = f" v{version}" if version and version > 1 else ""
+        print(f"[{mem_id}]{static_label}{forgotten_label}{version_label} {updated}")
         if tags:
             print(f"  tags: {tags}")
         print(f"  {content}")
 
-    print(f"\n{len(results)} results total.")
-
-
-def cmd_profile(args, container_tag=None):
-    if container_tag is None:
-        container_tag = CONTAINER_DEFAULT
-    body = {
-        "containerTag": container_tag,
-    }
-
-    result = api("POST", "/v4/profile", body)
-    profile = result.get("profile", {})
-
-    static = profile.get("static", "")
-    dynamic = profile.get("dynamic", "")
-
-    label = container_tag.capitalize()
-
-    if static:
-        print(f"=== {label} Static Profile ===")
-        print(static)
-        print()
-    if dynamic:
-        print(f"=== {label} Dynamic Context ===")
-        print(dynamic)
+        history = mem.get("history") or []
+        if history:
+            for h in history[:3]:
+                h_ver = h.get("version", "?")
+                h_content = (h.get("memory") or h.get("content") or "")[:100]
+                h_date = (h.get("createdAt") or "")[:10]
+                print(f"    v{h_ver} ({h_date}): {h_content}")
         print()
 
-    if not static and not dynamic:
-        print(f"No profile data yet for [{container_tag}]. Save some memories first.")
+    print(f"Showing {min(limit, len(memories))} of {len(memories)} memory entries.")
 
 
-def cmd_conversation(args, container_tag=None):
-    if container_tag is None:
-        container_tag = CONTAINER_DEFAULT
-    content = None
-    custom_id = None
-    i = 0
-    while i < len(args):
-        if args[i] == "--content" and i + 1 < len(args):
-            content = args[i + 1]; i += 2
-        elif args[i] == "--id" and i + 1 < len(args):
-            custom_id = args[i + 1]; i += 2
-        else:
-            i += 1
+def cmd_help(**_):
+    print("""Supermemory companion CLI -- commands not in the official CLI
 
-    if not content:
-        if not sys.stdin.isatty():
-            content = sys.stdin.read().strip()
-        if not content:
-            print("ERROR: --content required or pipe content via stdin", file=sys.stderr)
-            sys.exit(1)
+For most operations, use the official CLI:
+  npx supermemory remember "content" --tag <tag>
+  npx supermemory search "query" --tag <tag>
+  npx supermemory profile --tag <tag>
+  npx supermemory forget <id> --tag <tag>
+  npx supermemory update <id> "new content" --tag <tag>
+  npx supermemory add <content|file|url> --tag <tag>
+  npx supermemory tags list
+  npx supermemory docs list --tag <tag>
 
-    body = {
-        "content": content,
-        "containerTag": container_tag,
-    }
-    if custom_id:
-        body["customId"] = custom_id
+This companion script covers two gaps:
 
-    result = api("POST", "/v4/conversations", body)
-    print(f"Conversation ingested to [{container_tag}]. ID: {result.get('id', 'unknown')}")
-    return result
+  conversation  Ingest structured messages via v4/conversations
+                  --content "text"    Raw text or JSON messages (or pipe)
+                  --file "path.json"  Load messages from JSON file
+                  --id "conv-id"      Conversation ID (enables incremental updates)
 
-
-def cmd_list(args, container_tag=None):
-    if container_tag is None:
-        container_tag = CONTAINER_DEFAULT
-    limit = 20
-    i = 0
-    while i < len(args):
-        if args[i] == "--limit" and i + 1 < len(args):
-            limit = int(args[i + 1]); i += 2
-        else:
-            i += 1
-
-    body = {
-        "containerTags": [container_tag],
-    }
-
-    result = api("POST", "/v3/documents/list", body)
-    docs = result.get("memories", result.get("documents", result.get("results", [])))
-
-    if not docs:
-        print(f"No memories found in [{container_tag}].")
-        return
-
-    for doc in docs[:limit]:
-        doc_id = doc.get("id", "")
-        title = doc.get("title", "")
-        summary = doc.get("summary", "")[:150]
-        status = doc.get("status", "")
-        tags = doc.get("metadata", {}).get("tags", "")
-        created = doc.get("createdAt", "")[:10]
-        print(f"[{doc_id}] ({status}) {created}")
-        if title:
-            print(f"  {title}")
-        if tags:
-            print(f"  tags: {tags}")
-        if summary:
-            print(f"  {summary}")
-        print()
-
-    print(f"Showing {min(limit, len(docs))} of {len(docs)} memories.")
-
-
-def cmd_forget(args, container_tag=None):
-    memory_id = None
-    i = 0
-    while i < len(args):
-        if args[i] == "--id" and i + 1 < len(args):
-            memory_id = args[i + 1]; i += 2
-        else:
-            i += 1
-
-    if not memory_id:
-        print("ERROR: --id required", file=sys.stderr)
-        sys.exit(1)
-
-    api("DELETE", f"/v3/documents/{memory_id}")
-    print(f"Document deleted: {memory_id}")
-
-
-def cmd_close(args, container_tag=None):
-    summary = None
-    saves = 0
-    i = 0
-    while i < len(args):
-        if args[i] == "--summary" and i + 1 < len(args):
-            summary = args[i + 1]; i += 2
-        elif args[i] == "--saves" and i + 1 < len(args):
-            saves = int(args[i + 1]); i += 2
-        else:
-            i += 1
-
-    if not summary:
-        print("ERROR: --summary required", file=sys.stderr)
-        sys.exit(1)
-
-    log_file = "/home/workspace/Data/memory-close-log.jsonl"
-    os.makedirs(os.path.dirname(log_file), exist_ok=True)
-
-    handoff_exists = os.path.exists("/home/workspace/Data/handoff.json")
-
-    entry = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "summary": summary,
-        "saves": saves,
-        "handoff": handoff_exists,
-    }
-
-    with open(log_file, "a") as f:
-        f.write(json.dumps(entry) + "\n")
-
-    print(f"Close logged. Saves: {saves}, Handoff pending: {handoff_exists}")
-    print(f"  Summary: {summary}")
-
-
-# Self-* shortcuts: use the AI's own container
-def cmd_self_save(args, container_tag=None):
-    return cmd_save(args, container_tag=CONTAINER_SELF)
-
-def cmd_self_search(args, container_tag=None):
-    return cmd_search(args, container_tag=CONTAINER_SELF)
-
-def cmd_self_profile(args, container_tag=None):
-    return cmd_profile(args, container_tag=CONTAINER_SELF)
-
-
-def cmd_help():
-    print(f"""Supermemory CLI -- long-term memory for your AI
-
-Containers:
-  Default (user context): {CONTAINER_DEFAULT}
-  Self (AI self-knowledge): {CONTAINER_SELF}
+  memories      List extracted memory entries with version history
+                  --limit N           Max results (default: 30)
 
 Global flags:
-  --as <name>    Target a specific container (default: {CONTAINER_DEFAULT})
-
-Commands:
-  save          Save a memory
-                  --content "text"  Content to save (or pipe via stdin)
-                  --tags "a,b"      Comma-separated tags (optional)
-                  --id "custom-id"  Custom ID for document-level dedup (optional)
-
-  search        Search memories
-                  --query "text"    Search query (required)
-                  --limit N         Max results (default: 10)
-
-  profile       Get profile (static facts + dynamic context)
-
-  self-save     Save to AI's own container (shortcut for --as {CONTAINER_SELF} save)
-  self-search   Search AI's own container
-  self-profile  Get AI's own profile
-
-  conversation  Ingest a conversation for memory extraction
-                  --content "text"  Conversation text (or pipe via stdin)
-                  --id "conv-id"    Conversation ID (optional)
-
-  list          List recent documents
-                  --limit N         Max results (default: 20)
-
-  forget        Delete a document (permanent)
-                  --id "doc-id"     Document ID to delete (required)
-
-  close         Log conversation close protocol execution
-                  --summary "text"  Brief conversation summary (required)
-                  --saves N         Number of saves made this session (default: 0)
-
-  help          Show this help""")
+  --container <name>   Override target container""")
 
 
 COMMANDS = {
-    "save": cmd_save,
-    "search": cmd_search,
-    "profile": cmd_profile,
-    "self-save": cmd_self_save,
-    "self-search": cmd_self_search,
-    "self-profile": cmd_self_profile,
     "conversation": cmd_conversation,
-    "list": cmd_list,
-    "forget": cmd_forget,
-    "close": cmd_close,
-    "help": lambda _, **kw: cmd_help(),
+    "memories": cmd_memories,
+    "help": lambda *a, **kw: cmd_help(),
 }
 
 
@@ -359,21 +226,20 @@ def main():
         cmd_help()
         sys.exit(0 if len(sys.argv) < 2 else 1)
 
-    # Extract --as flag from anywhere in args
-    container_tag = CONTAINER_DEFAULT
+    container_tag = None
     args = list(sys.argv[2:])
     filtered_args = []
     i = 0
     while i < len(args):
-        if args[i] == "--as" and i + 1 < len(args):
-            container_tag = args[i + 1].lower()
+        if args[i] == "--container" and i + 1 < len(args):
+            container_tag = args[i + 1]
             i += 2
         else:
             filtered_args.append(args[i])
             i += 1
 
-    command = sys.argv[1]
-    COMMANDS[command](filtered_args, container_tag=container_tag)
+    container_tag = get_container(container_tag)
+    COMMANDS[sys.argv[1]](filtered_args, container_tag=container_tag)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The official `npx supermemory` CLI now covers the core operations that were previously handled by the custom `memory.py` script. This PR updates the supermemory skill to reflect that.

**Changes:**
- **Primary CLI is now `npx supermemory`** for: `remember`, `search`, `profile`, `forget`, `update`, `add`, `tags`, `docs`
- **`memory.py` trimmed to a companion script** covering only two commands the official CLI doesn't have yet: `conversation` (v4/conversations structured message ingestion with role attribution) and `memories` (v4/memories/list with version history)
- **SKILL.md rewritten** with full command reference for both CLIs, documentation for v4 API features (static vs dynamic memories, search modes, reranking, container management)
- **API upgraded from v3 to v4** endpoints throughout

The old `memory.py` had ~380 lines reimplementing what `npx supermemory` now does natively. The new companion is ~170 lines covering only the gaps.

## Test plan

- [ ] `npx supermemory remember "test" --tag test` saves successfully
- [ ] `npx supermemory search "test" --tag test` returns the saved memory
- [ ] `npx supermemory forget --tag test --content "test"` soft-deletes it
- [ ] `python3 memory.py conversation --container test '[{"role":"user","content":"hello"}]'` ingests via v4/conversations
- [ ] `python3 memory.py memories --container test` lists extracted entries
- [ ] `python3 memory.py help` shows correct usage with official CLI references