### PR TITLE
Add Clarion Intelligence System (10 skills)

### DIFF
--- a/External/clarion-expected-return-calc/SKILL.md
+++ b/External/clarion-expected-return-calc/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: clarion-expected-return-calc
+description: Compute the equity-vs-T-bill allocation for the Value bucket (50% of portfolio). Implements the Expected-Return Framework — looks up the historical 10-year forward return from the S&P 500 Shiller CAPE, computes the regime-adjusted hurdle (rf + regime premium), and produces a 5-tier verdict (STRONG EQUITY / LEAN EQUITY / NEUTRAL / LEAN T-BILLS / MAXIMUM T-BILLS) with recommended Value-bucket equity/T-bill split. Use when the user asks "should I be in stocks or bonds right now?", "what's the equity hurdle?", "is the market overvalued?", "what's the right Value bucket allocation?", or before adding any new equity to the Value bucket.
+metadata:
+  author: cis.zo.computer
+  category: External
+  display-name: Clarion Expected Return
+  homepage: https://github.com/jingerzz/clarion-intelligence-system
+---
+
+# Clarion expected-return calculator
+
+Answers one question for the Value bucket (50% of portfolio): **what's the right equity/T-bill mix right now?**
+
+Implements the Expected-Return Framework from [`docs/ALLOCATION-POLICY.md`](../../docs/ALLOCATION-POLICY.md) and the hurdle-rate framework from [`docs/DESIGN-LANGUAGE.md`](../../docs/DESIGN-LANGUAGE.md).
+
+## When to use
+
+User asks any of:
+- "Should I be in stocks or bonds?"
+- "What's the equity hurdle right now?"
+- "Is the market overvalued?"
+- "What's the right Value bucket allocation?"
+- "Is this a good time to buy stocks?"
+
+Also: before any major new equity allocation decision in the Value bucket, this skill should run first.
+
+## Decision tree
+
+1. **Fetch the inputs the script can't auto-source.** Use WebSearch to look up:
+   - **Shiller CAPE** (required) — search `"Shiller PE Ratio current"` or `"S&P 500 CAPE current"`. Primary sources: multpl.com, Yardeni Research.
+   - **Trailing P/E** (optional but useful for cross-check) — search `"S&P 500 trailing P/E current"` (multpl.com).
+   - **Forward P/E** (optional) — multpl.com or Yardeni.
+   - **10-year Treasury yield** (optional context) — Treasury.gov daily rates or any major financial site.
+
+   Use multpl.com or Yardeni Research as the primary sources. **Never fabricate.** If WebSearch returns conflicting numbers, present both and use the more conservative one.
+
+2. **Run the script** with the values you found:
+
+   ```bash
+   python /home/workspace/clarion-intelligence-system/skills/clarion-expected-return-calc/scripts/expected_return.py \
+       --cape 35.2 --trailing-pe 28.4
+   ```
+
+   The script auto-fetches the 3-month T-bill yield from Treasury.gov (no API key), computes the regime via the shared regime layer, looks up implied 10-year forward return, computes the regime-adjusted hurdle, and produces a 5-tier verdict.
+
+3. **Present the script output to the user verbatim.** It's already structured (Numbers / Math / Verdict / Recommended Split / Context).
+
+4. **If the user asks "what would change this?"** — point at the Context section, which already lists the most likely scenario shifts.
+
+5. **If the user wants to act on the verdict** — for new equity additions, suggest `clarion-single-stock-eval` so each candidate goes through the Buffett Question Bank.
+
+## How to run
+
+```bash
+EXPECTED=python /home/workspace/clarion-intelligence-system/skills/clarion-expected-return-calc/scripts/expected_return.py
+
+# Required: --cape (Shiller CAPE, primary lookup)
+$EXPECTED --cape 35.2
+
+# Add trailing P/E as cross-check (warns if divergence > 5 points)
+$EXPECTED --cape 35.2 --trailing-pe 28.4
+
+# Override risk-free rate (skip Treasury.gov fetch)
+$EXPECTED --cape 35.2 --rf-rate-pct 4.45
+
+# Skip Treasury.gov fetch (require manual rf)
+$EXPECTED --cape 35.2 --rf-rate-pct 4.45 --no-fetch-rf
+
+# Add 10-year Treasury and forward P/E for context
+$EXPECTED --cape 35.2 --forward-pe 21.3 --ten-year-yield-pct 4.85
+```
+
+## Voice
+
+Show the math. Lead with the verdict, then the spread, then the context. Don't soften — if the math says MAXIMUM T-BILLS, say so plainly. The framework is doing its job; bad news is signal.
+
+When the trailing P/E and CAPE diverge meaningfully, the script flags it. **Do not ignore the flag** — point the user at the divergence and invite cross-checking the inputs.
+
+## Hard rules
+
+1. **Never fabricate P/E ratios or yields.** If WebSearch returns conflicting numbers, present both with sources and use the more conservative one.
+2. **Always show the math.** The recommendation is only as good as the calculation behind it.
+3. **DANGER state overrides everything.** When the regime is DANGER, the verdict is automatically MAXIMUM T-BILLS regardless of P/E math. The script enforces this.
+4. **This skill is a Value-bucket allocation tool, not a per-position decision.** For per-position decisions (single-stock evaluations, theses), use `clarion-single-stock-eval`.
+
+## On error
+
+- **`EXPECTED_RETURN_ERROR: could not resolve risk-free rate`** — Treasury.gov unreachable AND no `--rf-rate-pct` passed AND no `rf_rate_pct` in `~/clarion/config.json`. Pass `--rf-rate-pct X.X` (current 3-month T-bill, look up on Treasury.gov website).
+- **`EXPECTED_RETURN_ERROR: could not compute regime`** — yfinance cache empty for SPY/TLT/RSP. Run `clarion-regime-check` first to seed the cache.
+- **`EXPECTED_RETURN_ERROR: --cape is required`** — Shiller CAPE wasn't supplied. Look up on multpl.com (search: "Shiller PE Ratio current").

--- a/External/clarion-expected-return-calc/SKILL.md
+++ b/External/clarion-expected-return-calc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clarion-expected-return-calc
-description: Compute the equity-vs-T-bill allocation for the Value bucket (50% of portfolio). Implements the Expected-Return Framework — looks up the historical 10-year forward return from the S&P 500 Shiller CAPE, computes the regime-adjusted hurdle (rf + regime premium), and produces a 5-tier verdict (STRONG EQUITY / LEAN EQUITY / NEUTRAL / LEAN T-BILLS / MAXIMUM T-BILLS) with recommended Value-bucket equity/T-bill split. Use when the user asks "should I be in stocks or bonds right now?", "what's the equity hurdle?", "is the market overvalued?", "what's the right Value bucket allocation?", or before adding any new equity to the Value bucket.
+description: Compute the equity-vs-T-bill allocation for the Value bucket (50% of portfolio). Implements the Expected-Return Framework — looks up the historical 10-year forward return from the S&P 500 Shiller CAPE, computes the regime-adjusted hurdle (rf + regime premium), and produces a 5-tier verdict (STRONG EQUITY / LEAN EQUITY / NEUTRAL / LEAN T-BILLS / MAXIMUM T-BILLS) with recommended Value-bucket equity/T-bill split. Use when the user asks "should I be in stocks or bonds right now?", "what's the equity hurdle?", "is the market overvalued?", "what's the right Value bucket allocation?", or before adding any new equity to the Value bucket. Requires clarion-setup to have been run.
 metadata:
   author: cis.zo.computer
   category: External

--- a/External/clarion-expected-return-calc/references/expected-return-framework.md
+++ b/External/clarion-expected-return-calc/references/expected-return-framework.md
@@ -1,0 +1,57 @@
+# Expected-Return Framework — quick reference
+
+Full source: [`docs/ALLOCATION-POLICY.md → Expected-Return Framework`](../../../docs/ALLOCATION-POLICY.md#expected-return-framework). Load that for the complete reasoning.
+
+This file is a quick-lookup reference for use during a chat turn.
+
+---
+
+## S&P 500 CAPE → 10-year forward return (historical)
+
+| CAPE range | 10-year CAGR | Confidence |
+|---|---|---|
+| < 10 | 12-16% | High (strong base rate) |
+| 10-15 | 8-12% | High |
+| 15-20 | 5-8% | Moderate |
+| 20-25 | 2-5% | Moderate |
+| 25-30 | 0-3% | Moderate (wide dispersion) |
+| > 30 | -2% to 0% | Low (small sample, extreme valuations) |
+
+**Use Shiller CAPE as the primary lookup. Trailing P/E is a secondary cross-check.** If the two diverge by more than 5 P/E points, note the divergence in the output and verify both inputs.
+
+---
+
+## Hurdle = rf + regime premium
+
+| Regime | Premium |
+|---|---|
+| Green / Blue | +4% |
+| Orange | +6% |
+| Red | +8% |
+| Danger | +10% (effectively: buy almost nothing) |
+
+---
+
+## Verdict map
+
+| Spread (implied vs hurdle) | Verdict | Equity % |
+|---|---|---|
+| > Hurdle + 3% | STRONG EQUITY | 80-100% |
+| > Hurdle | LEAN EQUITY | 60-80% |
+| Within ±1% | NEUTRAL | 40-60% |
+| < Hurdle | LEAN T-BILLS | 20-40% |
+| < rf rate | MAXIMUM T-BILLS | 0-20% |
+| DANGER state | MAXIMUM T-BILLS | 0-20% (hard override) |
+
+---
+
+## Where each input comes from
+
+| Input | Source | Why |
+|---|---|---|
+| Shiller CAPE | WebSearch → multpl.com / Yardeni | Primary 10-year-forward-return lookup |
+| Trailing P/E | WebSearch → multpl.com | Cross-check; warn on divergence > 5 points |
+| Forward P/E | WebSearch → multpl.com / Yardeni | Optional context |
+| Regime color | clarion-regime-check (auto) | Determines premium |
+| 3-month T-bill | Treasury.gov daily CSV (auto) | Risk-free rate; user can override with `--rf-rate-pct` |
+| 10-year Treasury | WebSearch (optional) | Long-duration benchmark for context |

--- a/External/clarion-expected-return-calc/scripts/expected_return.py
+++ b/External/clarion-expected-return-calc/scripts/expected_return.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Clarion expected-return calculator — equities or T-bills?
+
+Implements the Expected-Return Framework from docs/ALLOCATION-POLICY.md and
+the hurdle-rate framework from docs/DESIGN-LANGUAGE.md.
+
+Answers one question for the Value bucket (50% of portfolio):
+"What's the right equity / T-bill mix right now?"
+
+Does NOT make per-position decisions; that's clarion-single-stock-eval.
+
+Usage:
+    python expected_return.py --cape 35.2 --trailing-pe 28.4
+    python expected_return.py --cape 35.2 --rf-rate-pct 4.45
+    python expected_return.py --cape 35.2 --no-fetch-rf  # require --rf-rate-pct
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+from ai_buffett_zo.data import EquityStore
+from ai_buffett_zo.macro import (
+    AllocationDecision,
+    ImpliedReturn,
+    decide_allocation,
+    fetch_3mo_yield,
+    implied_return_from_pe,
+)
+from ai_buffett_zo.regime import HURDLE_PREMIUM_PCT, RegimeSnapshot, snapshot
+from ai_buffett_zo.voice import (
+    cite_quote,
+    footer,
+    header,
+    md_table,
+    show_math,
+)
+
+
+def _config_path() -> Path:
+    return Path.home() / "clarion" / "config.json"
+
+
+def _config_rf() -> float | None:
+    cfg = _config_path()
+    if not cfg.exists():
+        return None
+    try:
+        data = json.loads(cfg.read_text())
+        v = data.get("rf_rate_pct")
+        return float(v) if v is not None else None
+    except (json.JSONDecodeError, TypeError, ValueError, OSError):
+        return None
+
+
+def _resolve_rf(args: argparse.Namespace) -> tuple[float | None, str]:
+    """Returns (rate_pct, source_label). source_label describes provenance."""
+    if args.rf_rate_pct is not None:
+        return float(args.rf_rate_pct), "user-supplied"
+    if not args.no_fetch_rf:
+        y = fetch_3mo_yield()
+        if y is not None:
+            return y.rate_pct, f"Treasury.gov 3-mo (asof {y.asof.isoformat()})"
+    cfg_rf = _config_rf()
+    if cfg_rf is not None:
+        return cfg_rf, "~/clarion/config.json fallback"
+    return None, "unresolved"
+
+
+def _resolve_regime() -> RegimeSnapshot | None:
+    """Best-effort regime snapshot using cached SPY/TLT/RSP."""
+    try:
+        store = EquityStore()
+        spy = store.history("SPY", max_age=timedelta(hours=24))
+        tlt = store.history("TLT", max_age=timedelta(hours=24))
+        rsp = store.history("RSP", max_age=timedelta(hours=24))
+    except Exception:  # noqa: BLE001
+        return None
+    if not spy or not tlt or not rsp:
+        return None
+    try:
+        return snapshot(spy, tlt, rsp)
+    except ValueError:
+        return None
+
+
+def run(args: argparse.Namespace) -> int:
+    rf_rate_pct, rf_source = _resolve_rf(args)
+    if rf_rate_pct is None:
+        print(
+            "EXPECTED_RETURN_ERROR: could not resolve risk-free rate. "
+            "Pass --rf-rate-pct X.X manually, or seed `rf_rate_pct` in "
+            f"{_config_path()}, or check Treasury.gov reachability."
+        )
+        return 1
+
+    regime_snap = _resolve_regime()
+    if regime_snap is None:
+        print(
+            "EXPECTED_RETURN_ERROR: could not compute regime. "
+            "Run clarion-regime-check first to seed the SPY/TLT/RSP cache."
+        )
+        return 1
+
+    if args.cape is None:
+        print(
+            "EXPECTED_RETURN_ERROR: --cape is required. "
+            "Look up the current Shiller CAPE on multpl.com or Yardeni Research."
+        )
+        return 1
+
+    implied = implied_return_from_pe(args.cape)
+    hurdle_pct = rf_rate_pct + HURDLE_PREMIUM_PCT[regime_snap.color]
+    decision = decide_allocation(
+        implied_return_mid_pct=implied.midpoint_pct,
+        rf_rate_pct=rf_rate_pct,
+        hurdle_rate_pct=hurdle_pct,
+        danger_state=(regime_snap.color == "danger"),
+    )
+
+    _render(
+        regime_snap=regime_snap,
+        rf_rate_pct=rf_rate_pct,
+        rf_source=rf_source,
+        cape=args.cape,
+        trailing_pe=args.trailing_pe,
+        forward_pe=args.forward_pe,
+        ten_year_yield_pct=args.ten_year_yield_pct,
+        implied=implied,
+        hurdle_pct=hurdle_pct,
+        decision=decision,
+    )
+    return 0
+
+
+def _render(
+    *,
+    regime_snap: RegimeSnapshot,
+    rf_rate_pct: float,
+    rf_source: str,
+    cape: float,
+    trailing_pe: float | None,
+    forward_pe: float | None,
+    ten_year_yield_pct: float | None,
+    implied: ImpliedReturn,
+    hurdle_pct: float,
+    decision: AllocationDecision,
+) -> None:
+    print(
+        header(
+            f"Expected Return Check — {date.today().isoformat()}",
+            f"Regime: {regime_snap.color.upper()}",
+        )
+    )
+    print()
+
+    # The Numbers
+    print("## The Numbers")
+    print()
+    rows = [
+        ["Trailing P/E", _fmt_pe(trailing_pe), "user-supplied" if trailing_pe is not None else "—"],
+        ["Shiller CAPE", _fmt_pe(cape), "user-supplied (multpl.com / Yardeni)"],
+        ["Forward P/E", _fmt_pe(forward_pe), "user-supplied" if forward_pe is not None else "—"],
+        ["3-month T-bill", f"{rf_rate_pct:.2f}%", rf_source],
+        [
+            "10-year Treasury",
+            _fmt_pct(ten_year_yield_pct),
+            "user-supplied" if ten_year_yield_pct is not None else "—",
+        ],
+        ["Regime", regime_snap.color.upper(), "clarion-regime-check"],
+    ]
+    print(md_table(["Metric", "Value", "Source"], rows))
+
+    if trailing_pe is not None and abs(trailing_pe - cape) > 5.0:
+        print()
+        print(
+            f"_⚠ CAPE ({cape:.1f}) and trailing P/E ({trailing_pe:.1f}) diverge by "
+            f"more than 5 points. Cross-check both inputs._"
+        )
+
+    print()
+
+    # The Math
+    print("## The Math")
+    print()
+    print(
+        show_math(
+            f"Implied equity return (CAPE {cape:.1f})",
+            f"{implied.return_low_pct:.0f}–{implied.return_high_pct:.0f}% "
+            f"annualized over 10 years (confidence: {implied.confidence})",
+            f"midpoint {implied.midpoint_pct:.1f}%",
+        )
+    )
+    print(
+        show_math(
+            "Risk-free rate (3-month T-bill)",
+            rf_source,
+            f"{rf_rate_pct:.2f}%",
+        )
+    )
+    print(
+        show_math(
+            f"Regime premium ({regime_snap.color.upper()})",
+            "from docs/ALLOCATION-POLICY.md",
+            f"+{HURDLE_PREMIUM_PCT[regime_snap.color]:.1f}%",
+        )
+    )
+    print(
+        show_math(
+            "Hurdle rate",
+            f"{rf_rate_pct:.2f}% + {HURDLE_PREMIUM_PCT[regime_snap.color]:.1f}%",
+            f"{hurdle_pct:.2f}%",
+        )
+    )
+    print(
+        show_math(
+            "Spread",
+            f"implied {implied.midpoint_pct:.1f}% vs hurdle {hurdle_pct:.2f}%",
+            f"{implied.midpoint_pct - hurdle_pct:+.2f}%",
+        )
+    )
+    print()
+
+    # The Verdict
+    print("## The Verdict")
+    print()
+    print(f"**{decision.verdict}**")
+    print()
+    print(decision.rationale)
+    print()
+
+    # Recommended Value Bucket Split
+    print("## Recommended Value Bucket Split")
+    print()
+    print(f"- Equities: {decision.equity_low}-{decision.equity_high}%")
+    print(f"- T-bills / cash: {100 - decision.equity_high}-{100 - decision.equity_low}%")
+    print()
+
+    # Context
+    print("## Context")
+    print()
+    print(_context(regime_snap=regime_snap, rf_rate_pct=rf_rate_pct, cape=cape))
+    print()
+
+    # Footer
+    print(
+        footer(
+            source_lines=[
+                cite_quote("SPY/TLT/RSP daily bars (yfinance)", regime_snap.asof.isoformat()),
+                f"Risk-free rate: {rf_source}",
+                "Shiller CAPE: user-supplied",
+                "Framework: docs/ALLOCATION-POLICY.md, docs/DESIGN-LANGUAGE.md",
+            ]
+        )
+    )
+
+
+def _context(*, regime_snap: RegimeSnapshot, rf_rate_pct: float, cape: float) -> str:
+    notes: list[str] = []
+    if regime_snap.color in ("green", "blue"):
+        next_premium = HURDLE_PREMIUM_PCT["orange"]
+        notes.append(
+            f"A move to ORANGE would raise the hurdle to "
+            f"{rf_rate_pct + next_premium:.2f}% — tighter spread, possibly downgrading the verdict."
+        )
+    elif regime_snap.color == "orange":
+        notes.append(
+            f"A move to GREEN/BLUE would lower the hurdle to "
+            f"{rf_rate_pct + HURDLE_PREMIUM_PCT['green']:.2f}%; a move to RED would raise it to "
+            f"{rf_rate_pct + HURDLE_PREMIUM_PCT['red']:.2f}%."
+        )
+    elif regime_snap.color == "red":
+        notes.append(
+            f"A move to ORANGE would lower the hurdle to "
+            f"{rf_rate_pct + HURDLE_PREMIUM_PCT['orange']:.2f}% — wider spread, possibly upgrading the verdict."
+        )
+    elif regime_snap.color == "danger":
+        notes.append(
+            "DANGER state forces MAXIMUM T-BILLS regardless of P/E math. "
+            "A regime downgrade would re-enable the framework."
+        )
+
+    cape_15 = cape * 0.85
+    new_implied = implied_return_from_pe(cape_15)
+    notes.append(
+        f"A 15% market correction would bring CAPE to ~{cape_15:.1f}, implying "
+        f"{new_implied.return_low_pct:.0f}–{new_implied.return_high_pct:.0f}% returns."
+    )
+    return "\n\n".join(notes)
+
+
+def _fmt_pe(v: float | None) -> str:
+    if v is None:
+        return "—"
+    return f"{v:.2f}"
+
+
+def _fmt_pct(v: float | None) -> str:
+    if v is None:
+        return "—"
+    return f"{v:.2f}%"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="clarion-expected-return-calc")
+    ap.add_argument(
+        "--cape",
+        type=float,
+        default=None,
+        help="Shiller CAPE (cyclically adjusted P/E, 10-year). Required. Look up on multpl.com.",
+    )
+    ap.add_argument(
+        "--trailing-pe",
+        type=float,
+        default=None,
+        help="Trailing 12-month P/E. Optional cross-check.",
+    )
+    ap.add_argument(
+        "--forward-pe",
+        type=float,
+        default=None,
+        help="Next-12-month forward P/E. Optional context.",
+    )
+    ap.add_argument(
+        "--rf-rate-pct",
+        type=float,
+        default=None,
+        help="3-month T-bill rate as a percent (e.g. 4.45). If omitted, fetched from Treasury.gov.",
+    )
+    ap.add_argument(
+        "--ten-year-yield-pct",
+        type=float,
+        default=None,
+        help="10-year Treasury yield (optional context).",
+    )
+    ap.add_argument(
+        "--no-fetch-rf",
+        action="store_true",
+        help="Skip Treasury.gov auto-fetch (require --rf-rate-pct).",
+    )
+    args = ap.parse_args()
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/External/clarion-living-letter-update/SKILL.md
+++ b/External/clarion-living-letter-update/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: clarion-living-letter-update
+description: Update the annual investor letter at ~/clarion/letters/{YEAR}-letter.md with a new quarterly section, or finalize it at year-end. Auto-fills the system-deterministic parts (regime snapshot, thesis health table, portfolio bucket positions from active theses); marks the narrative-heavy parts (What We Did, What We Learned, Year in Context, Mistakes & Lessons, Looking Ahead) as [TODO] for the user to write with chat assistance. Append-only — refuses to overwrite an already-populated quarter without --force. Use when the user asks "update the letter", "quarterly letter update", "finalize the letter", or "write the {Q1/Q2/Q3/Q4} entry".
+metadata:
+  author: cis.zo.computer
+  category: External
+  display-name: Clarion Living Letter
+  homepage: https://github.com/jingerzz/clarion-intelligence-system
+---
+
+# Clarion living-letter update
+
+The annual investor letter is the system's self-accountability tool — a real-time, timestamped record of how the system thought, what it did, and what it learned. Per [`docs/PRINCIPLES.md` Principle 10 (Compound Knowledge, Not Just Capital)](../../docs/PRINCIPLES.md#10-compound-knowledge-not-just-capital), it's where the institutional memory accrues.
+
+This skill scaffolds quarterly entries and the year-end finalization. The system fills in regime + thesis health automatically; the human writes the narrative.
+
+## When to use
+
+User says any of:
+- "Update the letter."
+- "Quarterly letter update."
+- "Write the Q2 entry."
+- "Finalize the {YEAR} letter."
+
+Cadence:
+- **Quarterly (minimum)** — at the end of each quarter, run `update`. The script writes the structured sections; the user fills the narrative.
+- **Year-end** — after Q4 is filled in, run `finalize` to add the Year in Context intro and the Full Year Summary scaffold.
+
+## Decision tree
+
+1. **Pick the operation:**
+   - `update` (default) — append the current quarter's section
+   - `finalize` — year-end Year in Context + Full Year Summary
+   - `status` — show what's already in the letter
+
+2. **Run the script.**
+
+   ```bash
+   python /home/workspace/clarion-intelligence-system/skills/clarion-living-letter-update/scripts/letter.py update
+   python ... letter.py update --quarter 2 --year 2026
+   python ... letter.py finalize --year 2026
+   python ... letter.py status --year 2026
+   ```
+
+   If the letter file doesn't exist for the requested year, the script creates the skeleton (placeholder quarters + section headers) before writing.
+
+3. **For `update`:** the script:
+   - Refuses to overwrite a populated quarter without `--force`
+   - Pulls regime via the shared `clarion-regime-check` data path
+   - Pulls active theses from `~/clarion/theses/` and renders the Thesis Health table + Portfolio Snapshot bucket positions
+   - Leaves the narrative sections as `[TODO]`
+   - Prints the path written and a checklist of TODOs the user must fill
+
+4. **Walk the user through filling the [TODO] sections in order.** The most important to nail:
+   - **What We Did** — be specific (named tickers, prices, reasoning **at the time**)
+   - **What We Learned** — surprises, mistakes, patterns (per the format spec, this is the section that compounds in value over years)
+
+5. **For `finalize`:** the script:
+   - Refuses to finalize before all four quarters are populated (override with `--force`)
+   - Scaffolds the Year in Context and Full Year Summary sections
+   - Pre-populates the Theses: Final Scorecard with every thesis on file (active + closed)
+   - Leaves performance numbers, mistakes & lessons, looking ahead as `[TODO]`
+
+## How to run
+
+```bash
+LETTER=python /home/workspace/clarion-intelligence-system/skills/clarion-living-letter-update/scripts/letter.py
+
+$LETTER update                          # current year, current quarter
+$LETTER update --quarter 2              # current year, Q2 specifically
+$LETTER update --year 2026 --quarter 3  # explicit year + quarter
+$LETTER update --quarter 2 --force      # overwrite an already-populated Q2
+
+$LETTER finalize                        # current year
+$LETTER finalize --year 2026
+
+$LETTER status                          # current year status
+$LETTER status --year 2026
+```
+
+## Voice
+
+The letter is **honest** and **specific**. Per the format spec rule #3:
+> "Show the reasoning, not just the outcome. 'We bought X and it went up 30%' is useless. 'We bought X because the filing showed Y, the valuation was Z, and the regime was Green — it went up 30% but mostly for reasons we didn't anticipate' is how you actually learn."
+
+Avoid PR voice. Include the bad with the good. The mistakes section is the most valuable.
+
+When walking the user through TODOs, push back on vague language. "Performance was strong" → "Portfolio +12.4% vs S&P 500 +9.1% in Q2; ~80% of that came from NVDA's catalyst landing earlier than expected."
+
+## Hard rules
+
+1. **Never edit past quarters retroactively.** The whole point is a timestamped record. Hindsight commentary belongs in NEW sections in brackets — not as edits to old quarters. The script enforces this by refusing to overwrite populated quarters without `--force`.
+2. **The narrative sections are human-written.** The system can fill regime, theses, and portfolio bucket *positions* — but never What We Did or What We Learned. Those have to come from the principal.
+3. **Show the reasoning, not the outcome.** A quarterly entry that only chronicles wins is fiction.
+4. **Keep it concise.** Each quarterly update should be readable in 5-10 minutes. Link to thesis files for depth rather than duplicating.
+
+## On error
+
+- **`LETTER_ERROR: quarter already populated`** — the requested quarter has structural content. Pass `--force` to overwrite (rare; usually means re-running for the same period).
+- **`LETTER_ERROR: cannot finalize`** — at least one quarter is still placeholder. Fill in Q1-Q4 first, then finalize.
+- **`LETTER_ERROR: unknown quarter`** — pass an integer 1-4 for `--quarter`.

--- a/External/clarion-living-letter-update/SKILL.md
+++ b/External/clarion-living-letter-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clarion-living-letter-update
-description: Update the annual investor letter at ~/clarion/letters/{YEAR}-letter.md with a new quarterly section, or finalize it at year-end. Auto-fills the system-deterministic parts (regime snapshot, thesis health table, portfolio bucket positions from active theses); marks the narrative-heavy parts (What We Did, What We Learned, Year in Context, Mistakes & Lessons, Looking Ahead) as [TODO] for the user to write with chat assistance. Append-only — refuses to overwrite an already-populated quarter without --force. Use when the user asks "update the letter", "quarterly letter update", "finalize the letter", or "write the {Q1/Q2/Q3/Q4} entry".
+description: Update the annual investor letter at ~/clarion/letters/{YEAR}-letter.md with a new quarterly section, or finalize it at year-end. Auto-fills the system-deterministic parts (regime snapshot, thesis health table, portfolio bucket positions from active theses); marks the narrative-heavy parts (What We Did, What We Learned, Year in Context, Mistakes & Lessons, Looking Ahead) as [TODO] for the user to write with chat assistance. Append-only — refuses to overwrite an already-populated quarter without --force. Use when the user asks "update the letter", "quarterly letter update", "finalize the letter", or "write the {Q1/Q2/Q3/Q4} entry". Requires clarion-setup to have been run.
 metadata:
   author: cis.zo.computer
   category: External

--- a/External/clarion-living-letter-update/references/letter-format-guide.md
+++ b/External/clarion-living-letter-update/references/letter-format-guide.md
@@ -1,0 +1,68 @@
+# Letter format guide
+
+Source: [`docs/PRINCIPLES.md` Principle 10](../../../docs/PRINCIPLES.md#10-compound-knowledge-not-just-capital) and the AWB `LIVING-LETTER-FORMAT.md`.
+
+This file is a quick-reference for filling in the [TODO] sections after the script writes the scaffold.
+
+## File location
+
+`~/clarion/letters/{YEAR}-letter.md` — one file per calendar year.
+
+## Quarterly section structure (filled in throughout the year)
+
+```
+## Q{N}: {months}
+
+**Updated: {YYYY-MM-DD}**
+
+### Regime & Environment           ← system-filled (regime + rationale)
+### Portfolio Snapshot             ← system-filled positions, manual weights
+### What We Did                    ← human, narrative
+### Thesis Health                  ← system-filled (thesis archive)
+### What We Learned                ← human, narrative
+### Performance                    ← human-supplied numbers
+```
+
+## Year-end sections (added by `finalize`)
+
+```
+## Year in Context                 ← human, opening narrative
+## Full Year Summary
+  ### Performance                  ← human (multi-benchmark table)
+  ### By Bucket                    ← human (per-bucket attribution)
+  ### Mistakes & Lessons           ← human, ranked-by-impact
+  ### Theses: Final Scorecard      ← system-filled list, human outcomes
+  ### Looking Ahead                ← human, observations not predictions
+```
+
+## Voice rules (from the format spec)
+
+1. **Never edit past quarters retroactively.** Hindsight goes in NEW sections in brackets, not edits.
+2. **Include the bad with the good.** Mistakes section is the most valuable.
+3. **Show the reasoning, not the outcome.**
+   - Bad: "We bought X and it went up 30%."
+   - Good: "We bought X at $42 because the 10-K showed Y, valuation was 12x trailing earnings, regime was Green. It went up 30% — mostly from a macro tailwind we didn't anticipate, not the catalyst we expected. The thesis was right but for the wrong reason."
+4. **Keep each quarterly section to 5-10 minutes of reading.** Link to the thesis file for depth.
+5. **The finalized year-end letter can be shared.** Aim for self-contained.
+
+## What goes in "What We Learned"
+
+This is the section that compounds in value over years. Look for:
+
+- **Surprises** — what you didn't expect to happen
+- **Mistakes** — wrong inputs, wrong reasoning, wrong sizing, wrong patience
+- **Patterns** — multi-quarter or multi-position observations the system didn't have a model for yet
+- **Process changes** — what you'd do differently next time
+
+Don't write generic lessons. "Be patient" isn't a lesson; "I bought ADBE 4 weeks before earnings expecting the AI hype to resolve, and it took 6 months — next time I'll widen catalyst windows on hype-driven names" is a lesson.
+
+## What "Looking Ahead" is NOT
+
+It's not predictions. It's not "I think rates will fall." It's:
+
+- Observations about the current environment
+- The opportunity set the system is watching
+- The places risk seems concentrated
+- The asymmetry the system might be willing to underwrite
+
+Per the format spec: *"What regimes might we be entering? Where is the risk? Where is the asymmetry?"*

--- a/External/clarion-living-letter-update/scripts/letter.py
+++ b/External/clarion-living-letter-update/scripts/letter.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Clarion living-letter update — quarterly + year-end finalization.
+
+Operations:
+    update    Append/replace the current (or specified) quarter's section.
+    finalize  Year-end finalization (Year in Context + Full Year Summary).
+    status    Show what's populated in the letter.
+
+Append-only philosophy: refuses to overwrite an already-populated quarter
+without --force. Hindsight commentary belongs in NEW sections, not as edits
+to old quarters.
+
+Usage:
+    python letter.py update
+    python letter.py update --quarter 2
+    python letter.py update --year 2026 --quarter 3 --force
+    python letter.py finalize
+    python letter.py status
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+from ai_buffett_zo.data import EquityStore
+from ai_buffett_zo.letters import (
+    DEFAULT_LETTERS_ROOT,
+    QUARTER_LABELS,
+    current_quarter,
+    ensure_letter,
+    is_finalized,
+    is_quarter_populated,
+    letter_path,
+    list_letters,
+    render_finalization,
+    render_quarterly_section,
+    replace_full_year_summary,
+    replace_quarter,
+    replace_year_in_context,
+)
+from ai_buffett_zo.regime import RegimeSnapshot, snapshot
+from ai_buffett_zo.theses import (
+    DEFAULT_THESES_ROOT,
+    ThesisMetadata,
+    list_theses,
+    parse_thesis_metadata,
+)
+
+
+def letters_root() -> Path:
+    return Path(os.environ.get("CLARION_LETTERS_ROOT") or DEFAULT_LETTERS_ROOT)
+
+
+def theses_root() -> Path:
+    return Path(os.environ.get("CLARION_THESES_ROOT") or DEFAULT_THESES_ROOT)
+
+
+# ---- System data resolution -----------------------------------------------
+
+
+def _resolve_regime() -> RegimeSnapshot | None:
+    try:
+        store = EquityStore()
+        spy = store.history("SPY", max_age=timedelta(hours=24))
+        tlt = store.history("TLT", max_age=timedelta(hours=24))
+        rsp = store.history("RSP", max_age=timedelta(hours=24))
+    except Exception:  # noqa: BLE001
+        return None
+    if not spy or not tlt or not rsp:
+        return None
+    try:
+        return snapshot(spy, tlt, rsp)
+    except ValueError:
+        return None
+
+
+def _active_theses() -> list[ThesisMetadata]:
+    out: list[ThesisMetadata] = []
+    for p in list_theses(theses_root()):
+        try:
+            md = parse_thesis_metadata(p.read_text())
+        except OSError:
+            continue
+        if md is None:
+            continue
+        if md.status == "active":
+            out.append(md)
+    return out
+
+
+def _all_theses() -> list[ThesisMetadata]:
+    out: list[ThesisMetadata] = []
+    for p in list_theses(theses_root()):
+        try:
+            md = parse_thesis_metadata(p.read_text())
+        except OSError:
+            continue
+        if md is not None:
+            out.append(md)
+    return out
+
+
+# ---- Operations ------------------------------------------------------------
+
+
+def cmd_update(args: argparse.Namespace) -> int:
+    year = args.year or date.today().year
+    quarter = args.quarter or current_quarter()
+    if quarter not in (1, 2, 3, 4):
+        print(f"LETTER_ERROR: unknown quarter {quarter}; pass 1-4.")
+        return 1
+
+    root = letters_root()
+    path = ensure_letter(root, year)
+    content = path.read_text()
+
+    if is_quarter_populated(content, quarter) and not args.force:
+        print(
+            f"LETTER_ERROR: quarter already populated. "
+            f"Q{quarter} {year} contains structural content. "
+            f"Pass --force to overwrite (rare; usually means re-running for the same period). "
+            f"Hindsight commentary belongs in a NEW section in brackets, not as edits to past quarters."
+        )
+        return 1
+
+    regime = _resolve_regime()
+    theses = _active_theses()
+    section = render_quarterly_section(
+        quarter=quarter,
+        update_date=date.today(),
+        regime=regime,
+        active_theses=theses,
+    )
+    new_content = replace_quarter(content, quarter, section)
+    path.write_text(new_content)
+
+    print(f"Wrote Q{quarter} {year} to: {path}")
+    print()
+    if regime is None:
+        print("_warning: regime unavailable (yfinance cache empty for SPY/TLT/RSP)._")
+        print()
+    print(f"Active theses surfaced ({len(theses)}):")
+    for t in sorted(theses, key=lambda m: m.ticker):
+        print(f"  - {t.ticker} ({t.bucket}, score {t.health_score or '—'})")
+    print()
+    print("**Next:** open the letter and fill these [TODO] sections in order:")
+    print()
+    print("1. **Regime & Environment** — Macro events, S&P 500 P/E at quarter start")
+    print("2. **Portfolio Snapshot** — Actual bucket weights (system can't track real-time)")
+    print("3. **What We Did** — Specific decisions, named tickers, reasoning at the time")
+    print("4. **Thesis Health → Notes** — One-line key development per thesis")
+    print("5. **What We Learned** — Surprises, mistakes, patterns (most valuable section)")
+    print("6. **Performance** — Quarter return, S&P 500, 60/40, YTD")
+    return 0
+
+
+def cmd_finalize(args: argparse.Namespace) -> int:
+    year = args.year or date.today().year
+    root = letters_root()
+    path = ensure_letter(root, year)
+    content = path.read_text()
+
+    # All four quarters must be populated before finalizing
+    missing = [q for q in (1, 2, 3, 4) if not is_quarter_populated(content, q)]
+    if missing and not args.force:
+        labels = ", ".join(f"Q{q}" for q in missing)
+        print(
+            f"LETTER_ERROR: cannot finalize. The following quarters are still "
+            f"placeholders: {labels}. Fill them in first (clarion-living-letter-update update "
+            f"--quarter N), or pass --force to finalize anyway."
+        )
+        return 1
+
+    if is_finalized(content) and not args.force:
+        print(
+            f"LETTER_ERROR: letter already finalized. {path} contains a populated "
+            f"Full Year Summary. Pass --force to re-render the scaffold (rare)."
+        )
+        return 1
+
+    theses = _all_theses()
+    year_in_context, full_summary = render_finalization(
+        year=year,
+        finalize_date=date.today(),
+        active_theses=theses,
+    )
+
+    new_content = replace_year_in_context(content, year_in_context)
+    new_content = replace_full_year_summary(new_content, full_summary)
+    path.write_text(new_content)
+
+    print(f"Finalization scaffold written to: {path}")
+    print()
+    print(f"Theses on file ({len(theses)}):")
+    by_status: dict[str, int] = {}
+    for t in theses:
+        by_status[t.status] = by_status.get(t.status, 0) + 1
+    for status, count in sorted(by_status.items()):
+        print(f"  - {status}: {count}")
+    print()
+    print("**Next:** fill these [TODO] sections:")
+    print()
+    print("1. **Year in Context** — 2-3 paragraphs setting the macro scene")
+    print("2. **Performance table** — Total return / drawdown / Sharpe / best+worst month")
+    print("3. **By Bucket** — Per-bucket attribution + key winner/loser")
+    print("4. **Mistakes & Lessons** — Ranked by impact (this is the most valuable section)")
+    print("5. **Theses: Final Scorecard → Outcome** — One-line outcome per thesis")
+    print("6. **Looking Ahead** — Observations (NOT predictions) about regime, opportunity, risk, asymmetry")
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    year = args.year or date.today().year
+    root = letters_root()
+    path = letter_path(root, year)
+    if not path.exists():
+        print(f"No letter for {year} yet. Run `clarion-living-letter-update update` to create.")
+        all_files = list_letters(root)
+        if all_files:
+            print()
+            print("Existing letters:")
+            for f in all_files:
+                print(f"  - {f.name}")
+        return 0
+    content = path.read_text()
+    print(f"Letter: {path}")
+    print()
+    for q in (1, 2, 3, 4):
+        flag = "✓ populated" if is_quarter_populated(content, q) else "  placeholder"
+        print(f"  {flag}  {QUARTER_LABELS[q]}")
+    print()
+    print(f"  {'✓ finalized' if is_finalized(content) else '  not finalized'}  Full Year Summary")
+    return 0
+
+
+# ---- Main ------------------------------------------------------------------
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="clarion-living-letter-update")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_up = sub.add_parser("update", help="Append/replace a quarterly section.")
+    p_up.add_argument("--year", type=int, default=None)
+    p_up.add_argument("--quarter", type=int, default=None, help="1-4")
+    p_up.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an already-populated quarter (rare).",
+    )
+    p_up.set_defaults(func=cmd_update)
+
+    p_fin = sub.add_parser("finalize", help="Year-end Year in Context + Full Year Summary.")
+    p_fin.add_argument("--year", type=int, default=None)
+    p_fin.add_argument(
+        "--force",
+        action="store_true",
+        help="Finalize even if some quarters are placeholders.",
+    )
+    p_fin.set_defaults(func=cmd_finalize)
+
+    p_stat = sub.add_parser("status", help="Show what's populated in the letter.")
+    p_stat.add_argument("--year", type=int, default=None)
+    p_stat.set_defaults(func=cmd_status)
+
+    args = ap.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/External/clarion-regime-check/SKILL.md
+++ b/External/clarion-regime-check/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: clarion-regime-check
+description: Reads the SPY/TLT/RSP color regime and the equity hurdle rate. Use when the user asks about the market regime, risk-on / risk-off, market color, SPY/TLT regime, breadth, or what hurdle rate to use for new positions. Pulls daily bars via yfinance (cached locally). Optionally accepts a 1Y T-bill yield to compute the equity hurdle rate. Requires clarion-setup to have been run.
+metadata:
+  author: cis.zo.computer
+  category: External
+  display-name: Clarion Regime Check
+  homepage: https://github.com/jingerzz/clarion-intelligence-system
+---
+
+# Clarion regime check
+
+Reports the current market regime color (GREEN / BLUE / ORANGE / RED / DANGER) and, if a risk-free rate is supplied, the equity hurdle rate.
+
+## When to use
+
+User asks any of:
+- "What's the market regime?"
+- "Is the market risk-on or risk-off?"
+- "What color is SPY/TLT today?"
+- "What's the breadth signal?"
+- "What hurdle rate should I use for new positions?"
+
+## How to run
+
+```bash
+python /home/workspace/clarion-intelligence-system/skills/clarion-regime-check/scripts/regime.py
+```
+
+If the user mentioned a 1Y T-bill yield, risk-free rate, or "rf rate", pass it (a percent value, no `%` sign):
+
+```bash
+python ... regime.py --rf-rate-pct 4.5
+```
+
+If the user wants the latest cached read without re-fetching from yfinance:
+
+```bash
+python ... regime.py --offline
+```
+
+## Output
+
+The script prints a structured markdown report:
+
+- **Heading** — color and as-of date
+- **Rationale** — a short paragraph stating which signal triggered the color
+- **Signals table** — SPY 20d return, TLT 20d return, RSP-SPY 60d spread, SPY 252d drawdown
+- **Hurdle rate** — only when `--rf-rate-pct` is supplied
+- **Footer** — sources and timestamp
+
+Pass the script output through to the user verbatim. Do not paraphrase the numbers or invent a new format.
+
+If the user asks what a color **means** — e.g. "what does ORANGE imply?" or "how should I size positions in this regime?" — load `references/regime-color-guide.md` and answer from it.
+
+## On error
+
+If the script prints `REGIME_ERROR: ...`, surface the error to the user. Common cases:
+
+- **`empty history for SPY` / `TLT` / `RSP`** — yfinance returned no rows. Network glitch or rate limit. Suggest waiting a minute and retrying, or running with `--offline` if there's a recent cache.
+- **`need at least 61 bars`** — the workspace is brand new and the cache hasn't backfilled enough history. Tell the user to wait for the first full fetch (the script will fetch ~5 years on first run).

--- a/External/clarion-regime-check/references/regime-color-guide.md
+++ b/External/clarion-regime-check/references/regime-color-guide.md
@@ -1,0 +1,67 @@
+# Regime color guide
+
+Five colors classify the cross-asset risk environment. Each maps to allocation policy bands and an equity hurdle premium.
+
+## GREEN — Risk-on, expansion
+
+**Trigger:** SPY 20d return > 0 AND TLT 20d return < 0.
+
+Bonds selling, equities rising — classic risk-on / expansion regime. Money flowing out of safety into growth.
+
+- Allocation tilt: lean equities (55% Value bucket per ALLOCATION-POLICY)
+- Hurdle premium: **+4.0%**
+- Action: deploy on quality names that clear hurdle; size full positions
+
+## BLUE — Both up, "everything works"
+
+**Trigger:** SPY 20d return > 0 AND TLT 20d return > 0.
+
+Liquidity-driven — both equities and bonds rising. Strong but verify breadth before sizing up. Often late-cycle.
+
+- Allocation tilt: lean equities (55% Value)
+- Hurdle premium: **+4.0%**
+- Action: deploy but check the RSP-SPY spread; if breadth is narrowing the regime auto-degrades to ORANGE
+
+## ORANGE — Caution
+
+**Trigger (either):**
+- SPY 20d return < 0 AND TLT 20d return > 0 (flight to safety)
+- RSP - SPY 60d spread < -5% (narrow leadership / late-cycle concentration)
+
+Default conservative state. Money rotating to bonds, or leadership has narrowed to a few names.
+
+- Allocation: baseline 50/30/10/10
+- Hurdle premium: **+6.0%**
+- Action: increase T-Bill weight modestly; new positions need a clearer margin of safety
+
+## RED — Correlation breakdown
+
+**Trigger:** SPY 20d return < -5% AND TLT 20d return < 0.
+
+Risk-off without the typical bond bid — bond-equity correlation has broken. Inflation regime, rate shock, or systemic stress.
+
+- Allocation: defensive 45/25/15/10 (more shorts, less Value)
+- Hurdle premium: **+8.0%**
+- Action: shift weight to short bucket; trim Value names below conviction; raise cash
+
+## DANGER — Severe drawdown
+
+**Trigger:** SPY drawdown ≥ -20% from 252-day high.
+
+Crash regime. Maximum defense. The lesson of every prior cycle is "live to fight again." Capital preservation is paramount.
+
+- Allocation: 40/20/20/5 with explicit cash buffer
+- Hurdle premium: **+10.0%**
+- Action: no new long entries except deeply discounted forced sales; review every active thesis for kill-condition triggers; preserve liquidity
+
+## Hurdle rate computation
+
+If a 1Y T-bill yield is supplied, the equity hurdle rate equals:
+
+```
+hurdle = rf + regime_premium
+```
+
+Example: in ORANGE with rf = 4.5%, hurdle = 4.5% + 6.0% = **10.5%**.
+
+A long position must clear this hurdle in expected return to be worth holding. The hurdle rises in worse regimes — we demand more compensation when conditions are less forgiving.

--- a/External/clarion-regime-check/scripts/regime.py
+++ b/External/clarion-regime-check/scripts/regime.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Clarion regime check — SPY/TLT/RSP color + equity hurdle rate.
+
+Pulls daily bars via yfinance (cached at ~/clarion/data/equities/), computes
+the regime snapshot, and prints a markdown report to stdout. Errors print a
+single `REGIME_ERROR: ...` line and exit non-zero.
+
+Usage:
+    python regime.py
+    python regime.py --rf-rate-pct 4.5
+    python regime.py --offline
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import timedelta
+
+from ai_buffett_zo.data import EquityStore
+from ai_buffett_zo.regime import HURDLE_PREMIUM_PCT, RegimeSnapshot, snapshot
+from ai_buffett_zo.voice import (
+    cite_quote,
+    footer,
+    header,
+    md_table,
+    no_data,
+    show_math,
+)
+
+REQUIRED_TICKERS = ("SPY", "TLT", "RSP")
+
+
+def format_regime_output(snap: RegimeSnapshot) -> str:
+    """Render the regime snapshot as the markdown report shown to the user."""
+    parts: list[str] = [
+        header(
+            f"Market Regime — {snap.color.upper()}",
+            f"as of {snap.asof.isoformat()}",
+        ),
+        snap.rationale,
+        "",
+        "**Signals**",
+        md_table(
+            ["Signal", "Value"],
+            [
+                ["SPY 20d return", f"{snap.spy_ret_short:+.2%}"],
+                ["TLT 20d return", f"{snap.tlt_ret_short:+.2%}"],
+                ["RSP-SPY 60d spread", f"{snap.rsp_vs_spy_long:+.2%}"],
+                ["SPY drawdown vs 252d high", f"{snap.spy_drawdown_from_high:+.2%}"],
+            ],
+        ),
+    ]
+    if snap.hurdle_rate_pct is not None:
+        parts.append("")
+        parts.append("**Equity hurdle rate**")
+        parts.append(
+            show_math(
+                "Hurdle",
+                f"rf + {HURDLE_PREMIUM_PCT[snap.color]:.1f}% regime premium",
+                f"{snap.hurdle_rate_pct:.2f}%",
+            )
+        )
+    parts.append("")
+    parts.append(
+        footer(
+            source_lines=[cite_quote("SPY/TLT/RSP daily bars (yfinance)", snap.asof.isoformat())]
+        )
+    )
+    return "\n".join(parts)
+
+
+def run(
+    *,
+    rf_rate_pct: float | None,
+    offline: bool,
+    max_age_hours: int,
+) -> int:
+    max_age = timedelta.max if offline else timedelta(hours=max_age_hours)
+    store = EquityStore()
+
+    histories = {}
+    for ticker in REQUIRED_TICKERS:
+        try:
+            bars = store.history(ticker, max_age=max_age)
+        except Exception as e:  # noqa: BLE001
+            print(f"REGIME_ERROR: failed to fetch {ticker}: {type(e).__name__}: {e}")
+            return 1
+        if not bars:
+            print(no_data(f"{ticker}: no bars available"))
+            print(f"REGIME_ERROR: empty history for {ticker}")
+            return 1
+        histories[ticker] = bars
+
+    try:
+        snap = snapshot(
+            histories["SPY"],
+            histories["TLT"],
+            histories["RSP"],
+            rf_rate_pct=rf_rate_pct,
+        )
+    except ValueError as e:
+        print(f"REGIME_ERROR: {e}")
+        return 1
+
+    print(format_regime_output(snap))
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="clarion-regime-check")
+    ap.add_argument(
+        "--rf-rate-pct",
+        type=float,
+        default=None,
+        help="1Y T-bill yield as a percent (e.g. 4.5). If set, the hurdle rate is computed.",
+    )
+    ap.add_argument(
+        "--offline",
+        action="store_true",
+        help="Use only cached bars; do not call yfinance.",
+    )
+    ap.add_argument(
+        "--max-age-hours",
+        type=int,
+        default=24,
+        help="Refresh cache if last bar older than this many hours (default 24).",
+    )
+    args = ap.parse_args()
+    return run(
+        rf_rate_pct=args.rf_rate_pct,
+        offline=args.offline,
+        max_age_hours=args.max_age_hours,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/External/clarion-sec-research/SKILL.md
+++ b/External/clarion-sec-research/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: clarion-sec-research
+description: Pull, index, and search SEC EDGAR filings (10-K, 10-Q). Use when the user asks about a company's SEC filings, risk factors, MD&A, business description, or wants to analyze a specific filing in plain English. Single ticker or multiple tickers (comma-separated). On first request for a ticker, indexing happens in the background (1-5 min). Subsequent queries are fast. Requires clarion-setup to have been run.
+metadata:
+  author: cis.zo.computer
+  category: External
+  display-name: Clarion SEC Research
+  homepage: https://github.com/jingerzz/clarion-intelligence-system
+---
+
+# Clarion SEC research
+
+Three subcommands: `index`, `search`, `status`.
+
+## When to use
+
+User asks any of:
+- "Analyze NVDA's most recent 10-K."
+- "What are the risk factors for AAPL?"
+- "Compare KO's MD&A across the last two 10-Ks."
+- "Pull NVDA's latest 10-Q."
+- "What does NVDA say about supply chain?"
+- "Index AMD."
+
+## Decision tree
+
+When the user asks about a specific ticker:
+
+1. Run `status <TICKER>` to check whether the requested filing is already indexed.
+2. **If indexed** → run `search` with a query phrase that captures the user's question. Pass `--tickers <TICKER>` to scope the search.
+3. **If NOT indexed** → run `index <TICKER> [--form 10-Q]`. Tell the user the indexing is queued (typically 1-5 minutes) and suggest they come back.
+4. **If the user asks a thematic question across multiple tickers** (e.g. "which of NVDA, AMD, INTC mentions supply chain risk?"), run `search` with `--tickers NVDA,AMD,INTC`. If any of the tickers shows zero hits, surface that and suggest indexing them.
+
+## How to run
+
+The script is at `/home/workspace/clarion-intelligence-system/skills/clarion-sec-research/scripts/research.py`. Below, `RESEARCH=python /home/workspace/clarion-intelligence-system/skills/clarion-sec-research/scripts/research.py` for brevity.
+
+### Index
+
+```bash
+$RESEARCH index NVDA              # latest 10-K (default)
+$RESEARCH index NVDA --form 10-Q  # latest 10-Q
+```
+
+### Search
+
+```bash
+$RESEARCH search "supply chain risk"
+$RESEARCH search "supply chain risk" --tickers NVDA,AMD
+$RESEARCH search "competitive pressure" --sections risk_factors,mdna
+$RESEARCH search "data center revenue" --top-k 5
+```
+
+Section labels: `business`, `risk_factors`, `mdna`, `financial_statements`.
+
+### Status
+
+```bash
+$RESEARCH status NVDA
+```
+
+## Output
+
+Each subcommand prints structured markdown that you should pass through to the user verbatim. `index` confirms the queue submission. `search` returns a hit table and top-5 snippets with citations. `status` lists indexed filings and last request state.
+
+When you want to **summarize or interpret** the filing content beyond the script's snippets:
+
+- Quote specific numbers from the filing where relevant.
+- **Always cite** the filing on each claim. The search output's `citation` field is the canonical form: `NVDA 10-K filed 2026-02-21 → risk_factors`.
+- Tier 1 is the filing itself. Don't speculate beyond what's in the text.
+- If the user asks a question and the answer isn't in the indexed corpus, say so explicitly — don't fill in from training data.
+
+## Voice
+
+Conservative and direct. Show the math (numbers from the filing) where relevant. Never fabricate financial data — if the search snippet doesn't have the number the user asked for, say "the indexed sections don't contain that figure" and offer to index more sections or another form (e.g. the 10-Q for more recent data).
+
+## On error
+
+- **`status` shows last_request.state = failed`** — the indexer hit an error. Surface the `error` field. Common causes: ticker not in SEC's tickers map (typo), no `ZO_API_KEY` set, network issue.
+- **`search` returns no hits** for a ticker that should have content — confirm with `status` that indexing actually completed; if `state` is still `running` or missing, indexing isn't done yet.

--- a/External/clarion-sec-research/SKILL.md
+++ b/External/clarion-sec-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clarion-sec-research
-description: Pull, index, and search SEC EDGAR filings (10-K, 10-Q). Use when the user asks about a company's SEC filings, risk factors, MD&A, business description, or wants to analyze a specific filing in plain English. Single ticker or multiple tickers (comma-separated). On first request for a ticker, indexing happens in the background (1-5 min). Subsequent queries are fast. Requires clarion-setup to have been run.
+description: Pull, index, and search SEC EDGAR filings for any public company. Supports 10-K and 10-Q (annual/quarterly with curated section extraction for risk factors, MD&A, business, and financials), Form 3/4/5 (insider transactions), 8-K (material events), DEF 14A (proxy/governance), S-1 (IPO/registration), 20-F (foreign private issuers), and any other SEC form by name. Use when the user asks about a company's SEC filings, risk factors, MD&A, insider transactions, executive compensation, business description, or wants to analyze a specific filing in plain English. Single ticker or multiple tickers (comma-separated). On first request for a ticker+form, indexing happens in the background (1-5 min). Subsequent queries are fast. Requires clarion-setup to have been run.
 metadata:
   author: cis.zo.computer
   category: External
@@ -20,6 +20,10 @@ User asks any of:
 - "Compare KO's MD&A across the last two 10-Ks."
 - "Pull NVDA's latest 10-Q."
 - "What does NVDA say about supply chain?"
+- "Has there been any insider activity at NVDA?" (Form 4)
+- "Pull NVDA's latest insider transaction report." (Form 4)
+- "What's in TSLA's most recent 8-K?"
+- "Show me META's proxy statement on executive compensation." (DEF 14A)
 - "Index AMD."
 
 ## Decision tree
@@ -38,9 +42,15 @@ The script is at `/home/workspace/clarion-intelligence-system/skills/clarion-sec
 ### Index
 
 ```bash
-$RESEARCH index NVDA              # latest 10-K (default)
-$RESEARCH index NVDA --form 10-Q  # latest 10-Q
+$RESEARCH index NVDA                  # latest 10-K (default)
+$RESEARCH index NVDA --form 10-Q      # latest 10-Q
+$RESEARCH index NVDA --form 4         # latest Form 4 (insider transactions)
+$RESEARCH index TSLA --form 8-K       # latest 8-K (material events)
+$RESEARCH index META --form "DEF 14A" # latest proxy statement
+$RESEARCH index BABA --form 20-F      # latest 20-F (foreign private issuer)
 ```
+
+`--form` accepts any SEC form name. Pass it exactly as SEC reports it (e.g. `10-K`, `10-Q`, `4`, `3`, `5`, `8-K`, `S-1`, `DEF 14A`, `20-F`). Amendments use `/A` suffix (`10-K/A`).
 
 ### Search
 
@@ -49,9 +59,13 @@ $RESEARCH search "supply chain risk"
 $RESEARCH search "supply chain risk" --tickers NVDA,AMD
 $RESEARCH search "competitive pressure" --sections risk_factors,mdna
 $RESEARCH search "data center revenue" --top-k 5
+$RESEARCH search "insider transaction" --tickers NVDA  # Form 4 hits
 ```
 
-Section labels: `business`, `risk_factors`, `mdna`, `financial_statements`.
+**Section labels** depend on the form type:
+
+- **10-K / 10-Q** use canonical labels (curated extraction): `business`, `risk_factors`, `mdna`, `financial_statements`. The `--sections` filter is most useful here.
+- **All other forms** (Form 4, 8-K, S-1, DEF 14A, etc.) use slugified labels derived from each filing's headings — e.g. Form 4 sections appear as `form-4-insider-transaction-report`, `issuer`, `reporting-owners`, `non-derivative-transactions`. Look at `status` output or run `search` without `--sections` to see what's actually indexed before filtering.
 
 ### Status
 

--- a/External/clarion-sec-research/scripts/research.py
+++ b/External/clarion-sec-research/scripts/research.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Clarion SEC research — index / search / status.
+
+Subcommands:
+    index TICKER [--form 10-K|10-Q]   queue a filing for indexing
+    search "query" [--tickers ...] [--sections ...] [--top-k N]
+    status TICKER                     show indexing state for a ticker
+
+Reads from ~/clarion/queue (queue) and ~/clarion/sec (corpus). Override via
+$CLARION_QUEUE_ROOT and $CLARION_SEC_ROOT for testing or non-default layouts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from ai_buffett_zo.indexer import (
+    DEFAULT_QUEUE_ROOT,
+    IndexRequest,
+    enqueue,
+    load_status,
+)
+from ai_buffett_zo.secrag import (
+    DEFAULT_SEC_ROOT,
+    SearchHit,
+    list_indexed,
+    search,
+)
+from ai_buffett_zo.voice import (
+    cite_filing,
+    footer,
+    header,
+    md_table,
+    no_data,
+)
+
+
+def queue_root() -> Path:
+    return Path(os.environ.get("CLARION_QUEUE_ROOT") or DEFAULT_QUEUE_ROOT)
+
+
+def sec_root() -> Path:
+    return Path(os.environ.get("CLARION_SEC_ROOT") or DEFAULT_SEC_ROOT)
+
+
+# ---- index -----------------------------------------------------------------
+
+
+def cmd_index(args: argparse.Namespace) -> int:
+    qroot = queue_root()
+    qroot.mkdir(parents=True, exist_ok=True)
+    req = IndexRequest.new(args.ticker, form=args.form)
+    path = enqueue(req, root=qroot)
+
+    parts = [
+        header(f"Queued — {req.ticker} {req.form}"),
+        f"Request ID: `{req.id}`",
+        f"Queue path: `{path}`",
+        "",
+        (
+            f"The sec-indexer service will pick this up within a few seconds and "
+            f"index the latest {req.form} filing. Indexing typically takes 1-5 "
+            f"minutes depending on filing size and model. Check progress with:"
+        ),
+        "",
+        "```",
+        f"clarion-sec-research status {req.ticker}",
+        "```",
+        "",
+        footer(),
+    ]
+    print("\n".join(parts))
+    return 0
+
+
+# ---- search ----------------------------------------------------------------
+
+
+def cmd_search(args: argparse.Namespace) -> int:
+    sroot = sec_root()
+    tickers = _split_csv(args.tickers)
+    sections = _split_csv(args.sections)
+
+    hits = search(
+        args.query,
+        root=sroot,
+        tickers=tickers,
+        section_labels=sections,
+        top_k=args.top_k,
+    )
+
+    print(header(f'SEC search — "{args.query}"', _query_subtitle(tickers, sections)))
+
+    if not hits:
+        print()
+        print(no_data("no matches in the indexed corpus."))
+        _suggest_indexing(sroot, tickers)
+        return 0
+
+    print()
+    print(_hits_table(hits))
+    print()
+    print("**Top results**")
+    for i, h in enumerate(hits[: args.top_show], start=1):
+        print()
+        print(f"### {i}. {cite_filing(h.ticker, h.form, h.filed)} → `{h.path}`")
+        print()
+        print(f"> {h.snippet}")
+
+    print()
+    print(footer(source_lines=[h.citation for h in hits[: args.top_show]]))
+    return 0
+
+
+def _hits_table(hits: list[SearchHit]) -> str:
+    rows = [
+        [h.ticker, h.form, h.filed, h.section_label, f"{h.score:.0f}"]
+        for h in hits
+    ]
+    return md_table(["Ticker", "Form", "Filed", "Section", "Score"], rows)
+
+
+def _suggest_indexing(sroot: Path, tickers: list[str] | None) -> None:
+    if tickers:
+        print()
+        print("To index these tickers, run:")
+        for t in tickers:
+            print(f"```\nclarion-sec-research index {t.upper()}\n```")
+    else:
+        indexed = list_indexed(sroot)
+        if not indexed:
+            print()
+            print("No filings indexed yet. Index one with:")
+            print("```\nclarion-sec-research index <TICKER>\n```")
+
+
+def _query_subtitle(
+    tickers: list[str] | None, sections: list[str] | None
+) -> str | None:
+    parts: list[str] = []
+    if tickers:
+        parts.append(f"tickers: {', '.join(tickers)}")
+    if sections:
+        parts.append(f"sections: {', '.join(sections)}")
+    return " · ".join(parts) if parts else None
+
+
+def _split_csv(raw: str | None) -> list[str] | None:
+    if not raw:
+        return None
+    return [s.strip() for s in raw.split(",") if s.strip()]
+
+
+# ---- status ----------------------------------------------------------------
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    sroot = sec_root()
+    status = load_status(sroot, args.ticker)
+
+    print(header(f"Indexing status — {status.ticker}"))
+
+    if not status.filings and not status.last_request:
+        print()
+        print(f"No filings indexed yet for {status.ticker}.")
+        print(f"Run: `clarion-sec-research index {status.ticker}`")
+        print()
+        print(footer())
+        return 0
+
+    if status.last_request:
+        lr = status.last_request
+        print()
+        print("**Last request**")
+        print(f"- Form: `{lr.get('form', '?')}`")
+        print(f"- State: `{lr.get('state', '?')}`")
+        print(f"- Updated: `{lr.get('updated_at', '?')}`")
+        if lr.get("error"):
+            print(f"- Error: `{lr['error']}`")
+
+    if status.filings:
+        print()
+        print("**Indexed filings**")
+        rows = [
+            [f.form, f.filed, f.accession, f.indexed_at, f.status]
+            for f in status.filings
+        ]
+        print(md_table(["Form", "Filed", "Accession", "Indexed at", "Status"], rows))
+
+    print()
+    print(footer())
+    return 0
+
+
+# ---- main ------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="clarion-sec-research")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_index = sub.add_parser("index", help="Queue a filing for indexing.")
+    p_index.add_argument("ticker", type=str.upper)
+    p_index.add_argument("--form", default="10-K")
+    p_index.set_defaults(func=cmd_index)
+
+    p_search = sub.add_parser("search", help="Search indexed filings by keyword.")
+    p_search.add_argument("query")
+    p_search.add_argument("--tickers", help="Comma-separated tickers (filter).")
+    p_search.add_argument(
+        "--sections",
+        help="Comma-separated section labels: business, risk_factors, mdna, financial_statements.",
+    )
+    p_search.add_argument("--top-k", type=int, default=10)
+    p_search.add_argument(
+        "--top-show",
+        type=int,
+        default=5,
+        help="How many full-snippet entries to render after the table.",
+    )
+    p_search.set_defaults(func=cmd_search)
+
+    p_status = sub.add_parser("status", help="Show indexing status for a ticker.")
+    p_status.add_argument("ticker", type=str.upper)
+    p_status.set_defaults(func=cmd_status)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/External/clarion-sec-research/scripts/research.py
+++ b/External/clarion-sec-research/scripts/research.py
@@ -2,7 +2,10 @@
 """Clarion SEC research — index / search / status.
 
 Subcommands:
-    index TICKER [--form 10-K|10-Q]   queue a filing for indexing
+    index TICKER [--form FORM]        queue latest filing of FORM (default 10-K).
+                                      Common values: 10-K, 10-Q, 8-K, 4 (insider
+                                      transactions), 3, 5, S-1, DEF 14A, 20-F.
+                                      Any SEC form name works; amendments use /A.
     search "query" [--tickers ...] [--sections ...] [--top-k N]
     status TICKER                     show indexing state for a ticker
 
@@ -212,7 +215,13 @@ def main() -> int:
     p_search.add_argument("--tickers", help="Comma-separated tickers (filter).")
     p_search.add_argument(
         "--sections",
-        help="Comma-separated section labels: business, risk_factors, mdna, financial_statements.",
+        help=(
+            "Comma-separated section labels. For 10-K/10-Q the canonical labels "
+            "are: business, risk_factors, mdna, financial_statements. For other "
+            "forms (Form 4, 8-K, S-1, DEF 14A, ...) sections are slugified from "
+            "each filing's headings — run search without --sections first to see "
+            "what's indexed."
+        ),
     )
     p_search.add_argument("--top-k", type=int, default=10)
     p_search.add_argument(

--- a/External/clarion-setup/SKILL.md
+++ b/External/clarion-setup/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: clarion-setup
+description: Bootstraps the Clarion Intelligence System on Zo Computer. Run this once after installing the skill — clones the source repo, installs the ai_buffett_zo Python library, creates the ~/clarion/ workspace, writes default config, and registers the sec-indexer background service. Idempotent (safe to re-run). Use when the user asks to "set up Clarion", "install Clarion", or after they install any other clarion-* skill before it has been bootstrapped.
+metadata:
+  author: cis.zo.computer
+  category: External
+  display-name: Clarion Setup
+  homepage: https://github.com/jingerzz/clarion-intelligence-system
+---
+
+# Clarion Setup
+
+Bootstraps Clarion Intelligence System on a Zo workspace. Run this once before any other `clarion-*` skill.
+
+## What you do
+
+Run the steps below in order. Stop and surface any failure to the user immediately — do not proceed past a failure.
+
+### Step 1 — Clone or update the source repo
+
+The repo holds the Python library, the `sec-indexer` service code, and templates.
+
+If `/home/workspace/clarion-intelligence-system` does NOT exist:
+
+```bash
+gh repo clone jingerzz/clarion-intelligence-system /home/workspace/clarion-intelligence-system
+```
+
+If it exists, update it:
+
+```bash
+git -C /home/workspace/clarion-intelligence-system pull --ff-only
+```
+
+### Step 2 — Run the setup script
+
+```bash
+python /home/workspace/clarion-intelligence-system/skills/clarion-setup/scripts/setup.py
+```
+
+The script is idempotent. It will:
+
+- Install the `ai_buffett_zo` library editable (auto-detects whether to use `--system`)
+- Create the `~/clarion/{data/equities,sec,queue,theses,watchlists,letters}/` data tree
+- Write a default `~/clarion/config.json` (preserves any existing config)
+- Verify the `sec-indexer` console script is on PATH
+- Print service registration parameters between `--- BEGIN SERVICE_REGISTRATION ---` and `--- END SERVICE_REGISTRATION ---`
+- Print a final `SETUP_RESULT: ok` line on success, or `SETUP_RESULT: error: <reason>` on failure
+
+If you do NOT see `SETUP_RESULT: ok`, surface the error to the user verbatim and stop.
+
+### Step 3 — Confirm or create the ZO_API_KEY secret
+
+**Scope:** This step is only needed because of the `sec-indexer` **background service**. The other Clarion skills (`clarion-regime-check`, `clarion-sec-research`) run inside chat agent turns, which auto-inject `ZO_CLIENT_IDENTITY_TOKEN`, so they need no token setup. The indexer runs as a persistent process outside agent turns, has no auto-injected identity, and so needs a long-lived bearer.
+
+The token is **not** an external provider key (no OpenAI / Anthropic / Minimax keys involved). It's Zo-issued — created in Settings → Advanced → Access Tokens — and calls made with it are billed against the user's Zo monthly credit pool, same as their chat usage.
+
+Check whether the user has a Zo secret named exactly `ZO_API_KEY`. If they do, skip to Step 4.
+
+If they do NOT, tell the user:
+
+> I need to set up a Zo access token so the SEC indexer can call models on your behalf (charged to your Zo monthly credits — same pool as chat).
+>
+> Please:
+> 1. Open **Settings → Advanced → Access Tokens** and create a new token (any name, e.g. `clarion-sec-indexer`). Copy the token (it starts with `zo_sk_`).
+> 2. Open **Settings → Advanced → Secrets** and create a secret named exactly `ZO_API_KEY` with that token as the value.
+> 3. Tell me when you're done.
+
+Wait for confirmation before proceeding to Step 4.
+
+### Step 4 — Register the sec-indexer service
+
+Use the `register_user_service` agent tool with these exact parameters (also printed by setup.py in the SERVICE_REGISTRATION envelope):
+
+- **label**: `sec-indexer`
+- **mode**: `process`
+- **entrypoint**: `sec-indexer`
+- **workdir**: `/home/workspace`
+- **env_vars**: `{"ZO_API_KEY": "$ZO_API_KEY"}`
+- **description**: `Clarion sec-indexer — background SEC EDGAR filing indexer`
+
+The `$ZO_API_KEY` value is shell-style syntax telling Zo to resolve from the user's secret of the same name (created in Step 3) at service start. Use the snake_case parameter names exactly — `workdir` and `env_vars` — these are the canonical keys Zo's tool accepts.
+
+Confirm registration succeeded (the tool should return a service ID like `svc_…`).
+
+### Step 5 — Verify and report
+
+Run a final check:
+
+```bash
+sec-indexer --help
+```
+
+If it prints help text, all components are in place.
+
+Tell the user:
+
+> ✅ Clarion is set up.
+>
+> - Source: `/home/workspace/clarion-intelligence-system/`
+> - Workspace data: `~/clarion/`
+> - Background service: `sec-indexer` (running)
+>
+> Next, install the skills you want to use. Recommended:
+> - **clarion-regime-check** — SPY/TLT/RSP regime + hurdle rate
+> - **clarion-sec-research** — SEC filing pull, index, query
+
+## Idempotency
+
+Re-running this skill is safe. Each step:
+
+- Repo clone: skipped if already cloned (just `git pull`)
+- Library install: re-runs `uv pip install -e` (no harm)
+- Data tree: `mkdir -p` (no harm)
+- Config: preserved if present
+- Service registration: if the user already has a `sec-indexer` service, `register_user_service` should report it exists; treat that as success.
+
+## On failure
+
+If any step fails, do not silently proceed. Read the error, summarize the cause, and offer the user the next step to take. Common cases:
+
+- **`gh: command not found`** — Zo should ship `gh`. If missing, the user's workspace is in a non-standard state; ask them to contact Zo support.
+- **`uv: command not found`** — same.
+- **`uv pip install` fails with venv error** — the script tries `--system` automatically; if it still fails, ask the user to share the full error.
+- **`register_user_service` fails** — surface the tool's error message; check whether `ZO_API_KEY` secret exists.

--- a/External/clarion-setup/SKILL.md
+++ b/External/clarion-setup/SKILL.md
@@ -51,22 +51,24 @@ If you do NOT see `SETUP_RESULT: ok`, surface the error to the user verbatim and
 
 ### Step 3 — Confirm or create the ZO_API_KEY secret
 
-**Scope:** This step is only needed because of the `sec-indexer` **background service**. The other Clarion skills (`clarion-regime-check`, `clarion-sec-research`) run inside chat agent turns, which auto-inject `ZO_CLIENT_IDENTITY_TOKEN`, so they need no token setup. The indexer runs as a persistent process outside agent turns, has no auto-injected identity, and so needs a long-lived bearer.
+**Scope:** This step is only needed because of the `sec-indexer` **background service**. The other Clarion skills (`clarion-regime-check`, `clarion-sec-research`, etc.) run inside chat agent turns, which auto-inject `ZO_CLIENT_IDENTITY_TOKEN`, so they need no token setup. The indexer runs as a persistent process outside agent turns, has no auto-injected identity, and so needs a long-lived bearer.
 
-The token is **not** an external provider key (no OpenAI / Anthropic / Minimax keys involved). It's Zo-issued — created in Settings → Advanced → Access Tokens — and calls made with it are billed against the user's Zo monthly credit pool, same as their chat usage.
+The token is **not** an external provider key (no OpenAI / Anthropic / Minimax keys involved). It's Zo-issued and calls made with it are billed against the user's Zo monthly credit pool, same as their chat usage.
 
-Check whether the user has a Zo secret named exactly `ZO_API_KEY`. If they do, skip to Step 4.
+**Decision — fresh install vs. re-run:**
 
-If they do NOT, tell the user:
+- If the user already has a Zo secret named exactly `ZO_API_KEY` (most likely on a re-run), skip to Step 4.
+- Otherwise (most likely on a first install), do the verbatim-paste step below.
 
-> I need to set up a Zo access token so the SEC indexer can call models on your behalf (charged to your Zo monthly credits — same pool as chat).
->
-> Please:
-> 1. Open **Settings → Advanced → Access Tokens** and create a new token (any name, e.g. `clarion-sec-indexer`). Copy the token (it starts with `zo_sk_`).
-> 2. Open **Settings → Advanced → Secrets** and create a secret named exactly `ZO_API_KEY` with that token as the value.
-> 3. Tell me when you're done.
+**CRITICAL — paste the user-action block verbatim.** The setup script's stdout includes a block bounded by `--- BEGIN USER_ACTION_REQUIRED ---` and `--- END USER_ACTION_REQUIRED ---`. **Copy the contents of that block (everything between the two sentinels) into the chat exactly as written. Do not summarize, paraphrase, or condense.**
 
-Wait for confirmation before proceeding to Step 4.
+The block is dummy-proofed for a non-technical user: it has the exact menu paths, the exact secret name (`ZO_API_KEY`, uppercase, with underscore — the most error-prone part), the numbered sequence, and a note about UI variations. Compressing it removes the dummy-proofing.
+
+After pasting the block:
+
+1. Wait for the user to reply with `done` (or any clear confirmation).
+2. If they reply with a question instead of confirmation (e.g. "I can't find Settings"), help them — but lead with the same explicit substeps from the user-action block, not your own paraphrase.
+3. Once confirmed, proceed to Step 4.
 
 ### Step 4 — Register the sec-indexer service
 
@@ -95,15 +97,19 @@ If it prints help text, all components are in place.
 
 Tell the user:
 
-> ✅ Clarion is set up.
+> Clarion is set up.
 >
 > - Source: `/home/workspace/clarion-intelligence-system/`
 > - Workspace data: `~/clarion/`
 > - Background service: `sec-indexer` (running)
 >
-> Next, install the skills you want to use. Recommended:
+> Next, install the skills you want to use. Recommended starter set:
 > - **clarion-regime-check** — SPY/TLT/RSP regime + hurdle rate
-> - **clarion-sec-research** — SEC filing pull, index, query
+> - **clarion-sec-research** — pull, index, search SEC filings (10-K, 10-Q, Form 3/4/5, 8-K, DEF 14A, etc.)
+>
+> Or the full set: `clarion-single-stock-eval`, `clarion-expected-return-calc`, `clarion-value-screener`, `clarion-thesis-write`, `clarion-thesis-monitor`, `clarion-watchlist-update`, `clarion-living-letter-update`.
+>
+> Once any of those are installed, just ask me things like *"what's the market regime?"*, *"analyze NVDA's latest 10-K"*, or *"is the market overvalued?"*.
 
 ## Idempotency
 

--- a/External/clarion-setup/SKILL.md
+++ b/External/clarion-setup/SKILL.md
@@ -115,6 +115,15 @@ Re-running this skill is safe. Each step:
 - Config: preserved if present
 - Service registration: if the user already has a `sec-indexer` service, `register_user_service` should report it exists; treat that as success.
 
+### Re-running to pick up source updates
+
+Editable installs (`uv pip install -e`) do NOT reload an already-running service — the `sec-indexer` process keeps the Python modules it imported at startup in memory. After a `git pull` brings in new code, you MUST restart the service for the changes to take effect.
+
+If the user is re-running setup specifically to pull in upstream fixes (or you see behavior matching code that no longer exists in the repo), restart the service after Step 4:
+
+- Use the `update_user_service` agent tool with the existing `sec-indexer` service ID and `action: restart` (or whatever the equivalent restart action is in the user's Zo environment).
+- Confirm the service comes back up before re-running any failed `clarion-sec-research` query.
+
 ## On failure
 
 If any step fails, do not silently proceed. Read the error, summarize the cause, and offer the user the next step to take. Common cases:

--- a/External/clarion-setup/SKILL.md
+++ b/External/clarion-setup/SKILL.md
@@ -124,7 +124,7 @@ If the user is re-running setup specifically to pull in upstream fixes (or you s
 - Use the `update_user_service` agent tool with the existing `sec-indexer` service ID and `action: restart` (or whatever the equivalent restart action is in the user's Zo environment).
 - Confirm the service comes back up before re-running any failed `clarion-sec-research` query.
 
-## On failure
+## On error
 
 If any step fails, do not silently proceed. Read the error, summarize the cause, and offer the user the next step to take. Common cases:
 

--- a/External/clarion-setup/scripts/setup.py
+++ b/External/clarion-setup/scripts/setup.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Clarion Intelligence System setup script.
+
+Run from the cloned repo root (or any cwd — paths are resolved from this
+script's location). Idempotent.
+
+Steps:
+1. Validate uv is on PATH.
+2. uv pip install -e {repo}/lib  (with --system if no venv is active)
+3. mkdir -p ~/clarion/{data/equities,sec,queue,theses,watchlists,letters}
+4. Write ~/clarion/config.json if missing
+5. Verify `sec-indexer` console script resolves
+6. Print service registration envelope for the SKILL.md to consume
+7. Print SETUP_RESULT: ok | error: <reason>
+
+The SKILL.md parses stdout; structured output goes between
+`--- BEGIN SERVICE_REGISTRATION ---` and `--- END SERVICE_REGISTRATION ---`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]   # skills/clarion-setup/scripts/setup.py → repo
+LIB_DIR = REPO_ROOT / "lib"
+WORKSPACE = Path.home() / "clarion"
+DATA_SUBDIRS = (
+    "data/equities",
+    "sec",
+    "queue",
+    "theses",
+    "watchlists",
+    "letters",
+)
+
+DEFAULT_CONFIG: dict = {
+    "indexing_model": "zo:openai/gpt-5.4-mini",
+    "indexing_fallback_model": "zo:minimax/minimax-m2.5",
+    "reasoning_model": "zo:anthropic/claude-opus-4-7",
+    "sec_user_agent": "Clarion Intelligence System (clarion@example.com)",
+    "data_root": str(WORKSPACE),
+}
+
+SERVICE_REGISTRATION_PARAMS: dict = {
+    "label": "sec-indexer",
+    "mode": "process",
+    "entrypoint": "sec-indexer",
+    "workdir": "/home/workspace",
+    "env_vars": {"ZO_API_KEY": "$ZO_API_KEY"},
+    "description": "Clarion sec-indexer — background SEC EDGAR filing indexer",
+}
+
+
+def fail(msg: str) -> None:
+    """Emit the error sentinel and exit non-zero."""
+    print(f"\nSETUP_RESULT: error: {msg}", flush=True)
+    sys.exit(1)
+
+
+def ok() -> None:
+    print("\nSETUP_RESULT: ok", flush=True)
+
+
+# ---- pure helpers (testable) -----------------------------------------------
+
+
+def make_data_tree(workspace: Path) -> list[Path]:
+    """Create the per-user data tree under workspace. Idempotent."""
+    out: list[Path] = []
+    for sub in DATA_SUBDIRS:
+        d = workspace / sub
+        d.mkdir(parents=True, exist_ok=True)
+        out.append(d)
+    return out
+
+
+def write_default_config(workspace: Path, *, force: bool = False) -> Path:
+    """Write workspace/config.json with defaults. Preserved if exists unless force=True."""
+    workspace.mkdir(parents=True, exist_ok=True)
+    path = workspace / "config.json"
+    if path.exists() and not force:
+        return path
+    path.write_text(json.dumps(DEFAULT_CONFIG, indent=2))
+    return path
+
+
+def install_library(lib_dir: Path) -> tuple[int, str, str]:
+    """uv pip install -e {lib_dir}. Adds --system if no venv is active.
+
+    Returns (returncode, stdout, stderr). Caller decides what to do.
+    """
+    in_venv = bool(os.environ.get("VIRTUAL_ENV"))
+    cmd = ["uv", "pip", "install", "--quiet", "-e", str(lib_dir)]
+    if not in_venv:
+        cmd.insert(3, "--system")
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    return result.returncode, result.stdout, result.stderr
+
+
+def verify_console_script() -> tuple[int, str]:
+    """Confirm `sec-indexer --help` works. Returns (returncode, captured_output)."""
+    result = subprocess.run(
+        ["sec-indexer", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode, result.stdout + result.stderr
+
+
+# ---- main orchestration ----------------------------------------------------
+
+
+def main() -> None:
+    print("Clarion Intelligence System — setup\n")
+
+    # Step 1 — uv on PATH
+    if shutil.which("uv") is None:
+        fail("uv not found on PATH. Install uv: https://docs.astral.sh/uv/")
+
+    # Step 2 — install library
+    if not LIB_DIR.is_dir():
+        fail(f"library directory missing: {LIB_DIR} (is the repo cloned?)")
+
+    print(f"[1/5] Installing ai_buffett_zo from {LIB_DIR} ...")
+    rc, _, stderr = install_library(LIB_DIR)
+    if rc != 0:
+        fail(f"uv pip install failed (rc={rc}): {stderr.strip()[:300]}")
+    print("       installed.")
+
+    # Step 3 — data tree
+    print(f"[2/5] Creating data tree under {WORKSPACE} ...")
+    created = make_data_tree(WORKSPACE)
+    for d in created:
+        print(f"       {d}")
+
+    # Step 4 — config
+    print("[3/5] Writing default config ...")
+    config_path = write_default_config(WORKSPACE)
+    if config_path.read_text().strip() == json.dumps(DEFAULT_CONFIG, indent=2).strip():
+        print(f"       wrote {config_path}")
+    else:
+        print(f"       preserved existing {config_path}")
+
+    # Step 5 — entrypoint check
+    print("[4/5] Verifying sec-indexer entry point ...")
+    rc, output = verify_console_script()
+    if rc != 0:
+        fail(
+            "sec-indexer entry point not on PATH after install. "
+            "uv may have installed to a directory not in PATH. "
+            f"Output:\n{output[:300]}"
+        )
+    print("       OK")
+
+    # Step 6 — registration envelope
+    print("[5/5] Service registration parameters:")
+    print("--- BEGIN SERVICE_REGISTRATION ---")
+    print(json.dumps(SERVICE_REGISTRATION_PARAMS, indent=2))
+    print("--- END SERVICE_REGISTRATION ---")
+
+    ok()
+
+
+if __name__ == "__main__":
+    main()

--- a/External/clarion-setup/scripts/setup.py
+++ b/External/clarion-setup/scripts/setup.py
@@ -56,6 +56,49 @@ SERVICE_REGISTRATION_PARAMS: dict = {
 }
 
 
+# Verbatim user-facing message for the only manual step in setup. The chat
+# agent that invokes setup.py is expected to paste this between the BEGIN/END
+# sentinels into the user's chat unchanged — no summarization, no rewording.
+# The detail level here is deliberate: a non-technical user needs the exact
+# menu paths, the exact secret name, and the numbered sequence.
+USER_ACTION_MESSAGE = """\
+**Action required (1 of 1 manual step)** — Create your `ZO_API_KEY` secret
+
+Clarion's `sec-indexer` background service needs a Zo access token to call \
+models on your behalf. This token is **Zo-issued** (no OpenAI / Anthropic / \
+external keys involved) and bills against your Zo monthly credit pool — the \
+same pool as your chat usage.
+
+This is the **only** manual step in the entire setup. Total time: ~2 minutes.
+
+---
+
+**Step 1 — Create an access token**
+
+1. Open Zo Settings (top-right menu icon → **Settings**, or however your Zo client surfaces settings).
+2. Go to **Advanced → Access Tokens**.
+3. Click **Create token** (or the equivalent "+ New token" button).
+4. Name the token anything you like — `clarion-sec-indexer` is a good default.
+5. **Copy the token value.** It starts with `zo_sk_`. You'll paste it in Step 2.
+
+**Step 2 — Save it as a secret**
+
+1. In the same Settings area, go to **Advanced → Secrets**.
+2. Click **Create secret** (or "+ New secret").
+3. **Name:** type exactly `ZO_API_KEY` — uppercase, with the underscore. The indexer service looks for a secret with this exact name; any other spelling (lowercase, hyphens, etc.) will not be found.
+4. **Value:** paste the token you copied in Step 1.
+5. Save.
+
+**Step 3 — Confirm**
+
+Reply with **`done`** in this chat. I'll automatically register the indexer service for you and finish setup.
+
+---
+
+*If you can't find the menu items above, your Zo client UI may use slightly different labels — search for "Access Tokens" and "Secrets" in your settings. If you get stuck, tell me what you see and I'll help.*\
+"""
+
+
 def fail(msg: str) -> None:
     """Emit the error sentinel and exit non-zero."""
     print(f"\nSETUP_RESULT: error: {msg}", flush=True)
@@ -164,14 +207,24 @@ def main() -> None:
     print(json.dumps(SERVICE_REGISTRATION_PARAMS, indent=2))
     print("--- END SERVICE_REGISTRATION ---")
 
+    # User-facing message for the only manual step. The agent invoking this
+    # script must paste the block between BEGIN/END sentinels into chat
+    # verbatim — see SKILL.md Step 3.
+    print()
+    print("--- BEGIN USER_ACTION_REQUIRED ---")
+    print(USER_ACTION_MESSAGE)
+    print("--- END USER_ACTION_REQUIRED ---")
+
     # If sec-indexer is already running from a previous setup, an editable
     # install does NOT reload it — the running process keeps the modules it
     # imported at startup. The skill caller must restart the service after a
     # re-run, otherwise upstream bug fixes won't take effect.
     print(
-        "\nNOTE: if `sec-indexer` is already registered as a running service, "
-        "restart it now (e.g. `update_user_service` with action=restart) so "
-        "any updated source code is loaded into the running process."
+        "\nNOTE: if `sec-indexer` is already registered as a running service "
+        "(re-run scenario), the user does NOT need to redo the secret step. "
+        "Skip the USER_ACTION_REQUIRED block above and restart the service "
+        "via `update_user_service` with action=restart so any updated source "
+        "code is loaded into the running process."
     )
 
     ok()

--- a/External/clarion-setup/scripts/setup.py
+++ b/External/clarion-setup/scripts/setup.py
@@ -164,6 +164,16 @@ def main() -> None:
     print(json.dumps(SERVICE_REGISTRATION_PARAMS, indent=2))
     print("--- END SERVICE_REGISTRATION ---")
 
+    # If sec-indexer is already running from a previous setup, an editable
+    # install does NOT reload it — the running process keeps the modules it
+    # imported at startup. The skill caller must restart the service after a
+    # re-run, otherwise upstream bug fixes won't take effect.
+    print(
+        "\nNOTE: if `sec-indexer` is already registered as a running service, "
+        "restart it now (e.g. `update_user_service` with action=restart) so "
+        "any updated source code is loaded into the running process."
+    )
+
     ok()
 
 

--- a/External/clarion-single-stock-eval/SKILL.md
+++ b/External/clarion-single-stock-eval/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: clarion-single-stock-eval
+description: Evaluate a single stock using the Buffett lens. Pulls a quality snapshot from yfinance, current SPY/TLT regime context, and snippets from the indexed SEC filings across four dimensions (moat, management, financial trends, risks). The chat agent reasons over the structured output to produce a written evaluation. Use when the user says "evaluate <TICKER>", "is <TICKER> a buy?", "Buffett evaluation of <TICKER>", "what's <TICKER>'s moat?", or asks about a specific company's management, financials, or risks. Requires the ticker to be indexed first via clarion-sec-research.
+metadata:
+  author: cis.zo.computer
+  category: External
+  display-name: Clarion Single-Stock Eval
+  homepage: https://github.com/jingerzz/clarion-intelligence-system
+---
+
+# Clarion single-stock evaluation
+
+Pulls structured data + filing snippets for a ticker, then helps you compose a Buffett-style evaluation.
+
+## When to use
+
+User asks any of:
+- "Evaluate NVDA."
+- "Is KO still a long-term hold?"
+- "Buffett take on AAPL."
+- "What's NVDA's moat?"
+- "How does AMD's management allocate capital?"
+- "What are the biggest risks for INTC?"
+
+## Decision tree
+
+1. **Check indexing.** If the ticker hasn't been indexed yet, do not try to evaluate. Tell the user to run `clarion-sec-research index <TICKER>` first, wait 1–5 minutes, then come back.
+2. **Run `eval.py <TICKER>`.** If the user mentioned a 1Y T-bill yield or risk-free rate, pass `--rf-rate-pct X.X`. The script prints market context, a quality snapshot, and four dimensions of filing snippets.
+3. **Read the brief end-to-end.** Then synthesize an evaluation using the `references/buffett-question-bank.md` (load it on demand) — answer the four (or five, if hurdle was supplied) numbered questions in the script's "Reading guide" section, in order, citing the filing on every claim drawn from filings.
+4. **Conclude with one of three verdicts:**
+   - **Add** — clear thesis; expected return likely clears the regime hurdle; ready to size a position
+   - **Watchlist** — promising but waiting for {a better price / a specific catalyst / a clearer signal}
+   - **Skip** — material issue (no durable moat / impaired financials / unaligned management / risk profile too severe)
+5. **If the verdict is Add** and the user wants to act on it, suggest `clarion-thesis-write` (Phase B, coming soon).
+
+## How to run
+
+```bash
+EVAL=python /home/workspace/clarion-intelligence-system/skills/clarion-single-stock-eval/scripts/eval.py
+
+$EVAL NVDA                       # default — pulls all four dimensions
+$EVAL NVDA --rf-rate-pct 4.5     # adds equity hurdle to market context
+$EVAL NVDA --no-regime           # skip regime/hurdle if user just wants the lens
+```
+
+## Voice
+
+Conservative and direct. Show your math (numbers from the snippets and the quality table). Lead with what the filings actually say; surface uncertainty where the snippets are vague.
+
+**Always cite the filing on every claim drawn from filings.** Each snippet's `citation` line is canonical (`NVDA 10-K filed 2026-02-21 → risk_factors`). Do not paraphrase the citation — copy it.
+
+Don't fabricate. If a snippet doesn't directly support a claim you'd like to make, say so explicitly — "the indexed sections don't address customer concentration" beats inventing.
+
+The yfinance quality table is point-in-time and occasionally wrong (ticker remappings, delistings, foreign listings). For high-conviction calls, suggest the user verify against the latest filing.
+
+## On error
+
+- **`No filings indexed`** — run `clarion-sec-research index <TICKER>`, wait for completion, retry.
+- **`EVAL_ERROR: failed to fetch fundamentals`** — yfinance hiccup. Retry in a minute. The lens still works without fundamentals; consider running with `--no-regime` and noting the gap.

--- a/External/clarion-single-stock-eval/SKILL.md
+++ b/External/clarion-single-stock-eval/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clarion-single-stock-eval
-description: Evaluate a single stock using the Buffett lens. Pulls a quality snapshot from yfinance, current SPY/TLT regime context, and snippets from the indexed SEC filings across four dimensions (moat, management, financial trends, risks). The chat agent reasons over the structured output to produce a written evaluation. Use when the user says "evaluate <TICKER>", "is <TICKER> a buy?", "Buffett evaluation of <TICKER>", "what's <TICKER>'s moat?", or asks about a specific company's management, financials, or risks. Requires the ticker to be indexed first via clarion-sec-research.
+description: Evaluate a single stock using the Buffett lens. Pulls a quality snapshot from yfinance, current SPY/TLT regime context, and snippets from the indexed SEC filings across four dimensions (moat, management, financial trends, risks). The chat agent reasons over the structured output to produce a written evaluation. Use when the user says "evaluate <TICKER>", "is <TICKER> a buy?", "Buffett evaluation of <TICKER>", "what's <TICKER>'s moat?", or asks about a specific company's management, financials, or risks. Requires clarion-setup to have been run, and the ticker to be indexed first via clarion-sec-research.
 metadata:
   author: cis.zo.computer
   category: External
@@ -31,7 +31,7 @@ User asks any of:
    - **Add** — clear thesis; expected return likely clears the regime hurdle; ready to size a position
    - **Watchlist** — promising but waiting for {a better price / a specific catalyst / a clearer signal}
    - **Skip** — material issue (no durable moat / impaired financials / unaligned management / risk profile too severe)
-5. **If the verdict is Add** and the user wants to act on it, suggest `clarion-thesis-write` (Phase B, coming soon).
+5. **If the verdict is Add** and the user wants to act on it, suggest `clarion-thesis-write` to formalize the position into a thesis file.
 
 ## How to run
 

--- a/External/clarion-single-stock-eval/references/buffett-question-bank.md
+++ b/External/clarion-single-stock-eval/references/buffett-question-bank.md
@@ -1,0 +1,47 @@
+# Buffett Question Bank — single-stock-eval reference
+
+The full Question Bank lives in [`docs/DESIGN-LANGUAGE.md`](../../../docs/DESIGN-LANGUAGE.md#the-buffett-question-bank) — load that for the complete set when the user asks what a dimension means or wants the full methodology.
+
+This file holds the **synthesis template** for writing a Buffett-style evaluation after the script has produced its structured output.
+
+---
+
+## How the four lenses map to evaluation
+
+The script's `eval.py` runs four lenses against the indexed filings:
+
+- **Moat & competitive position** — *Business quality* questions from the Question Bank
+- **Management & capital allocation** — *Management quality* questions
+- **Financial trends** — *Valuation* and revenue / margin / FCF questions
+- **Risk factors** — *Risk* questions
+
+Each lens returns search hits with citations. Use the Question Bank in `docs/DESIGN-LANGUAGE.md` to interrogate the snippets.
+
+---
+
+## Synthesis template
+
+After running the four lenses, write a brief that answers:
+
+1. **What I believe** — one paragraph, plain English.
+2. **Why I believe it** — numbered evidence drawn from filings. Cite each (the script's `citation` lines are canonical).
+3. **What it's worth** — bear / base / bull scenarios with rough numbers (margin range × revenue range × multiple range, then sanity-check against current price).
+4. **What changes my mind** — kill conditions: specific, measurable, falsifiable.
+5. **Why now** — the catalyst, or the patience case for waiting.
+
+End with one of three verdicts: **Add** / **Watchlist** / **Skip**.
+
+A good evaluation is concise — under 800 words is plenty. If you need more, the thesis isn't clear enough yet.
+
+---
+
+## Anti-patterns to avoid
+
+From [`docs/DESIGN-LANGUAGE.md#anti-patterns`](../../../docs/DESIGN-LANGUAGE.md#anti-patterns-what-the-system-never-does):
+
+- Never present a recommendation without showing the alternative ("Buy X" is incomplete; "Buy X versus holding T-bills" is a decision)
+- Never use relative language without an anchor ("cheap" means nothing without context)
+- Never bury the conclusion (verdict goes early, evidence follows)
+- Never ignore the base rate (what *usually* happens in this situation?)
+- Never conflate precision with accuracy (use ranges, not false-precision point estimates)
+- Never recommend without sizing (a great idea at the wrong size is a bad idea)

--- a/External/clarion-single-stock-eval/scripts/eval.py
+++ b/External/clarion-single-stock-eval/scripts/eval.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Clarion single-stock evaluation — Buffett lens over indexed filings + market data.
+
+Reads:
+- yfinance .info for the quality snapshot
+- regime.snapshot for SPY/TLT/RSP color and equity hurdle
+- secrag.search for filing snippets across four Buffett dimensions
+
+Outputs structured markdown that the Zo chat agent reasons over to produce
+a Buffett-style evaluation. The script does not synthesize a thesis itself —
+the SKILL.md instructs Zo to compose using the question-bank reference.
+
+Usage:
+    python eval.py NVDA
+    python eval.py NVDA --rf-rate-pct 4.5
+    python eval.py NVDA --no-regime
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import timedelta
+from pathlib import Path
+
+from ai_buffett_zo.data import EquityStore
+from ai_buffett_zo.evaluation import (
+    Fundamentals,
+    LensView,
+    fetch_fundamentals,
+    view as lens_view,
+)
+from ai_buffett_zo.regime import HURDLE_PREMIUM_PCT, RegimeSnapshot, snapshot
+from ai_buffett_zo.secrag import DEFAULT_SEC_ROOT, list_indexed
+from ai_buffett_zo.voice import (
+    cite_quote,
+    footer,
+    header,
+    md_table,
+    no_data,
+    show_math,
+)
+
+
+def sec_root() -> Path:
+    return Path(os.environ.get("CLARION_SEC_ROOT") or DEFAULT_SEC_ROOT)
+
+
+def run(args: argparse.Namespace) -> int:
+    ticker = args.ticker.upper()
+    sroot = sec_root()
+
+    indexed = [m for m in list_indexed(sroot) if m.ticker == ticker]
+    if not indexed:
+        print(header(f"Single-Stock Evaluation — {ticker}"))
+        print()
+        print(no_data(f"No filings indexed for {ticker}."))
+        print()
+        print(f"Run `clarion-sec-research index {ticker}` first, wait for completion, then retry.")
+        print()
+        print(footer())
+        return 0
+
+    try:
+        f = fetch_fundamentals(ticker)
+    except Exception as e:  # noqa: BLE001
+        print(f"EVAL_ERROR: failed to fetch fundamentals for {ticker}: {type(e).__name__}: {e}")
+        return 1
+
+    regime_snap = None if args.no_regime else _maybe_regime(args.rf_rate_pct)
+    lens = lens_view(ticker, sec_root=sroot)
+
+    _render(f, regime_snap, lens, indexed_accessions=[m.accession for m in indexed])
+    return 0
+
+
+def _maybe_regime(rf_rate_pct: float | None) -> RegimeSnapshot | None:
+    """Best-effort regime snapshot. Non-fatal on failure — eval still runs."""
+    try:
+        store = EquityStore()
+        spy = store.history("SPY", max_age=timedelta(hours=24))
+        tlt = store.history("TLT", max_age=timedelta(hours=24))
+        rsp = store.history("RSP", max_age=timedelta(hours=24))
+    except Exception:  # noqa: BLE001
+        return None
+    if not spy or not tlt or not rsp:
+        return None
+    try:
+        return snapshot(spy, tlt, rsp, rf_rate_pct=rf_rate_pct)
+    except ValueError:
+        return None
+
+
+# ---- rendering --------------------------------------------------------------
+
+
+def _render(
+    f: Fundamentals,
+    regime_snap: RegimeSnapshot | None,
+    lens: list[LensView],
+    *,
+    indexed_accessions: list[str],
+) -> None:
+    print(header(f"Single-Stock Evaluation — {f.ticker}", f.company))
+    print()
+
+    if regime_snap is not None:
+        _render_market_context(regime_snap)
+        print()
+
+    _render_quality_snapshot(f)
+    print()
+
+    print("## Buffett lens")
+    print()
+    print("*Snippets from indexed SEC filings, grouped by dimension.*")
+    print()
+    for lv in lens:
+        _render_lens_view(lv)
+
+    print("## Reading guide")
+    print()
+    print(_reading_guide(regime_snap))
+    print()
+
+    sources: list[str] = []
+    if regime_snap is not None:
+        sources.append(cite_quote("SPY/TLT/RSP daily bars (yfinance)", regime_snap.asof.isoformat()))
+    sources.append(f"{f.ticker} indexed accessions: {', '.join(indexed_accessions)}")
+    sources.append(f"{f.ticker} fundamentals: yfinance .info (point-in-time)")
+    print(footer(source_lines=sources))
+
+
+def _render_market_context(snap: RegimeSnapshot) -> None:
+    print("## Market context")
+    print()
+    print(f"Regime: **{snap.color.upper()}** — {snap.rationale}")
+    if snap.hurdle_rate_pct is not None:
+        print()
+        print(
+            show_math(
+                "Equity hurdle",
+                f"rf + {HURDLE_PREMIUM_PCT[snap.color]:.1f}% regime premium",
+                f"{snap.hurdle_rate_pct:.2f}%",
+            )
+        )
+
+
+def _render_quality_snapshot(f: Fundamentals) -> None:
+    print("## Quality snapshot")
+    print()
+    print("*yfinance .info — point-in-time data; verify against the latest filing for serious decisions.*")
+    print()
+    rows = [
+        ["Market cap", _fmt_money(f.market_cap)],
+        ["Trailing P/E", _fmt_num(f.trailing_pe)],
+        ["Forward P/E", _fmt_num(f.forward_pe)],
+        ["Price/Book", _fmt_num(f.price_to_book)],
+        ["Operating margin", _fmt_pct(f.operating_margin)],
+        ["Profit margin", _fmt_pct(f.profit_margin)],
+        ["Return on equity", _fmt_pct(f.return_on_equity)],
+        ["Return on assets", _fmt_pct(f.return_on_assets)],
+        ["Debt/Equity", _fmt_num(f.debt_to_equity)],
+        ["Free cash flow (TTM)", _fmt_money(f.free_cash_flow)],
+        ["Operating cash flow (TTM)", _fmt_money(f.operating_cash_flow)],
+        ["Dividend yield", _fmt_pct(f.dividend_yield)],
+        ["52w high", _fmt_money(f.week52_high)],
+        ["52w low", _fmt_money(f.week52_low)],
+        ["Last close", _fmt_money(f.last_close)],
+    ]
+    print(md_table(["Metric", "Value"], rows))
+
+
+def _render_lens_view(lv: LensView) -> None:
+    print(f"### {lv.title}")
+    print()
+    if not lv.hits:
+        print(no_data(f"no hits in indexed filings for the {lv.dimension} query."))
+        print()
+        return
+    for h in lv.hits:
+        print(f"> {h.snippet}")
+        print()
+        print(f"— {h.citation}")
+        print()
+
+
+def _reading_guide(regime_snap: RegimeSnapshot | None) -> str:
+    """Tells Zo what to do with the structured output. SKILL.md amplifies."""
+    lines = [
+        "Reason over the data above to produce a Buffett-style evaluation:",
+        "",
+        "1. **Moat durability** — does the business have a sustainable competitive advantage? Are the moat snippets specific (named customers, contracts, brand, IP, scale) or vague?",
+        "2. **Management quality** — does management discuss capital allocation explicitly? Buybacks at attractive prices? Dividends? Reinvestment? Are they aligned and honest?",
+        "3. **Financial trends** — are revenue and operating margins expanding, stable, or eroding? Is FCF healthy and growing, or propped up by working capital / asset sales?",
+        "4. **Risk profile** — what's the most severe risk in the indexed filings? Is it tail (unlikely but ruinous) or recurring (drag on returns)? Is the company mitigating it?",
+    ]
+    if regime_snap is not None and regime_snap.hurdle_rate_pct is not None:
+        lines.append(
+            f"5. **Hurdle clearance** — does the expected return on this position clear "
+            f"{regime_snap.hurdle_rate_pct:.1f}% (the {regime_snap.color.upper()} regime hurdle)?"
+        )
+    lines.append("")
+    lines.append(
+        "Show your math. Cite the filing on every claim drawn from filings — copy the canonical "
+        "`citation` line under each snippet. End with one of three verdicts: **Add** / "
+        "**Watchlist** / **Skip**."
+    )
+    return "\n".join(lines)
+
+
+# ---- formatters -------------------------------------------------------------
+
+
+def _fmt_money(v: float | None) -> str:
+    if v is None:
+        return "—"
+    av = abs(v)
+    if av >= 1e9:
+        return f"${v/1e9:.2f}B"
+    if av >= 1e6:
+        return f"${v/1e6:.1f}M"
+    return f"${v:,.2f}"
+
+
+def _fmt_pct(v: float | None) -> str:
+    if v is None:
+        return "—"
+    return f"{v*100:.2f}%"
+
+
+def _fmt_num(v: float | None) -> str:
+    if v is None:
+        return "—"
+    return f"{v:.2f}"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="clarion-single-stock-eval")
+    ap.add_argument("ticker", type=str.upper)
+    ap.add_argument(
+        "--rf-rate-pct",
+        type=float,
+        default=None,
+        help="1Y T-bill yield as a percent (e.g. 4.5). Adds equity hurdle to market context.",
+    )
+    ap.add_argument(
+        "--no-regime",
+        action="store_true",
+        help="Skip regime/hurdle calculation (fundamentals + lens only).",
+    )
+    args = ap.parse_args()
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/External/clarion-thesis-monitor/SKILL.md
+++ b/External/clarion-thesis-monitor/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: clarion-thesis-monitor
+description: Monitor the health of every active thesis in ~/clarion/theses/. For each one — refresh price, recompute Risk Environment from the current regime, check kill conditions (read from the file's status column), aggregate to an Overall score, recommend an action (EXIT / REDUCE / HOLD / ADD), and write the updated scores + history back to the thesis file. Produces a dashboard surfacing what needs attention. Use when the user asks "monitor my theses", "thesis health check", "any kill conditions triggered?", "what's the action on <TICKER>", or as part of a daily / weekly review.
+metadata:
+  author: cis.zo.computer
+  category: External
+  display-name: Clarion Thesis Monitor
+  homepage: https://github.com/jingerzz/clarion-intelligence-system
+---
+
+# Clarion thesis monitor
+
+Reads every active thesis from `~/clarion/theses/`, scores health, checks kill conditions, and produces an action recommendation per thesis. Updates each file with the new scores and timestamps; appends a History entry when the action changes.
+
+Implements [`docs/PRINCIPLES.md` Principle 2 (Thesis-First, Always)](../../docs/PRINCIPLES.md#2-thesis-first-always) — *"a thesis that isn't monitored is just a hope."*
+
+## When to use
+
+User asks any of:
+- "Monitor my theses."
+- "Thesis health check."
+- "Any kill conditions triggered?"
+- "What's the action on NVDA right now?"
+- "Run a full health check across the portfolio."
+
+Cadence guidance:
+- **Daily** — `--quick` mode (kill condition statuses + price refresh + Risk Environment recompute, no full re-scoring)
+- **Weekly** — full mode (all directly-derivable components recomputed; carries forward LLM-driven components)
+- **Monthly** — full mode + manual review of the LLM-driven components (Business Health, Insider Alignment, Thesis Integrity)
+
+## Decision tree
+
+1. **Default invocation:** run with no args to process all active theses.
+
+   ```bash
+   python /home/workspace/clarion-intelligence-system/skills/clarion-thesis-monitor/scripts/monitor.py
+   ```
+
+   Filters to `status: active` theses; skips `watchlist`, `closed`, `killed`.
+
+2. **Single-thesis review:** if the user asks about one ticker, scope it.
+
+   ```bash
+   python ... monitor.py --ticker NVDA
+   ```
+
+3. **Quick mode (daily):** skip the full health re-scoring; just check kill conditions, refresh prices, recompute Risk Environment.
+
+   ```bash
+   python ... monitor.py --quick
+   ```
+
+4. **Read-only mode:** preview the dashboard without writing back to thesis files.
+
+   ```bash
+   python ... monitor.py --no-write
+   ```
+
+5. **Pass the dashboard output to the user verbatim.** It's already structured (per-thesis action + score, kill alerts at the top).
+
+6. **Surface "Action Items"** — if any thesis flips to EXIT or REDUCE, raise it explicitly. The user makes the call; the system does not pull triggers automatically. ([`docs/PRINCIPLES.md` Anti-principle 5](../../docs/PRINCIPLES.md#the-anti-principles-what-the-system-refuses-to-be).)
+
+## What gets recomputed
+
+| Component | v1 behavior | Notes |
+|---|---|---|
+| Valuation Safety | If `--current-price` provided AND a `base_case_fair_value` is in the thesis metadata, recomputed. Else carried forward. | Add `base_case_fair_value: 480.0` to the thesis metadata block to enable auto-scoring. |
+| Business Health | Carried forward in v1 | Future: `/zo/ask` over recent MD&A snippets |
+| Insider Alignment | Carried forward in v1 | Future: WebSearch over recent Form 4s |
+| Catalyst Proximity | If `catalyst_date` in metadata, recomputed. Else carried forward. | Add `catalyst_date: 2026-08-15` to enable auto-scoring. |
+| Thesis Integrity | Carried forward in v1 | Future: `/zo/ask` over thesis evidence + new filings |
+| Risk Environment | **Always recomputed** | regime × bucket matrix |
+
+When the lib's deterministic-scoring v2 lands (LLM-driven Business Health / Thesis Integrity via `/zo/ask`), the carry-forward defaults will be replaced. The user's manually-set scores remain authoritative until then.
+
+## How to run
+
+```bash
+MONITOR=python /home/workspace/clarion-intelligence-system/skills/clarion-thesis-monitor/scripts/monitor.py
+
+$MONITOR                                 # all active theses, full mode
+$MONITOR --quick                         # kill checks + Risk Env only
+$MONITOR --ticker NVDA                   # single thesis
+$MONITOR --no-write                      # preview, don't update files
+$MONITOR --ticker NVDA --current-price 142.50  # force re-score Valuation Safety
+```
+
+## Voice
+
+Lead with **action items** (any EXIT or REDUCE), then the dashboard. Don't bury bad news. The whole point of monitoring is the moments when things degrade.
+
+When a kill condition is triggered, surface it explicitly: *"NVDA — kill condition triggered (gross margin < 60% per latest 10-Q). Action is EXIT regardless of score. Review within 48 hours per the thesis hard rule."*
+
+## Hard rules
+
+1. **Kill conditions are binary.** A triggered kill condition forces EXIT — no exceptions, no "well, maybe it's fine." This is enforced in code.
+2. **Never fabricate health scores.** If the script can't compute a component (no current price, no base case fair value), it carries forward the previous score and marks "data unavailable."
+3. **Always update the thesis files.** The monitor is not read-only by default. It writes back updated scores, dates, and findings. (Use `--no-write` to opt out for previews.)
+4. **Regime overrides are conservative.** In Danger state, all theses downgrade one action level. Shorts upgrade. This is enforced in `lib/ai_buffett_zo/theses/health.py:adjust_for_regime`.
+5. **Show the evidence.** Every component score in the output has a one-line rationale traceable to a regime, a price, or a previous-run carry-forward.
+
+## On error
+
+- **`THESIS_MONITOR_ERROR: no active theses`** — `~/clarion/theses/` is empty or every thesis has `status: closed/killed/watchlist`. Run `clarion-thesis-write` first.
+- **`THESIS_MONITOR_ERROR: regime unavailable`** — yfinance cache empty for SPY/TLT/RSP. Run `clarion-regime-check` first to seed it.
+- **`THESIS_MONITOR_ERROR: malformed thesis`** — a specific thesis file failed to parse. The dashboard still runs for the others; the failed one is listed separately for the user to fix.

--- a/External/clarion-thesis-monitor/SKILL.md
+++ b/External/clarion-thesis-monitor/SKILL.md
@@ -36,7 +36,7 @@ Cadence guidance:
    python /home/workspace/clarion-intelligence-system/skills/clarion-thesis-monitor/scripts/monitor.py
    ```
 
-   Filters to `status: active` theses; skips `watchlist`, `closed`, `killed`.
+   Filters to `status: active` theses; skips `draft`, `watchlist`, `closed`, `killed`. (`draft` is the default status of a freshly scaffolded thesis from `clarion-thesis-write` — the user promotes to `active` once the prose is filled in.)
 
 2. **Single-thesis review:** if the user asks about one ticker, scope it.
 
@@ -101,6 +101,6 @@ When a kill condition is triggered, surface it explicitly: *"NVDA — kill condi
 
 ## On error
 
-- **`THESIS_MONITOR_ERROR: no active theses`** — `~/clarion/theses/` is empty or every thesis has `status: closed/killed/watchlist`. Run `clarion-thesis-write` first.
+- **`THESIS_MONITOR_ERROR: no active theses`** — `~/clarion/theses/` is empty, or every thesis has `status: draft/closed/killed/watchlist`. If you have draft theses, finish filling them in and promote the metadata `status: draft` → `status: active`. Otherwise run `clarion-thesis-write` to scaffold a new one.
 - **`THESIS_MONITOR_ERROR: regime unavailable`** — yfinance cache empty for SPY/TLT/RSP. Run `clarion-regime-check` first to seed it.
 - **`THESIS_MONITOR_ERROR: malformed thesis`** — a specific thesis file failed to parse. The dashboard still runs for the others; the failed one is listed separately for the user to fix.

--- a/External/clarion-thesis-monitor/SKILL.md
+++ b/External/clarion-thesis-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clarion-thesis-monitor
-description: Monitor the health of every active thesis in ~/clarion/theses/. For each one — refresh price, recompute Risk Environment from the current regime, check kill conditions (read from the file's status column), aggregate to an Overall score, recommend an action (EXIT / REDUCE / HOLD / ADD), and write the updated scores + history back to the thesis file. Produces a dashboard surfacing what needs attention. Use when the user asks "monitor my theses", "thesis health check", "any kill conditions triggered?", "what's the action on <TICKER>", or as part of a daily / weekly review.
+description: Monitor the health of every active thesis in ~/clarion/theses/. For each one — refresh price, recompute Risk Environment from the current regime, check kill conditions (read from the file's status column), aggregate to an Overall score, recommend an action (EXIT / REDUCE / HOLD / ADD), and write the updated scores + history back to the thesis file. Produces a dashboard surfacing what needs attention. Use when the user asks "monitor my theses", "thesis health check", "any kill conditions triggered?", "what's the action on <TICKER>", or as part of a daily / weekly review. Requires clarion-setup to have been run.
 metadata:
   author: cis.zo.computer
   category: External

--- a/External/clarion-thesis-monitor/references/health-scoring-guide.md
+++ b/External/clarion-thesis-monitor/references/health-scoring-guide.md
@@ -1,0 +1,69 @@
+# Health scoring guide
+
+Source of truth for the framework: [`docs/PRINCIPLES.md` Principle 2](../../../docs/PRINCIPLES.md#2-thesis-first-always), [`docs/ALLOCATION-POLICY.md`](../../../docs/ALLOCATION-POLICY.md), and [`lib/ai_buffett_zo/theses/health.py`](../../../lib/ai_buffett_zo/theses/health.py).
+
+This file is a quick-reference for interpreting the dashboard.
+
+## The six components
+
+| Component | What it measures | Auto-scored? |
+|---|---|---|
+| **Valuation Safety** | Margin of safety: current price vs base-case fair value | Yes (when `base_case_fair_value` in metadata) |
+| **Business Health** | Revenue, margin, FCF trends from latest filing | Carried forward in v1; future LLM-driven |
+| **Insider Alignment** | Recent Form 4 activity, executive ownership | Carried forward in v1; future WebSearch-driven |
+| **Catalyst Proximity** | Days until expected catalyst | Yes (when `catalyst_date` in metadata) |
+| **Thesis Integrity** | Whether evidence in the thesis still holds | Carried forward in v1; future LLM-driven |
+| **Risk Environment** | Regime × bucket compatibility | **Always** auto-scored |
+
+## Scoring scales
+
+### Valuation Safety
+| Margin of safety | Score |
+|---|---|
+| > 40% | 90 |
+| 25-40% | 75 |
+| 10-25% | 60 |
+| 0-10% | 45 |
+| -20% to 0% | 30 |
+| < -20% | 15 |
+
+### Catalyst Proximity
+| Days to catalyst | Score |
+|---|---|
+| 0-30 | 85 |
+| 31-90 | 75 |
+| 91-180 | 60 |
+| > 180 (or none) | 50-55 |
+| Catalyst missed (negative) | 35 |
+
+### Risk Environment (regime × bucket)
+| Bucket → / Regime ↓ | Value | Systematic | Short | YOLO |
+|---|---|---|---|---|
+| Green / Blue | 80 | 70 | 40 | 70 |
+| Orange | 60 | 60 | 65 | 50 |
+| Red | 40 | 50 | 85 | 35 |
+| Danger | 30 | 40 | 85 | 30 |
+
+## Action map
+
+Overall score = weighted average of components (weights sum to 100). Action is then derived from the table below and adjusted for regime.
+
+| Score | Base action | Description |
+|---|---|---|
+| 0-39 | EXIT | Thesis is broken. Close the position. |
+| 40-54 | REDUCE | Thesis weakening. Trim to minimum band size. |
+| 55-74 | HOLD | Thesis intact. Maintain position. |
+| 75-100 | ADD | Thesis strong. Add on dips within sizing limits. |
+
+## Regime adjustments
+
+| Regime | Adjustment |
+|---|---|
+| Green / Blue | None |
+| Orange | None |
+| Red | YOLO downgrades one level; shorts upgrade one level |
+| Danger | All downgrade one level; shorts upgrade one level |
+
+## Hard override
+
+**A triggered kill condition forces EXIT regardless of score.** The whole point of kill conditions is they're decided when conviction is high; they exist for the moments when conviction wavers. Do not weaken kill conditions retroactively. (See [`docs/PRINCIPLES.md` Principle 2](../../../docs/PRINCIPLES.md#2-thesis-first-always).)

--- a/External/clarion-thesis-monitor/scripts/monitor.py
+++ b/External/clarion-thesis-monitor/scripts/monitor.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""Clarion thesis-monitor — health-check every active thesis.
+
+Reads ~/clarion/theses/ active theses, refreshes prices, recomputes the
+directly-derivable health components (Valuation Safety, Catalyst Proximity,
+Risk Environment), checks kill condition statuses, aggregates to an Overall
+score, recommends an action, and writes the result back to each thesis file.
+
+LLM-driven components (Business Health, Insider Alignment, Thesis Integrity)
+are carried forward from the previous run in v1. v2 will integrate /zo/ask
+for those.
+
+Usage:
+    python monitor.py                       # all active theses, full mode
+    python monitor.py --quick               # kill checks + Risk Env only
+    python monitor.py --ticker NVDA         # single thesis
+    python monitor.py --no-write            # preview, don't update files
+    python monitor.py --ticker NVDA --current-price 142.50
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+from ai_buffett_zo.data import EquityStore
+from ai_buffett_zo.regime import RegimeSnapshot, snapshot
+from ai_buffett_zo.theses import (
+    DEFAULT_THESES_ROOT,
+    HealthComponent,
+    HealthSnapshot,
+    HistoryEntry,
+    ThesisMetadata,
+    append_history_entry,
+    evaluate,
+    list_theses,
+    parse_health_components,
+    parse_kill_conditions,
+    parse_metadata_block,
+    parse_thesis_metadata,
+    score_catalyst_proximity,
+    score_risk_environment,
+    score_valuation_safety,
+    update_health_table,
+    update_kill_conditions_last_checked,
+    update_metadata_block,
+)
+from ai_buffett_zo.voice import footer, header, md_table
+
+
+def theses_root() -> Path:
+    return Path(os.environ.get("CLARION_THESES_ROOT") or DEFAULT_THESES_ROOT)
+
+
+# ---- Per-thesis processing -------------------------------------------------
+
+
+def _resolve_regime() -> RegimeSnapshot | None:
+    try:
+        store = EquityStore()
+        spy = store.history("SPY", max_age=timedelta(hours=24))
+        tlt = store.history("TLT", max_age=timedelta(hours=24))
+        rsp = store.history("RSP", max_age=timedelta(hours=24))
+    except Exception:  # noqa: BLE001
+        return None
+    if not spy or not tlt or not rsp:
+        return None
+    try:
+        return snapshot(spy, tlt, rsp)
+    except ValueError:
+        return None
+
+
+def _current_price(ticker: str, *, override: float | None) -> float | None:
+    if override is not None:
+        return override
+    try:
+        store = EquityStore()
+        bars = store.history(ticker, max_age=timedelta(hours=24))
+    except Exception:  # noqa: BLE001
+        return None
+    return bars[-1].close if bars else None
+
+
+def _recompute_components(
+    *,
+    components: list[HealthComponent],
+    metadata: ThesisMetadata,
+    raw_metadata: dict[str, str],
+    regime_color: str,
+    current_price: float | None,
+    quick: bool,
+    asof: date,
+) -> tuple[list[HealthComponent], list[str]]:
+    """Recompute the directly-derivable components, carry forward the rest.
+
+    Returns (new_components, notes_about_what_changed).
+    """
+    by_name = {c.name: c for c in components}
+    notes: list[str] = []
+
+    # Risk Environment is always re-scored — cheap, deterministic.
+    if "Risk Environment" in by_name:
+        old = by_name["Risk Environment"]
+        new_score = score_risk_environment(metadata.bucket, regime_color)
+        if old.score != new_score:
+            notes.append(f"Risk Environment {old.score}→{new_score} ({regime_color}/{metadata.bucket})")
+        by_name["Risk Environment"] = HealthComponent(
+            name="Risk Environment",
+            weight=old.weight,
+            score=new_score,
+            notes=f"{regime_color.upper()} regime, {metadata.bucket} bucket",
+        )
+
+    if quick:
+        return list(by_name.values()), notes
+
+    # Valuation Safety — only if base_case_fair_value is in metadata AND we have a price
+    base_case = _opt_float(raw_metadata.get("base_case_fair_value"))
+    if "Valuation Safety" in by_name and base_case is not None and current_price is not None:
+        margin_pct = ((base_case - current_price) / base_case) * 100
+        new_score = score_valuation_safety(margin_pct)
+        old = by_name["Valuation Safety"]
+        if old.score != new_score:
+            notes.append(
+                f"Valuation Safety {old.score}→{new_score} "
+                f"(margin {margin_pct:+.1f}% at ${current_price:.2f} vs ${base_case:.2f})"
+            )
+        by_name["Valuation Safety"] = HealthComponent(
+            name="Valuation Safety",
+            weight=old.weight,
+            score=new_score,
+            notes=f"margin {margin_pct:+.1f}% at ${current_price:.2f} vs base ${base_case:.2f}",
+        )
+
+    # Catalyst Proximity — only if catalyst_date is in metadata
+    catalyst_date_raw = raw_metadata.get("catalyst_date")
+    catalyst_date = _opt_date(catalyst_date_raw)
+    if "Catalyst Proximity" in by_name and catalyst_date is not None:
+        days = (catalyst_date - asof).days
+        new_score = score_catalyst_proximity(days)
+        old = by_name["Catalyst Proximity"]
+        if old.score != new_score:
+            notes.append(
+                f"Catalyst Proximity {old.score}→{new_score} (catalyst in {days}d)"
+            )
+        by_name["Catalyst Proximity"] = HealthComponent(
+            name="Catalyst Proximity",
+            weight=old.weight,
+            score=new_score,
+            notes=f"catalyst {catalyst_date.isoformat()} ({days}d away)",
+        )
+
+    return list(by_name.values()), notes
+
+
+def _process_thesis(
+    *,
+    path: Path,
+    regime: RegimeSnapshot,
+    quick: bool,
+    write: bool,
+    current_price_override: float | None,
+    asof: date,
+) -> tuple[ThesisMetadata, HealthSnapshot, list[str]] | None:
+    """Process one thesis. Returns (metadata, snapshot, change_notes) or None on parse fail."""
+    content = path.read_text()
+    metadata = parse_thesis_metadata(content)
+    if metadata is None or metadata.status != "active":
+        return None
+    raw_meta = parse_metadata_block(content)
+    components, _ = parse_health_components(content)
+    if not components:
+        return None
+    kill_conditions = parse_kill_conditions(content)
+
+    current_price = _current_price(metadata.ticker, override=current_price_override)
+
+    new_components, notes = _recompute_components(
+        components=components,
+        metadata=metadata,
+        raw_metadata=raw_meta,
+        regime_color=regime.color,
+        current_price=current_price,
+        quick=quick,
+        asof=asof,
+    )
+
+    snap = evaluate(
+        components=new_components,
+        bucket=metadata.bucket,
+        regime_color=regime.color,
+        kill_conditions=kill_conditions,
+    )
+
+    if write:
+        _write_back(
+            path=path,
+            content=content,
+            new_components=new_components,
+            snap=snap,
+            metadata=metadata,
+            asof=asof,
+        )
+
+    return metadata, snap, notes
+
+
+def _write_back(
+    *,
+    path: Path,
+    content: str,
+    new_components: list[HealthComponent],
+    snap: HealthSnapshot,
+    metadata: ThesisMetadata,
+    asof: date,
+) -> None:
+    new = update_health_table(content, new_components, snap.overall)
+    new = update_metadata_block(
+        new,
+        {
+            "last_reviewed": asof,
+            "health_score": snap.overall,
+        },
+    )
+    new = update_kill_conditions_last_checked(new, asof)
+
+    # Append history entry only when the action changed vs the previous review.
+    prior_action = _action_from_score(metadata.health_score)
+    if prior_action != snap.action:
+        new = append_history_entry(
+            new,
+            HistoryEntry(
+                date=asof,
+                event="ACTION CHANGED",
+                detail=f"{prior_action or 'INITIAL'} → {snap.action} ({snap.rationale})",
+            ),
+        )
+
+    path.write_text(new)
+
+
+def _action_from_score(score: int | None) -> str | None:
+    if score is None:
+        return None
+    from ai_buffett_zo.theses import action_for_score
+    return action_for_score(score)
+
+
+# ---- Dashboard rendering ---------------------------------------------------
+
+
+def _render_dashboard(
+    rows: list[tuple[ThesisMetadata, HealthSnapshot, list[str]]],
+    regime: RegimeSnapshot,
+    *,
+    quick: bool,
+    write: bool,
+) -> None:
+    title = "Thesis Health Dashboard" if not quick else "Thesis Quick Check"
+    print(header(f"{title} — {date.today().isoformat()}"))
+    print()
+    print(
+        f"**Regime:** {regime.color.upper()} · "
+        f"**Active theses:** {len(rows)} · "
+        f"**Mode:** {'quick' if quick else 'full'}{'' if write else ' (read-only)'}"
+    )
+    print()
+
+    # Action items first
+    action_items = [
+        (m, s) for m, s, _ in rows if s.action in ("EXIT", "REDUCE") or s.kill_triggered
+    ]
+    if action_items:
+        print("## Action Items")
+        print()
+        for m, s in action_items:
+            tag = " (KILL)" if s.kill_triggered else ""
+            print(f"- **{m.ticker}** → **{s.action}**{tag} — {s.rationale}")
+            for kr in s.kill_reasons:
+                print(f"  - kill: {kr}")
+        print()
+
+    # Per-thesis summary
+    print("## Per-Thesis Summary")
+    print()
+    table_rows = []
+    for m, s, _ in rows:
+        kill_flag = "⚠" if s.kill_triggered else ""
+        table_rows.append(
+            [
+                m.ticker,
+                m.bucket,
+                f"{s.overall}/100",
+                s.action,
+                kill_flag,
+                _lowest_component(s),
+            ]
+        )
+    print(
+        md_table(
+            ["Ticker", "Bucket", "Overall", "Action", "Kill", "Weakest"],
+            table_rows,
+        )
+    )
+
+    # Per-thesis component detail
+    print()
+    print("## Component Detail")
+    for m, s, notes in rows:
+        print()
+        print(f"### {m.ticker} — {s.overall}/100 → {s.action}")
+        print()
+        print(
+            md_table(
+                ["Component", "Weight", "Score", "Notes"],
+                [[c.name, f"{c.weight}%", c.score, c.notes] for c in s.components],
+            )
+        )
+        if notes:
+            print()
+            print("_changes this run:_")
+            for n in notes:
+                print(f"- {n}")
+
+    print()
+    print(
+        footer(
+            source_lines=[
+                "Regime: clarion-regime-check",
+                "Prices: yfinance via EquityStore",
+                "Framework: docs/ALLOCATION-POLICY.md, docs/PRINCIPLES.md",
+            ]
+        )
+    )
+
+
+def _lowest_component(snap: HealthSnapshot) -> str:
+    if not snap.components:
+        return ""
+    lowest = min(snap.components, key=lambda c: c.score)
+    return f"{lowest.name} ({lowest.score})"
+
+
+# ---- Main ------------------------------------------------------------------
+
+
+def run(args: argparse.Namespace) -> int:
+    troot = theses_root()
+    paths = list_theses(troot)
+    if args.ticker:
+        paths = [p for p in paths if p.stem.upper() == args.ticker.upper()]
+    if not paths:
+        print(
+            "THESIS_MONITOR_ERROR: no theses to monitor. "
+            "Check ~/clarion/theses/ or run clarion-thesis-write first."
+        )
+        return 1
+
+    regime = _resolve_regime()
+    if regime is None:
+        print(
+            "THESIS_MONITOR_ERROR: regime unavailable. "
+            "Run clarion-regime-check first to seed the SPY/TLT/RSP cache."
+        )
+        return 1
+
+    asof = date.today()
+    rows: list[tuple[ThesisMetadata, HealthSnapshot, list[str]]] = []
+    malformed: list[Path] = []
+    for path in paths:
+        try:
+            result = _process_thesis(
+                path=path,
+                regime=regime,
+                quick=args.quick,
+                write=not args.no_write,
+                current_price_override=args.current_price,
+                asof=asof,
+            )
+        except Exception as e:  # noqa: BLE001
+            print(
+                f"_warning: failed to process {path.name}: {type(e).__name__}: {e}_"
+            )
+            malformed.append(path)
+            continue
+        if result is None:
+            continue
+        rows.append(result)
+
+    if not rows:
+        print(
+            "THESIS_MONITOR_ERROR: no active theses to monitor "
+            "(parsed but all status != active, or all malformed)."
+        )
+        if malformed:
+            for p in malformed:
+                print(f"  malformed: {p.name}")
+        return 1
+
+    _render_dashboard(rows, regime, quick=args.quick, write=not args.no_write)
+
+    if malformed:
+        print()
+        print("## Malformed Theses (skipped)")
+        for p in malformed:
+            print(f"- {p.name}")
+
+    return 0
+
+
+def _opt_float(s: object) -> float | None:
+    if s is None or s == "":
+        return None
+    try:
+        return float(s)
+    except (TypeError, ValueError):
+        return None
+
+
+def _opt_date(s: object) -> date | None:
+    if s is None or s == "":
+        return None
+    if isinstance(s, date):
+        return s
+    try:
+        return date.fromisoformat(str(s))
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="clarion-thesis-monitor")
+    ap.add_argument(
+        "--ticker",
+        default=None,
+        help="Process only this ticker (default: all active theses).",
+    )
+    ap.add_argument(
+        "--quick",
+        action="store_true",
+        help="Quick mode: kill checks + Risk Environment recompute only. Skip full re-scoring.",
+    )
+    ap.add_argument(
+        "--no-write",
+        action="store_true",
+        help="Preview the dashboard without writing back to thesis files.",
+    )
+    ap.add_argument(
+        "--current-price",
+        type=float,
+        default=None,
+        help="Override current price (single-thesis mode). For Valuation Safety re-scoring.",
+    )
+    args = ap.parse_args()
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/External/clarion-thesis-monitor/scripts/monitor.py
+++ b/External/clarion-thesis-monitor/scripts/monitor.py
@@ -394,7 +394,8 @@ def run(args: argparse.Namespace) -> int:
     if not rows:
         print(
             "THESIS_MONITOR_ERROR: no active theses to monitor "
-            "(parsed but all status != active, or all malformed)."
+            "(parsed but all status != active — drafts, watchlist, closed, "
+            "and killed theses are skipped — or all malformed)."
         )
         if malformed:
             for p in malformed:

--- a/External/clarion-thesis-write/SKILL.md
+++ b/External/clarion-thesis-write/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: clarion-thesis-write
+description: Scaffold a new thesis document for a ticker in the canonical Clarion thesis format. Pre-fills the YAML metadata block, opens the History with an OPENED entry, and (when filings are indexed) seeds the "Why I Believe It" evidence section with draft citations from the Buffett-lens search. The user fills in the actual prose. Outputs a markdown file at ~/clarion/theses/{TICKER}.md. Use when the user says "write a thesis on <TICKER>", "scaffold a thesis for <TICKER>", "draft a thesis for <TICKER>", or after clarion-single-stock-eval returns an Add verdict and the user wants to formalize the position.
+metadata:
+  author: cis.zo.computer
+  category: External
+  display-name: Clarion Thesis Write
+  homepage: https://github.com/jingerzz/clarion-intelligence-system
+---
+
+# Clarion thesis write
+
+Scaffolds a new thesis in the canonical [`docs/`](../../docs)-defined format. The script generates the structure with metadata + draft citations; the user (with your help) fills in the prose.
+
+## When to use
+
+User says any of:
+- "Write a thesis on NVDA."
+- "Scaffold a thesis for AAPL."
+- "Draft the thesis for KO."
+- After `clarion-single-stock-eval` returns an **Add** verdict.
+
+## Decision tree
+
+1. **Confirm the inputs.** Ask the user (or default) for:
+   - **Ticker** (required)
+   - **Bucket**: `value` (default), `systematic`, `short`, or `yolo` — see [`docs/ALLOCATION-POLICY.md`](../../docs/ALLOCATION-POLICY.md) for what each means
+   - **Opened**: today's date by default, or a backfilled date if the user is documenting an existing position
+
+2. **Verify the ticker has indexed SEC filings.** If not, suggest running `clarion-sec-research index <TICKER>` first and waiting 1–5 minutes — without indexed filings, the evidence section won't be seeded with citations and the user will have to gather them manually.
+
+3. **Run `write.py`** with the ticker and bucket:
+
+   ```bash
+   python /home/workspace/clarion-intelligence-system/skills/clarion-thesis-write/scripts/write.py NVDA --bucket value
+   ```
+
+   The script will:
+   - Refuse to overwrite an existing thesis file unless `--force` is passed
+   - Pull fundamentals from yfinance for the metadata block
+   - Pull Buffett-lens snippets from indexed filings for the evidence section
+   - Render the canonical template to `~/clarion/theses/{TICKER}.md`
+   - Print the path written + a short list of "TODO" sections the user must fill in
+
+4. **Walk the user through the TODO sections in order.** The most important to get right early:
+   - **What I Believe** — the core insight, 1-3 paragraphs
+   - **Why I Believe It** — numbered evidence, each citing a filing or data source
+   - **What's It Worth** — bear/base/bull scenarios with rough numbers
+   - **Why Now** — catalyst or patience rationale
+   - **Kill Conditions** — specific, measurable, falsifiable
+
+   Reference [`docs/PRINCIPLES.md` Principle 2 (Thesis-First)](../../docs/PRINCIPLES.md#2-thesis-first-always) and [`docs/DESIGN-LANGUAGE.md` Anti-patterns](../../docs/DESIGN-LANGUAGE.md#anti-patterns-what-the-system-never-does) when guiding the user.
+
+5. **After the prose is filled in,** suggest running `clarion-thesis-monitor --ticker <TICKER>` to compute the initial health score.
+
+## How to run
+
+```bash
+WRITE=python /home/workspace/clarion-intelligence-system/skills/clarion-thesis-write/scripts/write.py
+
+$WRITE NVDA                          # value bucket, opened today
+$WRITE NVDA --bucket yolo            # YOLO bucket
+$WRITE NVDA --opened 2024-08-01      # backfill an existing position
+$WRITE NVDA --force                  # overwrite an existing file
+$WRITE NVDA --no-lens                # skip the secrag lens pre-population
+```
+
+## Voice
+
+After scaffolding, switch into co-author mode. Help the user write specific, measurable, sourced prose. Cite every claim drawn from filings (the script's seeded citations are canonical). Show the math in the valuation table. Use the [Buffett Question Bank](../../docs/DESIGN-LANGUAGE.md#the-buffett-question-bank) to interrogate weak sections.
+
+The thesis should be **conversational and direct** — the style described in [`docs/DESIGN-LANGUAGE.md`](../../docs/DESIGN-LANGUAGE.md). Vague claims ("strong moat," "good management") are flags to push back on.
+
+## On error
+
+- **`THESIS_WRITE_ERROR: file already exists`** — pass `--force` to overwrite, or pick a different filename.
+- **`THESIS_WRITE_ERROR: failed to fetch fundamentals`** — yfinance hiccup. Retry, or pass `--no-fundamentals` to skip the snapshot pre-fill.
+- **`THESIS_WRITE_ERROR: ticker not indexed`** — only when `--require-indexed` is set. Run `clarion-sec-research index <TICKER>` first.

--- a/External/clarion-thesis-write/SKILL.md
+++ b/External/clarion-thesis-write/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clarion-thesis-write
-description: Scaffold a new thesis document for a ticker in the canonical Clarion thesis format. Pre-fills the YAML metadata block, opens the History with an OPENED entry, and (when filings are indexed) seeds the "Why I Believe It" evidence section with draft citations from the Buffett-lens search. The user fills in the actual prose. Outputs a markdown file at ~/clarion/theses/{TICKER}.md. Use when the user says "write a thesis on <TICKER>", "scaffold a thesis for <TICKER>", "draft a thesis for <TICKER>", or after clarion-single-stock-eval returns an Add verdict and the user wants to formalize the position.
+description: Scaffold a new thesis document for a ticker in the canonical Clarion thesis format. Pre-fills the YAML metadata block, opens the History with an OPENED entry, and (when filings are indexed) seeds the "Why I Believe It" evidence section with draft citations from the Buffett-lens search. The user fills in the actual prose. Outputs a markdown file at ~/clarion/theses/{TICKER}.md. Use when the user says "write a thesis on <TICKER>", "scaffold a thesis for <TICKER>", "draft a thesis for <TICKER>", or after clarion-single-stock-eval returns an Add verdict and the user wants to formalize the position. Requires clarion-setup to have been run.
 metadata:
   author: cis.zo.computer
   category: External

--- a/External/clarion-thesis-write/SKILL.md
+++ b/External/clarion-thesis-write/SKILL.md
@@ -51,7 +51,9 @@ User says any of:
 
    Reference [`docs/PRINCIPLES.md` Principle 2 (Thesis-First)](../../docs/PRINCIPLES.md#2-thesis-first-always) and [`docs/DESIGN-LANGUAGE.md` Anti-patterns](../../docs/DESIGN-LANGUAGE.md#anti-patterns-what-the-system-never-does) when guiding the user.
 
-5. **After the prose is filled in,** suggest running `clarion-thesis-monitor --ticker <TICKER>` to compute the initial health score.
+5. **Promote `status: draft` → `status: active`.** Scaffolded theses ship at `status: draft` so `clarion-thesis-monitor` skips them while they're still being written. Once the prose is in (especially Kill Conditions, which are load-bearing), update the metadata block: `status: draft` → `status: active`. Until that flip, the thesis is invisible to the monitor.
+
+6. **After promoting to active,** suggest running `clarion-thesis-monitor --ticker <TICKER>` to compute the initial health score.
 
 ## How to run
 

--- a/External/clarion-thesis-write/references/thesis-template-guide.md
+++ b/External/clarion-thesis-write/references/thesis-template-guide.md
@@ -1,0 +1,43 @@
+# Thesis template guide
+
+Source: the canonical thesis structure is fixed by [`lib/ai_buffett_zo/theses/`](../../../lib/ai_buffett_zo/theses) and [`docs/PRINCIPLES.md` Principle 2](../../../docs/PRINCIPLES.md#2-thesis-first-always). This file is a quick-reference for filling in the scaffold the script produces.
+
+## Sections in order
+
+| # | Section | What goes here |
+|---|---|---|
+| 1 | Metadata (YAML block) | Pre-filled by the script. The user adjusts `cost_basis`, `shares`, `portfolio_weight` after position is taken. `health_score` is set by `clarion-thesis-monitor`. |
+| 2 | Core Thesis → What I Believe | 1-3 paragraphs. The core insight the market is missing or underweighting. **Specific.** "This is cheap" is not a thesis. |
+| 3 | Core Thesis → Why I Believe It | Numbered evidence. Each item cites a filing, data point, or verified external source. The script seeds candidates from the indexed-filing lens. |
+| 4 | Core Thesis → What's It Worth | Bear/Base/Bull scenarios. Show the math. Use ranges, not false-precision point estimates. |
+| 5 | Core Thesis → Why Now | The catalyst, or the patience rationale. Be explicit. |
+| 6 | Kill Conditions | Specific, measurable, falsifiable. Each row: condition + how to monitor + last checked. |
+| 7 | Health Scoring | Six components, weights summing to 100. The Overall row equals the metadata's `health_score`. Set on first monitor run. |
+| 8 | Position Management | Sizing rules, entry/exit levels, options strategy if any. |
+| 9 | Monitoring Schedule | Default cadence; adjust if the position warrants tighter monitoring. |
+| 10 | History | Append-only event log. The script seeds with an OPENED entry. |
+| 11 | Notes | Free-form observations, dated. |
+
+## Anti-patterns to avoid
+
+From [`docs/DESIGN-LANGUAGE.md`](../../../docs/DESIGN-LANGUAGE.md#anti-patterns-what-the-system-never-does):
+
+- **Never use relative language without an anchor.** "Cheap" → "trades at 12x owner earnings, vs 18x 10-year median."
+- **Never bury the conclusion.** The thesis appears in the first paragraph of "What I Believe."
+- **Never ignore the base rate.** Before "this time is different," present what usually happens in this situation.
+- **Never conflate precision with accuracy.** A DCF that says fair value is $147.32 is precise but not accurate. Use ranges.
+- **Never recommend without sizing.** A great idea at the wrong size is a bad idea.
+
+## Kill condition examples
+
+Strong (specific, measurable, falsifiable):
+- `Operating margin falls below 25% in any quarter`
+- `Top 3 customers exceed 50% of revenue`
+- `CEO departure (8-K filing)`
+- `Long-term debt / EBITDA exceeds 3.0`
+- `Stock above 3x tangible book value` (for shorts)
+
+Weak (avoid):
+- `Business gets worse` — not measurable
+- `Sentiment turns bearish` — not falsifiable; sentiment is always mixed
+- `If I lose conviction` — circular

--- a/External/clarion-thesis-write/scripts/write.py
+++ b/External/clarion-thesis-write/scripts/write.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Clarion thesis-write — scaffold a new thesis for a ticker.
+
+Generates a markdown thesis at ~/clarion/theses/{TICKER}.md following the
+canonical Clarion format. Pre-fills the YAML metadata block, seeds the
+History with an OPENED entry, and (when secrag has indexed filings) seeds
+the "Why I Believe It" section with draft citations from the Buffett lens.
+
+The script does not write the thesis prose — that's the human's job. The
+SKILL.md instructs Zo to walk the user through the TODO sections after
+the file is generated.
+
+Usage:
+    python write.py NVDA
+    python write.py NVDA --bucket yolo
+    python write.py NVDA --opened 2024-08-01
+    python write.py NVDA --force
+    python write.py NVDA --no-lens         # skip lens pre-population
+    python write.py NVDA --no-fundamentals # skip yfinance pre-population
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import date
+from pathlib import Path
+
+from ai_buffett_zo.evaluation import (
+    Fundamentals,
+    LensView,
+    fetch_fundamentals,
+    view as lens_view,
+)
+from ai_buffett_zo.secrag import DEFAULT_SEC_ROOT, list_indexed
+from ai_buffett_zo.theses import (
+    DEFAULT_HEALTH_WEIGHTS,
+    DEFAULT_THESES_ROOT,
+    HEALTH_COMPONENT_NAMES,
+    Bucket,
+    thesis_path,
+)
+
+
+def theses_root() -> Path:
+    return Path(os.environ.get("CLARION_THESES_ROOT") or DEFAULT_THESES_ROOT)
+
+
+def sec_root() -> Path:
+    return Path(os.environ.get("CLARION_SEC_ROOT") or DEFAULT_SEC_ROOT)
+
+
+# ---- Template rendering ----------------------------------------------------
+
+
+_TEMPLATE = """\
+# Thesis: {ticker} — [TODO one-line thesis summary]
+
+---
+
+## Metadata
+
+```yaml
+ticker: {ticker}
+company: {company}
+bucket: {bucket}
+status: active
+opened: {opened}
+last_reviewed:
+health_score:  # Set by clarion-thesis-monitor on first run
+cost_basis:
+shares: 0
+portfolio_weight:
+```
+
+---
+
+## Core Thesis
+
+### What I Believe
+
+[TODO 1-3 paragraphs stating the core investment claim. What is the insight \
+the market is missing or underweighting? Be specific — "this is cheap" is not \
+a thesis.]
+
+### Why I Believe It (Evidence)
+
+{evidence_section}
+
+### What's It Worth (Valuation)
+
+**Primary method**: [TODO DCF / Multiples / Asset-based / Sum-of-parts]
+
+| Scenario | Assumptions | Fair Value | Upside/Downside |
+|----------|------------|------------|-----------------|
+| Bear | [TODO] | $[TODO] | [TODO]% |
+| Base | [TODO] | $[TODO] | [TODO]% |
+| Bull | [TODO] | $[TODO] | [TODO]% |
+
+**Current price**: ${current_price} as of {asof}
+**Margin of safety**: [TODO]% (base case fair value vs current price)
+
+### Why Now (Catalyst / Patience Rationale)
+
+[TODO What causes the market to re-rate this? Or if no near-term catalyst, \
+why is patience the right approach?]
+
+---
+
+## Kill Conditions
+
+| # | Kill Condition | How to Monitor | Last Checked |
+|---|---------------|----------------|--------------|
+| 1 | [TODO Specific, measurable condition] | [TODO MCP tool or data source] | |
+| 2 | [TODO Specific, measurable condition] | [TODO MCP tool or data source] | |
+| 3 | [TODO Specific, measurable condition] | [TODO MCP tool or data source] | |
+
+**Hard rule**: Kill conditions are written when the thesis is fresh and \
+conviction is high. They exist precisely for the moments when conviction \
+wavers and you need an objective framework. Do not weaken kill conditions \
+retroactively.
+
+---
+
+## Health Scoring
+
+| Component | Weight | Current Score | Notes |
+|-----------|--------|---------------|-------|
+{health_rows}
+| **Overall** | **100%** | **0** | |
+
+### Score → Action Mapping
+
+| Score Range | Action | Description |
+|-------------|--------|-------------|
+| 0-39 | **EXIT** | Thesis is broken. Close position. |
+| 40-54 | **REDUCE** | Thesis weakening. Trim to minimum. |
+| 55-74 | **HOLD** | Thesis intact. Maintain position. |
+| 75-100 | **ADD** | Thesis strong. Add on dips to fair value. |
+
+---
+
+## Position Management
+
+### Sizing Rules
+- **Max position size**: [TODO % of portfolio per ALLOCATION-POLICY.md limits]
+- **Current size**: [TODO % of portfolio]
+- **Target size**: [TODO % of portfolio]
+
+### Entry/Exit Levels
+- **Add zone**: Below $[TODO]
+- **Full position at**: $[TODO]
+- **Trim zone**: Above $[TODO]
+- **Exit at**: $[TODO]
+- **Stop loss**: [TODO $XX or N/A if thesis-based exit only]
+
+### Options Strategy (if applicable)
+
+[TODO Describe any options overlay — put selling, covered calls, LEAPS, \
+spreads. Include strike selection criteria, DTE targets, position limits.]
+
+---
+
+## Monitoring Schedule
+
+| Check | Frequency | Tool/Source | Last Run |
+|-------|-----------|-------------|----------|
+| Price vs levels | Daily | yfinance via EquityStore | |
+| Kill conditions | Weekly | varies per condition | |
+| Filing changes | On filing | clarion-sec-research | |
+| Insider activity | Weekly | WebSearch (Form 4) | |
+| Health score update | Monthly | clarion-thesis-monitor | |
+| Thesis review | Quarterly | Re-read thesis, update evidence | |
+
+---
+
+## History
+
+| Date | Event | Detail |
+|------|-------|--------|
+| {opened} | OPENED | [TODO Initial thesis written. Entry price $XX.] |
+
+---
+
+## Notes
+
+[TODO Free-form space for observations, pattern recognition, or context that \
+doesn't fit the structure above. Date each entry.]
+"""
+
+
+def _health_rows() -> str:
+    """Render the health scoring table rows with default weights and zero scores."""
+    rows = []
+    for name in HEALTH_COMPONENT_NAMES:
+        weight = DEFAULT_HEALTH_WEIGHTS[name]
+        rows.append(f"| {name} | {weight}% | 0 | |")
+    return "\n".join(rows)
+
+
+def _evidence_section(lens: list[LensView] | None) -> str:
+    """Compose the 'Why I Believe It' draft from lens hits, or a TODO if none."""
+    if not lens:
+        return (
+            "[TODO Numbered list of specific evidence supporting the thesis. "
+            "Each item should reference a data source — SEC filing, MCP tool "
+            "output, or verified external data.]\n\n"
+            "1. [TODO Evidence point] — Source: [filing doc_id, tool output, or URL]\n"
+            "2. [TODO Evidence point] — Source: [...]\n"
+            "3. [TODO Evidence point] — Source: [...]"
+        )
+
+    lines = [
+        "*Draft citations from the Buffett-lens search. Replace each with a written claim "
+        "supported by the citation; remove any that don't matter for this thesis.*",
+        "",
+    ]
+    n = 1
+    for lv in lens:
+        if not lv.hits:
+            continue
+        lines.append(f"**{lv.title} (DRAFT)**")
+        for h in lv.hits[:2]:  # cap 2 per dimension to keep section manageable
+            lines.append(f"{n}. [TODO claim]. Source: {h.citation}")
+            lines.append(f"   > _{h.snippet[:240]}_")
+            n += 1
+        lines.append("")
+    if n == 1:
+        # No hits anywhere
+        return _evidence_section(None)
+    return "\n".join(lines).rstrip()
+
+
+def render(
+    *,
+    ticker: str,
+    company: str,
+    bucket: Bucket,
+    opened: date,
+    current_price: str,
+    asof: str,
+    lens: list[LensView] | None,
+) -> str:
+    return _TEMPLATE.format(
+        ticker=ticker,
+        company=company or "[TODO Full Company Name]",
+        bucket=bucket,
+        opened=opened.isoformat(),
+        current_price=current_price,
+        asof=asof,
+        evidence_section=_evidence_section(lens),
+        health_rows=_health_rows(),
+    )
+
+
+# ---- Orchestration ---------------------------------------------------------
+
+
+def run(args: argparse.Namespace) -> int:
+    ticker = args.ticker.upper()
+    troot = theses_root()
+    troot.mkdir(parents=True, exist_ok=True)
+    out = thesis_path(troot, ticker)
+
+    if out.exists() and not args.force:
+        print(
+            f"THESIS_WRITE_ERROR: file already exists at {out}. "
+            f"Pass --force to overwrite, or delete the file first."
+        )
+        return 1
+
+    # Fundamentals — best-effort; non-fatal
+    fundamentals: Fundamentals | None = None
+    if not args.no_fundamentals:
+        try:
+            fundamentals = fetch_fundamentals(ticker)
+        except Exception as e:  # noqa: BLE001
+            print(
+                f"_warning: fundamentals fetch failed ({type(e).__name__}: {e}). "
+                f"Proceeding without yfinance pre-population._"
+            )
+
+    company = (fundamentals.company if fundamentals else "") or ""
+    if fundamentals and fundamentals.last_close is not None:
+        current_price = f"{fundamentals.last_close:.2f}"
+    else:
+        current_price = "[TODO]"
+    asof = date.today().isoformat()
+
+    # Lens — best-effort; non-fatal
+    lens: list[LensView] | None = None
+    if not args.no_lens:
+        sroot = sec_root()
+        indexed = [m for m in list_indexed(sroot) if m.ticker == ticker]
+        if not indexed:
+            if args.require_indexed:
+                print(
+                    f"THESIS_WRITE_ERROR: ticker not indexed. "
+                    f"Run `clarion-sec-research index {ticker}` first."
+                )
+                return 1
+            print(
+                f"_note: no indexed filings for {ticker}; evidence section "
+                f"will be a TODO. Consider `clarion-sec-research index {ticker}` "
+                f"and re-running with --force._"
+            )
+        else:
+            try:
+                lens = lens_view(ticker, sec_root=sroot)
+            except Exception as e:  # noqa: BLE001
+                print(
+                    f"_warning: lens search failed ({type(e).__name__}: {e}). "
+                    f"Proceeding without seeded citations._"
+                )
+
+    content = render(
+        ticker=ticker,
+        company=company,
+        bucket=args.bucket,
+        opened=args.opened,
+        current_price=current_price,
+        asof=asof,
+        lens=lens,
+    )
+    out.write_text(content)
+
+    print(f"Thesis scaffolded at: {out}")
+    print()
+    print("**Next steps** — fill in the [TODO] sections, in this order:")
+    print()
+    print("1. Title line — replace `[TODO one-line thesis summary]` with the core insight")
+    print("2. **What I Believe** — 1-3 paragraphs of the core investment claim")
+    print("3. **Why I Believe It** — replace the DRAFT/TODO citations with written claims")
+    print("4. **What's It Worth** — fill in bear/base/bull scenarios with numbers")
+    print("5. **Why Now** — catalyst or patience rationale")
+    print("6. **Kill Conditions** — at least 3, specific and measurable")
+    print("7. Update **Metadata**: `cost_basis`, `shares`, `portfolio_weight` after entry")
+    print()
+    print(
+        f"After the prose is in, run: `clarion-thesis-monitor --ticker {ticker}` "
+        f"to compute the initial health score."
+    )
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="clarion-thesis-write")
+    ap.add_argument("ticker", type=str.upper)
+    ap.add_argument(
+        "--bucket",
+        choices=["value", "systematic", "short", "yolo"],
+        default="value",
+        help="Strategy bucket per docs/ALLOCATION-POLICY.md (default: value).",
+    )
+    ap.add_argument(
+        "--opened",
+        type=date.fromisoformat,
+        default=date.today(),
+        help="Date the position was opened (ISO format YYYY-MM-DD; default: today).",
+    )
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing thesis file at the same path.",
+    )
+    ap.add_argument(
+        "--no-lens",
+        action="store_true",
+        help="Skip the secrag Buffett-lens pre-population.",
+    )
+    ap.add_argument(
+        "--no-fundamentals",
+        action="store_true",
+        help="Skip the yfinance fundamentals pre-population.",
+    )
+    ap.add_argument(
+        "--require-indexed",
+        action="store_true",
+        help="Fail if the ticker has no indexed SEC filings. Off by default.",
+    )
+    args = ap.parse_args()
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/External/clarion-thesis-write/scripts/write.py
+++ b/External/clarion-thesis-write/scripts/write.py
@@ -65,7 +65,7 @@ _TEMPLATE = """\
 ticker: {ticker}
 company: {company}
 bucket: {bucket}
-status: active
+status: draft
 opened: {opened}
 last_reviewed:
 health_score:  # Set by clarion-thesis-monitor on first run
@@ -327,6 +327,12 @@ def run(args: argparse.Namespace) -> int:
 
     print(f"Thesis scaffolded at: {out}")
     print()
+    print(
+        "Status is `draft` — `clarion-thesis-monitor` will skip drafts to keep "
+        "the dashboard signal-clean. Promote to `active` (edit the metadata "
+        "block: `status: draft` → `status: active`) once the prose is filled in."
+    )
+    print()
     print("**Next steps** — fill in the [TODO] sections, in this order:")
     print()
     print("1. Title line — replace `[TODO one-line thesis summary]` with the core insight")
@@ -336,10 +342,11 @@ def run(args: argparse.Namespace) -> int:
     print("5. **Why Now** — catalyst or patience rationale")
     print("6. **Kill Conditions** — at least 3, specific and measurable")
     print("7. Update **Metadata**: `cost_basis`, `shares`, `portfolio_weight` after entry")
+    print("8. Promote `status: draft` → `status: active` to enable monitoring")
     print()
     print(
-        f"After the prose is in, run: `clarion-thesis-monitor --ticker {ticker}` "
-        f"to compute the initial health score."
+        f"After the prose is in and status is `active`, run: "
+        f"`clarion-thesis-monitor --ticker {ticker}` to compute the initial health score."
     )
     return 0
 

--- a/External/clarion-value-screener/SKILL.md
+++ b/External/clarion-value-screener/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: clarion-value-screener
+description: Run a value-quality screen and write a watchlist file. The script accepts either a list of tickers (fundamentals fetched from yfinance) or a JSON input file the chat agent prepared from a screener site (multpl.com, finviz, Yardeni, etc.). Computes the 8-factor composite score (P/E, P/FCF, ROE, ROIC, Operating Margin, D/E, Profit Margin, Insider) per docs/ALLOCATION-POLICY.md, applies regime-tightened thresholds, and produces a sector-capped Top-10 watchlist. Saves to ~/clarion/watchlists/sp500-screen-YYYY-MM-DD.md. Use when the user asks "run a value screen", "screen the S&P 500", "screen these tickers <list>", or after market drawdowns / regime changes.
+metadata:
+  author: cis.zo.computer
+  category: External
+  display-name: Clarion Value Screener
+  homepage: https://github.com/jingerzz/clarion-intelligence-system
+---
+
+# Clarion value screener
+
+Implements the two-stage pipeline from [`docs/ALLOCATION-POLICY.md`](../../docs/ALLOCATION-POLICY.md). Stage 1 (cast the net + score + sector cap + watchlist) is the script's job. Stage 2 (filing-level deep dives + thesis starters) is delegated to `clarion-single-stock-eval` per top candidate.
+
+## When to use
+
+User asks any of:
+- "Run a value screen."
+- "Screen the S&P 500 for new candidates."
+- "Screen NVDA, AAPL, ADBE."
+- "What names should I be looking at right now?"
+
+Cadence guidance (from AWB):
+- **Monthly** — full screen
+- **After market drawdowns** — opportunistic
+- **After regime changes** — especially Green→Orange or Orange→Red
+
+## Decision tree
+
+1. **Resolve scope.** If the user named specific tickers, use `--tickers`. Otherwise, the chat agent should prepare a JSON input by:
+   - Running [`clarion-regime-check`](../clarion-regime-check) to confirm regime
+   - Running [`clarion-expected-return-calc`](../clarion-expected-return-calc) to confirm hurdle
+   - Using `WebFetch` on a screener site (multpl.com / Yardeni / finviz) with regime-appropriate filters per [`docs/ALLOCATION-POLICY.md`](../../docs/ALLOCATION-POLICY.md)
+   - Building a JSON file with the resulting candidates (see schema below)
+
+2. **Run the script.**
+
+   ```bash
+   # Tickers list mode (script fetches yfinance fundamentals)
+   python /home/workspace/clarion-intelligence-system/skills/clarion-value-screener/scripts/screen.py \
+       --tickers NVDA,AAPL,ADBE,LULU,AOS
+
+   # JSON input mode (chat agent prepared the candidates)
+   python ... screen.py --input ~/clarion/queue/screen-input.json
+   ```
+
+3. **Read the watchlist file the script wrote.** Path is printed at the end. The file is the structured output; pass it through to the user verbatim for the tables, then walk them through the [TODO] sections (Sniff Test, Passed On, Existing Theses Impact).
+
+4. **Fill the Sniff Test sections** by running `clarion-single-stock-eval` on each top-cap candidate that isn't already covered by an active thesis. Use the eval output to write the sniff-test snapshot per the AWB watchlist examples.
+
+5. **Existing Theses Impact** — list any top candidate that already has a thesis in `~/clarion/theses/`. If so, summarize whether the screen confirms or challenges the existing thesis.
+
+## How to run
+
+```bash
+SCREEN=python /home/workspace/clarion-intelligence-system/skills/clarion-value-screener/scripts/screen.py
+
+# Tickers mode (most common when user names a list)
+$SCREEN --tickers NVDA,AAPL,ADBE,LULU,AOS
+
+# JSON input mode (full S&P 500 screen via WebFetch by chat agent)
+$SCREEN --input ~/clarion/queue/screen-input.json
+
+# Override context
+$SCREEN --tickers NVDA,AAPL --rf-rate-pct 4.45 --sp500-cape 35.2
+
+# Custom universe label and target size
+$SCREEN --tickers NVDA,AAPL,... --universe "Russell 1000" --top-size 15
+```
+
+### JSON input schema
+
+```json
+{
+  "screen_date": "2026-05-07",
+  "context": {
+    "regime_color": "orange",
+    "danger_state": false,
+    "rf_rate_pct": 4.45,
+    "hurdle_rate_pct": 10.45,
+    "sp500_cape": 35.2,
+    "sp500_trailing_pe": 28.4,
+    "implied_return_low_pct": 0.0,
+    "implied_return_high_pct": 3.0,
+    "universe": "S&P 500",
+    "notes": "Mega-cap led rally; verify breadth before sizing."
+  },
+  "candidates": [
+    {
+      "ticker": "NVDA",
+      "company": "NVIDIA Corp",
+      "sector": "Tech",
+      "pe": 35.2,
+      "pfcf": 40.0,
+      "roe": 0.55,
+      "roic": 0.42,
+      "op_margin": 0.62,
+      "profit_margin": 0.55,
+      "de": 0.25,
+      "insider_pct": -0.2,
+      "market_cap": 3000000000000,
+      "price": 140.50
+    }
+  ]
+}
+```
+
+Margin / yield / return fields are decimals (0.20 = 20%). Insider activity is a signed percent (positive = net buying). Any field can be omitted; the composite formula reduces its weight share when data is missing.
+
+## Voice
+
+Lead with the **regime + screening stance** (one line). Then surface the **top 3 by composite** with the most interesting one-line take. Then point at the watchlist file for the full ranked table and detail.
+
+When the script flags a candidate's `contributing_weight` as low (< 60), call it out — that means the score is based on partial data and shouldn't be over-weighted.
+
+## Hard rules
+
+1. **Never fabricate fundamental data.** If the screener site or yfinance doesn't return a metric, leave it None and let the contributing-weight surface the gap.
+2. **Regime adjusts aggressiveness, not quality.** In Red/Danger, deeper discounts required — never lower the quality bar.
+3. **The screener finds candidates, not positions.** The output is a watchlist with thesis starters. The principal reviews and decides what gets a full thesis.
+4. **Document what you passed on.** The "Passed On" section is as valuable as the winners.
+5. **Stage 2 requires filings.** Don't generate a thesis starter without indexed filings — run `clarion-sec-research index <TICKER>` first if needed.
+
+## On error
+
+- **`SCREEN_ERROR: regime unavailable`** — yfinance cache empty for SPY/TLT/RSP. Run `clarion-regime-check` first.
+- **`SCREEN_ERROR: --tickers or --input required`** — supply one of them.
+- **`SCREEN_ERROR: input file not found`** — check the `--input` path.
+- **`_warning: yfinance fetch failed for <TICKER>`** — non-fatal; that ticker's score will be based on partial data. The script continues.

--- a/External/clarion-value-screener/SKILL.md
+++ b/External/clarion-value-screener/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clarion-value-screener
-description: Run a value-quality screen and write a watchlist file. The script accepts either a list of tickers (fundamentals fetched from yfinance) or a JSON input file the chat agent prepared from a screener site (multpl.com, finviz, Yardeni, etc.). Computes the 8-factor composite score (P/E, P/FCF, ROE, ROIC, Operating Margin, D/E, Profit Margin, Insider) per docs/ALLOCATION-POLICY.md, applies regime-tightened thresholds, and produces a sector-capped Top-10 watchlist. Saves to ~/clarion/watchlists/sp500-screen-YYYY-MM-DD.md. Use when the user asks "run a value screen", "screen the S&P 500", "screen these tickers <list>", or after market drawdowns / regime changes.
+description: Run a value-quality screen and write a watchlist file. The script accepts either a list of tickers (fundamentals fetched from yfinance) or a JSON input file the chat agent prepared from a screener site (multpl.com, finviz, Yardeni, etc.). Computes the 8-factor composite score (P/E, P/FCF, ROE, ROIC, Operating Margin, D/E, Profit Margin, Insider) per docs/ALLOCATION-POLICY.md, applies regime-tightened thresholds, and produces a sector-capped Top-10 watchlist. Saves to ~/clarion/watchlists/sp500-screen-YYYY-MM-DD.md. Use when the user asks "run a value screen", "screen the S&P 500", "screen these tickers <list>", or after market drawdowns / regime changes. Requires clarion-setup to have been run.
 metadata:
   author: cis.zo.computer
   category: External

--- a/External/clarion-value-screener/references/screening-criteria.md
+++ b/External/clarion-value-screener/references/screening-criteria.md
@@ -1,0 +1,40 @@
+# Screening criteria — quick reference
+
+Source: [`docs/ALLOCATION-POLICY.md`](../../../docs/ALLOCATION-POLICY.md) and [`lib/ai_buffett_zo/screener/scoring.py`](../../../lib/ai_buffett_zo/screener/scoring.py).
+
+## Regime-adjusted thresholds (binary filter)
+
+| Metric | Green/Blue | Orange | Red/Danger |
+|---|---|---|---|
+| P/E (trailing) | < 25 | < 20 | < 15 |
+| P/FCF | < 20 | < 16 | < 12 |
+| Debt/Equity | < 1.0 | < 0.8 | < 0.5 |
+| ROE (5y avg) | > 12% | > 15% | > 18% |
+| Operating Margin | > 10% | > 12% | > 15% |
+
+A candidate fails the binary filter if **any** field is non-None **and** outside its regime cutoff. Missing fields don't fail (counted as unknown rather than fail).
+
+## 8-factor composite formula
+
+| Factor | Weight | Scoring |
+|---|---|---|
+| P/E | 15% | (25 - P/E) / 25 × 100, clamped [0, 100] |
+| P/FCF | 15% | (20 - P/FCF) / 20 × 100, clamped |
+| ROE | 15% | min(ROE × 100 / 40 × 100, 100) |
+| ROIC | 10% | min(ROIC × 100 / 30 × 100, 100) |
+| Operating Margin | 10% | min(OpM × 100 / 40 × 100, 100) |
+| D/E | 15% | (1 - D/E) × 100, clamped [0, 100] |
+| Profit Margin | 10% | min(margin × 100 / 30 × 100, 100) |
+| Insider Activity | 10% | Cluster buy ≥5%: 90; net buy: 75; |±1%| neutral: 50; net sell: 30; heavy sell ≤-10: 15 |
+
+Weights sum to 100. Missing fields reduce the contributing weight; the score is rescaled.
+
+## Sector cap
+
+- **Default:** max 3 per GICS sector in the top 10.
+- **Relaxation:** if fewer than 4 distinct sectors are represented in the top 20 by raw score, the cap relaxes to 4 per sector. This acknowledges genuinely-concentrated universes (e.g., a screen surfacing 8 P&C insurers).
+- **Displaced names** are listed in the watchlist with the reason ("sector cap: FinSvcs already has 3 representatives").
+
+## Stage 2 (delegated to clarion-single-stock-eval)
+
+For each top-cap candidate worth a deeper look, run `clarion-single-stock-eval --rf-rate-pct X.X TICKER`. That skill applies the Buffett Question Bank against indexed SEC filings and produces the structured input the user then turns into the Sniff Test sections of the watchlist.

--- a/External/clarion-value-screener/scripts/screen.py
+++ b/External/clarion-value-screener/scripts/screen.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Clarion value screener — Stage 1 of the AWB two-stage pipeline.
+
+Computes the 8-factor composite, applies regime-tightened thresholds and
+sector cap, writes a watchlist markdown file. Stage 2 (filing-level deep
+dive + thesis starters) is delegated to clarion-single-stock-eval per
+top candidate.
+
+Two input modes:
+
+  --tickers NVDA,AAPL,ADBE,...
+        Fetch fundamentals for each ticker via yfinance. Sector pulled
+        from yfinance .info. Fewer fields than a screener-site source
+        (no ROIC, no insider %), so the composite uses partial data.
+
+  --input candidates.json
+        Use a chat-agent-prepared JSON file (full schema in SKILL.md).
+        Best for full S&P 500 screens via WebFetch on a screener site.
+
+Usage:
+    python screen.py --tickers NVDA,AAPL,ADBE
+    python screen.py --input ~/clarion/queue/screen-input.json
+    python screen.py --tickers NVDA,AAPL --rf-rate-pct 4.45 --sp500-cape 35.2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+from ai_buffett_zo.data import EquityStore
+from ai_buffett_zo.evaluation import fetch_fundamentals
+from ai_buffett_zo.macro import fetch_3mo_yield
+from ai_buffett_zo.regime import HURDLE_PREMIUM_PCT, RegimeSnapshot, snapshot
+from ai_buffett_zo.screener import (
+    DEFAULT_WATCHLIST_ROOT,
+    Candidate,
+    ScreenContext,
+    apply_sector_cap,
+    render_watchlist,
+    score_and_rank,
+    watchlist_path,
+)
+
+
+def watchlist_root() -> Path:
+    return Path(os.environ.get("CLARION_WATCHLIST_ROOT") or DEFAULT_WATCHLIST_ROOT)
+
+
+# ---- Context resolution ---------------------------------------------------
+
+
+def _resolve_regime() -> RegimeSnapshot | None:
+    try:
+        store = EquityStore()
+        spy = store.history("SPY", max_age=timedelta(hours=24))
+        tlt = store.history("TLT", max_age=timedelta(hours=24))
+        rsp = store.history("RSP", max_age=timedelta(hours=24))
+    except Exception:  # noqa: BLE001
+        return None
+    if not spy or not tlt or not rsp:
+        return None
+    try:
+        return snapshot(spy, tlt, rsp)
+    except ValueError:
+        return None
+
+
+def _resolve_rf(args: argparse.Namespace) -> float | None:
+    if args.rf_rate_pct is not None:
+        return float(args.rf_rate_pct)
+    y = fetch_3mo_yield()
+    return y.rate_pct if y is not None else None
+
+
+def _build_context_from_args(
+    args: argparse.Namespace,
+    *,
+    regime: RegimeSnapshot,
+    rf_rate_pct: float | None,
+) -> ScreenContext:
+    hurdle = (
+        rf_rate_pct + HURDLE_PREMIUM_PCT[regime.color]
+        if rf_rate_pct is not None
+        else None
+    )
+    return ScreenContext(
+        screen_date=args.screen_date or date.today(),
+        regime_color=regime.color,
+        danger_state=(regime.color == "danger"),
+        rf_rate_pct=rf_rate_pct,
+        hurdle_rate_pct=hurdle,
+        sp500_cape=args.sp500_cape,
+        sp500_trailing_pe=args.sp500_trailing_pe,
+        implied_return_low_pct=args.implied_return_low_pct,
+        implied_return_high_pct=args.implied_return_high_pct,
+        universe=args.universe,
+        notes=args.notes or "",
+    )
+
+
+def _context_from_json(blob: dict) -> ScreenContext:
+    ctx = blob.get("context", {})
+    return ScreenContext(
+        screen_date=date.fromisoformat(blob.get("screen_date") or date.today().isoformat()),
+        regime_color=ctx.get("regime_color", "orange"),
+        danger_state=bool(ctx.get("danger_state", False)),
+        rf_rate_pct=_opt_float(ctx.get("rf_rate_pct")),
+        hurdle_rate_pct=_opt_float(ctx.get("hurdle_rate_pct")),
+        sp500_cape=_opt_float(ctx.get("sp500_cape")),
+        sp500_trailing_pe=_opt_float(ctx.get("sp500_trailing_pe")),
+        implied_return_low_pct=_opt_float(ctx.get("implied_return_low_pct")),
+        implied_return_high_pct=_opt_float(ctx.get("implied_return_high_pct")),
+        universe=ctx.get("universe", "S&P 500"),
+        notes=ctx.get("notes", ""),
+    )
+
+
+# ---- Candidate gathering --------------------------------------------------
+
+
+def _candidates_from_tickers(tickers: list[str]) -> list[Candidate]:
+    """Fetch yfinance fundamentals for each ticker, build Candidate list.
+
+    yfinance lacks ROIC and insider %, so those stay None — the composite
+    formula's contributing_weight will reflect the partial data.
+    """
+    out: list[Candidate] = []
+    for ticker in tickers:
+        ticker = ticker.upper().strip()
+        if not ticker:
+            continue
+        try:
+            f = fetch_fundamentals(ticker)
+        except Exception as e:  # noqa: BLE001
+            print(f"_warning: yfinance fetch failed for {ticker}: {type(e).__name__}: {e}_")
+            continue
+        sector = _sector_for(ticker) or "Unknown"
+        # yfinance debtToEquity is reported as a percent (e.g. 25.0 = 0.25 D/E)
+        de_normalized = (f.debt_to_equity / 100) if f.debt_to_equity is not None else None
+        # P/FCF computed from market_cap / FCF when both available
+        pfcf = (
+            f.market_cap / f.free_cash_flow
+            if f.market_cap is not None and f.free_cash_flow not in (None, 0)
+            else None
+        )
+        out.append(
+            Candidate(
+                ticker=ticker,
+                company=f.company,
+                sector=sector,
+                pe=f.trailing_pe,
+                pfcf=pfcf,
+                roe=f.return_on_equity,
+                roic=None,
+                op_margin=f.operating_margin,
+                profit_margin=f.profit_margin,
+                de=de_normalized,
+                insider_pct=None,
+                market_cap=f.market_cap,
+                price=f.last_close,
+            )
+        )
+    return out
+
+
+def _sector_for(ticker: str) -> str | None:
+    """Best-effort sector lookup via yfinance .info. Non-fatal on failure."""
+    try:
+        import yfinance as yf
+
+        info = yf.Ticker(ticker).info or {}
+    except Exception:  # noqa: BLE001
+        return None
+    return info.get("sector")
+
+
+def _candidates_from_json(blob: dict) -> list[Candidate]:
+    raw = blob.get("candidates") or []
+    out: list[Candidate] = []
+    for r in raw:
+        if "ticker" not in r:
+            continue
+        out.append(
+            Candidate(
+                ticker=r["ticker"].upper(),
+                company=r.get("company"),
+                sector=r.get("sector", "Unknown"),
+                pe=_opt_float(r.get("pe")),
+                pfcf=_opt_float(r.get("pfcf")),
+                roe=_opt_float(r.get("roe")),
+                roic=_opt_float(r.get("roic")),
+                op_margin=_opt_float(r.get("op_margin")),
+                profit_margin=_opt_float(r.get("profit_margin")),
+                de=_opt_float(r.get("de")),
+                insider_pct=_opt_float(r.get("insider_pct")),
+                market_cap=_opt_float(r.get("market_cap")),
+                price=_opt_float(r.get("price")),
+            )
+        )
+    return out
+
+
+# ---- Main ------------------------------------------------------------------
+
+
+def run(args: argparse.Namespace) -> int:
+    if not args.tickers and not args.input:
+        print("SCREEN_ERROR: --tickers or --input required.")
+        return 1
+
+    # 1. Build context
+    if args.input:
+        try:
+            blob = json.loads(Path(args.input).expanduser().read_text())
+        except FileNotFoundError:
+            print(f"SCREEN_ERROR: input file not found: {args.input}")
+            return 1
+        except json.JSONDecodeError as e:
+            print(f"SCREEN_ERROR: input JSON malformed: {e}")
+            return 1
+        context = _context_from_json(blob)
+        candidates = _candidates_from_json(blob)
+    else:
+        regime = _resolve_regime()
+        if regime is None:
+            print(
+                "SCREEN_ERROR: regime unavailable. "
+                "Run clarion-regime-check first to seed the SPY/TLT/RSP cache."
+            )
+            return 1
+        rf_rate_pct = _resolve_rf(args)
+        context = _build_context_from_args(args, regime=regime, rf_rate_pct=rf_rate_pct)
+        candidates = _candidates_from_tickers(args.tickers.split(","))
+
+    if not candidates:
+        print("SCREEN_ERROR: no candidates after fetching. Check tickers / input.")
+        return 1
+
+    # 2. Score + rank + sector cap
+    ranked = score_and_rank(candidates, regime_color=context.regime_color)
+    cap_result = apply_sector_cap(ranked, target_size=args.top_size)
+
+    # 3. Render + save
+    out_dir = watchlist_root()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = watchlist_path(out_dir, context.screen_date)
+    rendered = render_watchlist(
+        context=context,
+        ranked=ranked,
+        cap_result=cap_result,
+    )
+    out_path.write_text(rendered)
+
+    # 4. Print summary
+    print(f"Wrote {out_path}")
+    print()
+    print(f"Stage 1: {len(ranked)} candidates ranked. Top {len(cap_result.top)} after sector cap:")
+    for i, s in enumerate(cap_result.top, start=1):
+        print(
+            f"  {i}. {s.candidate.ticker} ({s.candidate.sector}) — score {s.composite:.1f}"
+            + (f" · price ${s.candidate.price:.2f}" if s.candidate.price else "")
+        )
+    if cap_result.sectors_relaxed:
+        print()
+        print("(sector cap relaxed to 4 per sector — universe genuinely concentrated)")
+    print()
+    print("Next steps:")
+    print(
+        "  1. Open the watchlist file and fill the Sniff Test / Passed On / Existing Theses sections"
+    )
+    print(
+        "  2. For each top candidate not already covered: "
+        "`clarion-single-stock-eval <TICKER>` for filing-level Buffett-lens evidence"
+    )
+    print(
+        "  3. For names worth a position: `clarion-thesis-write <TICKER>` to scaffold a thesis"
+    )
+    return 0
+
+
+def _opt_float(s: object) -> float | None:
+    if s is None or s == "":
+        return None
+    try:
+        return float(s)
+    except (TypeError, ValueError):
+        return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="clarion-value-screener")
+    ap.add_argument("--tickers", default=None, help="Comma-separated ticker list (yfinance mode).")
+    ap.add_argument("--input", default=None, help="Path to JSON input prepared by chat agent.")
+
+    # Context overrides (only used in --tickers mode; --input gets these from JSON)
+    ap.add_argument(
+        "--screen-date",
+        type=date.fromisoformat,
+        default=None,
+        help="ISO date for the screen (default: today).",
+    )
+    ap.add_argument("--rf-rate-pct", type=float, default=None)
+    ap.add_argument("--sp500-cape", type=float, default=None)
+    ap.add_argument("--sp500-trailing-pe", type=float, default=None)
+    ap.add_argument("--implied-return-low-pct", type=float, default=None)
+    ap.add_argument("--implied-return-high-pct", type=float, default=None)
+    ap.add_argument("--universe", default="S&P 500", help="Universe label for the watchlist title.")
+    ap.add_argument("--notes", default=None, help="Free-text notes for the Context block.")
+    ap.add_argument("--top-size", type=int, default=10, help="Top-N after sector cap.")
+
+    args = ap.parse_args()
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/External/clarion-watchlist-update/SKILL.md
+++ b/External/clarion-watchlist-update/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: clarion-watchlist-update
+description: Refresh prices on the latest watchlist and surface what's moved, what's hit triggers, and what's stale. Reads ~/clarion/watchlists/sp500-screen-LATEST.md, fetches current prices for every ticker via yfinance, computes % move since the screen, and flags large moves (>10% in either direction) as worth attention. Also reads ~/clarion/theses/ for status:watchlist theses and shows their current price vs cost basis. Use when the user asks "what's hit my watchlist?", "watchlist update", "anything moving on my watchlist?", or "is anything close to a trigger?". Read-only — does not modify the watchlist file.
+metadata:
+  author: cis.zo.computer
+  category: External
+  display-name: Clarion Watchlist Update
+  homepage: https://github.com/jingerzz/clarion-intelligence-system
+---
+
+# Clarion watchlist update
+
+Read-only snapshot of the latest watchlist with current prices. Surfaces what's moved, what might be near a trigger, and how stale the screen is. Does **not** modify the watchlist file — for a fresh screen, run `clarion-value-screener`.
+
+## When to use
+
+User asks any of:
+- "What's hit my watchlist?"
+- "Watchlist update."
+- "Anything moving on my watchlist?"
+- "Has anything reached a trigger?"
+- "Run a daily watchlist check."
+
+Cadence: this is a quick read, suitable for daily / pre-market.
+
+## Decision tree
+
+1. **Run the script** — no args needed.
+
+   ```bash
+   python /home/workspace/clarion-intelligence-system/skills/clarion-watchlist-update/scripts/update.py
+   ```
+
+   The script:
+   - Loads the latest watchlist file from `~/clarion/watchlists/`
+   - Fetches current prices for every ticker in the Stage 1 ranked table (via yfinance)
+   - Computes % move since the screen
+   - Pulls every thesis with `status: watchlist` from `~/clarion/theses/` and shows current vs cost-basis
+
+2. **Pass the report through to the user verbatim.** It's already structured (header / movers / watchlist theses / staleness).
+
+3. **If a screen-time price is missing** for a ticker (the script flags it), suggest a fresh screen — partial data on the watchlist undermines the comparison.
+
+4. **If the watchlist is stale** (>14 days), the script flags it. Suggest running `clarion-value-screener` for a fresh screen.
+
+5. **For names with large positive moves**, suggest checking whether the thesis still holds at the higher price — the entry case may no longer apply.
+
+6. **For names with large negative moves**, suggest checking whether a thesis is worth opening — those are the moments the screen pays off.
+
+## How to run
+
+```bash
+UPDATE=python /home/workspace/clarion-intelligence-system/skills/clarion-watchlist-update/scripts/update.py
+
+$UPDATE                          # all watchlist tickers
+$UPDATE --top-only               # only the Top-N after sector cap (less noise)
+$UPDATE --threshold-pct 5        # custom threshold for "noticeable mover" (default 10%)
+$UPDATE --max-stale-days 7       # custom staleness threshold (default 14)
+```
+
+## Voice
+
+Lead with what's moved. **Big movers first** (positive or negative — both are signal). Then watchlist-status theses. Then staleness flag.
+
+When a ticker has a large negative move (down >10% since screen), call attention to it explicitly — these are often the moments where a watchlist thesis becomes a real thesis. Suggest running `clarion-single-stock-eval <TICKER>` to refresh the lens.
+
+When a ticker has a large positive move (up >10%), don't add it to anything — the entry case has weakened. Surface for awareness but don't act.
+
+## On error
+
+- **`WATCHLIST_UPDATE_ERROR: no watchlists`** — `~/clarion/watchlists/` is empty. Run `clarion-value-screener` first.
+- **`WATCHLIST_UPDATE_ERROR: latest watchlist unparseable`** — the latest file isn't in canonical format. Verify it; consider regenerating with a fresh screener run.
+- **`_warning: yfinance fetch failed for <TICKER>`** — non-fatal; that ticker is shown without a current price.

--- a/External/clarion-watchlist-update/SKILL.md
+++ b/External/clarion-watchlist-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clarion-watchlist-update
-description: Refresh prices on the latest watchlist and surface what's moved, what's hit triggers, and what's stale. Reads ~/clarion/watchlists/sp500-screen-LATEST.md, fetches current prices for every ticker via yfinance, computes % move since the screen, and flags large moves (>10% in either direction) as worth attention. Also reads ~/clarion/theses/ for status:watchlist theses and shows their current price vs cost basis. Use when the user asks "what's hit my watchlist?", "watchlist update", "anything moving on my watchlist?", or "is anything close to a trigger?". Read-only — does not modify the watchlist file.
+description: Refresh prices on the latest watchlist and surface what's moved, what's hit triggers, and what's stale. Reads ~/clarion/watchlists/sp500-screen-LATEST.md, fetches current prices for every ticker via yfinance, computes % move since the screen, and flags large moves (>10% in either direction) as worth attention. Also reads ~/clarion/theses/ for status:watchlist theses and shows their current price vs cost basis. Use when the user asks "what's hit my watchlist?", "watchlist update", "anything moving on my watchlist?", or "is anything close to a trigger?". Read-only — does not modify the watchlist file. Requires clarion-setup to have been run.
 metadata:
   author: cis.zo.computer
   category: External

--- a/External/clarion-watchlist-update/references/triggers-guide.md
+++ b/External/clarion-watchlist-update/references/triggers-guide.md
@@ -1,0 +1,33 @@
+# Watchlist update — what to watch for
+
+Source: [`docs/PRINCIPLES.md` Principle 8 (Patience Is a Position)](../../../docs/PRINCIPLES.md#8-patience-is-a-position) and the AWB watchlist examples.
+
+## Why a watchlist is a position
+
+A watchlist is what we don't own *yet*. It's where the discipline of "wait for the pitch" ([Principle 8](../../../docs/PRINCIPLES.md#8-patience-is-a-position)) gets operationalized. The names on the list are the ones we've decided are interesting at the right price; this skill tells us when those prices show up.
+
+## What "moved" means
+
+| Move since screen | What it tells you |
+|---|---|
+| > +10% | Entry case has likely weakened. Don't add. Watch. |
+| +5% to +10% | Marginally less interesting. Re-check the thesis if you're inclined. |
+| ±5% | Noise. Ignore. |
+| -5% to -10% | Getting more interesting. Worth a fresh look. |
+| < -10% | This is what the watchlist exists for. Run `clarion-single-stock-eval <TICKER>`. |
+
+## Trigger hits (status:watchlist theses)
+
+A `watchlist` thesis is one with a defined entry zone in its **Position Management** section. The script reads each watchlist-status thesis from `~/clarion/theses/` and shows current price vs the thesis's `cost_basis` field (when present, it's the prior entry; otherwise the script just shows current price).
+
+For an explicit "did the entry zone hit?" check, look at the thesis's **Entry/Exit Levels** section directly — the script doesn't parse the prose-heavy add-zone fields in v1.
+
+## Staleness
+
+A watchlist older than 14 days is flagged. By that point regime, hurdle, and fundamentals have likely drifted enough that the screen needs a refresh — run `clarion-value-screener`.
+
+## What this skill does NOT do
+
+- Doesn't modify the watchlist file. For a fresh screen, run `clarion-value-screener`.
+- Doesn't auto-run `clarion-single-stock-eval` for big movers — that's the chat agent's call after surfacing the move.
+- Doesn't parse the prose-heavy Sniff Test or Passed-On sections — only the structured Stage 1 table.

--- a/External/clarion-watchlist-update/scripts/update.py
+++ b/External/clarion-watchlist-update/scripts/update.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Clarion watchlist update — read the latest screen, refresh prices.
+
+Read-only snapshot. Loads the latest watchlist file, fetches current prices,
+computes % move since the screen, surfaces big movers and watchlist-status
+theses. Doesn't modify any file.
+
+Usage:
+    python update.py
+    python update.py --top-only
+    python update.py --threshold-pct 5
+    python update.py --max-stale-days 7
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+from ai_buffett_zo.data import EquityStore
+from ai_buffett_zo.screener import (
+    DEFAULT_WATCHLIST_ROOT,
+    WatchlistRow,
+    latest_watchlist,
+    parse_ranked_table,
+)
+from ai_buffett_zo.theses import (
+    DEFAULT_THESES_ROOT,
+    ThesisMetadata,
+    list_theses,
+    parse_thesis_metadata,
+)
+from ai_buffett_zo.voice import footer, header, md_table
+
+
+def watchlist_root() -> Path:
+    return Path(os.environ.get("CLARION_WATCHLIST_ROOT") or DEFAULT_WATCHLIST_ROOT)
+
+
+def theses_root() -> Path:
+    return Path(os.environ.get("CLARION_THESES_ROOT") or DEFAULT_THESES_ROOT)
+
+
+# ---- Watchlist date extraction ---------------------------------------------
+
+
+_DATE_FROM_FILENAME = re.compile(r"sp500-screen-(\d{4}-\d{2}-\d{2})\.md$")
+
+
+def _date_from_filename(p: Path) -> date | None:
+    m = _DATE_FROM_FILENAME.search(p.name)
+    if m is None:
+        return None
+    try:
+        return date.fromisoformat(m.group(1))
+    except ValueError:
+        return None
+
+
+# ---- Price fetch -----------------------------------------------------------
+
+
+def _current_price(ticker: str) -> float | None:
+    try:
+        store = EquityStore()
+        bars = store.history(ticker, max_age=timedelta(hours=24))
+    except Exception:  # noqa: BLE001
+        return None
+    return bars[-1].close if bars else None
+
+
+# ---- Run -------------------------------------------------------------------
+
+
+def run(args: argparse.Namespace) -> int:
+    wl_path = latest_watchlist(watchlist_root())
+    if wl_path is None:
+        print(
+            "WATCHLIST_UPDATE_ERROR: no watchlists found at "
+            f"{watchlist_root()}. Run clarion-value-screener first."
+        )
+        return 1
+
+    content = wl_path.read_text()
+    rows = parse_ranked_table(content)
+    if not rows:
+        print(
+            f"WATCHLIST_UPDATE_ERROR: latest watchlist unparseable: {wl_path}. "
+            "Verify the Stage 1 ranked-results table is present."
+        )
+        return 1
+
+    if args.top_only:
+        rows = rows[: args.top_size]
+
+    screen_date = _date_from_filename(wl_path) or date.today()
+    age_days = (date.today() - screen_date).days
+    stale = age_days > args.max_stale_days
+
+    # Fetch current prices in order; small enough to do sequentially
+    enriched: list[tuple[WatchlistRow, float | None, float | None]] = []
+    for row in rows:
+        cur = _current_price(row.ticker)
+        if cur is not None and row.price is not None and row.price > 0:
+            move_pct = (cur / row.price - 1.0) * 100
+        else:
+            move_pct = None
+        enriched.append((row, cur, move_pct))
+
+    # Pull watchlist-status theses
+    watchlist_theses: list[tuple[ThesisMetadata, float | None]] = []
+    for tp in list_theses(theses_root()):
+        try:
+            md = parse_thesis_metadata(tp.read_text())
+        except OSError:
+            continue
+        if md is None or md.status != "watchlist":
+            continue
+        cur = _current_price(md.ticker)
+        watchlist_theses.append((md, cur))
+
+    _render(
+        wl_path=wl_path,
+        screen_date=screen_date,
+        age_days=age_days,
+        stale=stale,
+        max_stale_days=args.max_stale_days,
+        enriched=enriched,
+        threshold_pct=args.threshold_pct,
+        watchlist_theses=watchlist_theses,
+        top_only=args.top_only,
+    )
+    return 0
+
+
+def _render(
+    *,
+    wl_path: Path,
+    screen_date: date,
+    age_days: int,
+    stale: bool,
+    max_stale_days: int,
+    enriched: list[tuple[WatchlistRow, float | None, float | None]],
+    threshold_pct: float,
+    watchlist_theses: list[tuple[ThesisMetadata, float | None]],
+    top_only: bool,
+) -> None:
+    title = "Watchlist Update"
+    subtitle = f"latest screen: {screen_date.isoformat()} ({age_days}d old)"
+    print(header(title, subtitle))
+    print()
+    print(f"_Source: `{wl_path}`_" + (" — **stale**" if stale else ""))
+    print()
+
+    # Movers section
+    big = [
+        (row, cur, move) for row, cur, move in enriched if move is not None and abs(move) >= threshold_pct
+    ]
+    if big:
+        print(f"## Big movers (≥ {threshold_pct:.0f}% since screen)")
+        print()
+        rows = [
+            [
+                row.ticker,
+                row.sector,
+                f"{row.score:.1f}",
+                _fmt_money(row.price),
+                _fmt_money(cur),
+                _fmt_signed_pct(move),
+                _direction_note(move, threshold_pct),
+            ]
+            for row, cur, move in big
+        ]
+        print(md_table(["Ticker", "Sector", "Score", "Screen $", "Current $", "Move", "Note"], rows))
+        print()
+
+    # Full table
+    label = "Top-N (sector-capped)" if top_only else "Full ranked list"
+    print(f"## {label}")
+    print()
+    rows = [
+        [
+            str(row.rank),
+            row.ticker,
+            row.sector,
+            f"{row.score:.1f}",
+            _fmt_money(row.price),
+            _fmt_money(cur),
+            _fmt_signed_pct(move),
+        ]
+        for row, cur, move in enriched
+    ]
+    print(md_table(["Rank", "Ticker", "Sector", "Score", "Screen $", "Current $", "Move"], rows))
+    print()
+
+    # Watchlist theses
+    if watchlist_theses:
+        print("## Watchlist-status theses")
+        print()
+        rows = []
+        for md, cur in watchlist_theses:
+            rows.append(
+                [
+                    md.ticker,
+                    md.bucket,
+                    _fmt_money(md.cost_basis),
+                    _fmt_money(cur),
+                    _move_vs_basis(md.cost_basis, cur),
+                ]
+            )
+        print(md_table(["Ticker", "Bucket", "Cost Basis", "Current $", "vs Basis"], rows))
+        print()
+        print(
+            "_For exact entry-zone checks, open the thesis file directly — "
+            "the script doesn't parse the prose-heavy Position Management section in v1._"
+        )
+        print()
+
+    # Staleness footer
+    if stale:
+        print(
+            f"⚠ The latest screen is {age_days}d old (threshold: {max_stale_days}d). "
+            "Regime, hurdle, and fundamentals likely drifted — consider running "
+            "`clarion-value-screener` for a refresh."
+        )
+        print()
+
+    print(footer())
+
+
+def _direction_note(move: float, threshold: float) -> str:
+    if move >= threshold:
+        return "entry case weaker"
+    if move <= -threshold:
+        return "worth a fresh look"
+    return ""
+
+
+def _fmt_money(v: float | None) -> str:
+    if v is None:
+        return "n/a"
+    return f"${v:,.2f}"
+
+
+def _fmt_signed_pct(v: float | None) -> str:
+    if v is None:
+        return "n/a"
+    return f"{v:+.1f}%"
+
+
+def _move_vs_basis(basis: float | None, current: float | None) -> str:
+    if basis is None or current is None or basis == 0:
+        return "n/a"
+    return f"{(current / basis - 1) * 100:+.1f}%"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="clarion-watchlist-update")
+    ap.add_argument("--top-only", action="store_true", help="Only show top-N after sector cap.")
+    ap.add_argument(
+        "--top-size",
+        type=int,
+        default=10,
+        help="When --top-only is set, the size of the top group (default 10).",
+    )
+    ap.add_argument(
+        "--threshold-pct",
+        type=float,
+        default=10.0,
+        help="Move %% threshold to flag as 'big mover' (default 10).",
+    )
+    ap.add_argument(
+        "--max-stale-days",
+        type=int,
+        default=14,
+        help="Days before flagging the latest watchlist as stale (default 14).",
+    )
+    args = ap.parse_args()
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/external.yml
+++ b/external.yml
@@ -1,3 +1,23 @@
+- repository: jingerzz/clarion-intelligence-system
+  skill: clarion-setup
+- repository: jingerzz/clarion-intelligence-system
+  skill: clarion-regime-check
+- repository: jingerzz/clarion-intelligence-system
+  skill: clarion-sec-research
+- repository: jingerzz/clarion-intelligence-system
+  skill: clarion-single-stock-eval
+- repository: jingerzz/clarion-intelligence-system
+  skill: clarion-expected-return-calc
+- repository: jingerzz/clarion-intelligence-system
+  skill: clarion-thesis-write
+- repository: jingerzz/clarion-intelligence-system
+  skill: clarion-thesis-monitor
+- repository: jingerzz/clarion-intelligence-system
+  skill: clarion-value-screener
+- repository: jingerzz/clarion-intelligence-system
+  skill: clarion-watchlist-update
+- repository: jingerzz/clarion-intelligence-system
+  skill: clarion-living-letter-update
 - repository: clawdbot/clawdbot
   skill: gog
   description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs


### PR DESCRIPTION
Public, MIT-licensed Buffett-style investment research skills for Zo Computer, all from [`github.com/jingerzz/clarion-intelligence-system`](https://github.com/jingerzz/clarion-intelligence-system).

Updated from the original 3-skill PR to include all 10 shipped skills. Branch was rebased onto the latest `main`.

## Skills

- **`clarion-setup`** — bootstrap (clones source, installs `ai_buffett_zo` lib, registers `sec-indexer` process service)
- **`clarion-regime-check`** — SPY/TLT/RSP color regime + equity hurdle rate
- **`clarion-sec-research`** — SEC EDGAR fetch / index / search. Now supports **all filing forms** (10-K, 10-Q, S-1, S-3, S-4, DEF 14A, 6-K, F-1, etc.) via vendored [PageIndex](https://github.com/VectifyAI/PageIndex) (MIT) for full LLM-summarized indexing, plus a raw single-node fallback for short forms (8-K, Form 4 XML, 13D, etc.) that's still keyword-searchable. Two-stage search: keyword baseline + LLM reasoning fallback when keyword is weak.
- **`clarion-single-stock-eval`** — Buffett-lens evaluation over indexed filings (moat / management / financials / risks)
- **`clarion-expected-return-calc`** — equity-vs-T-bill allocation per the Expected-Return Framework (Shiller CAPE → 10-yr forward return + regime hurdle + 5-tier verdict)
- **`clarion-thesis-write`** — scaffolds a thesis in the canonical format with seeded Buffett-lens citations
- **`clarion-thesis-monitor`** — recomputes health scores (6 components, regime-adjusted action map) + checks kill conditions across active theses
- **`clarion-value-screener`** — Stage 1 composite scoring (8-factor formula) + sector cap; Stage 2 delegated to `clarion-single-stock-eval`
- **`clarion-watchlist-update`** — refreshes watchlist prices, surfaces movers vs the latest screen, lists watchlist-status theses
- **`clarion-living-letter-update`** — quarterly + year-end annual investor letter updates with append-only enforcement

## Status

Phase A (`clarion-setup`, `clarion-regime-check`, `clarion-sec-research`) was validated end-to-end on Zo Computer (2026-05-07) — `clarion-setup` bootstrapped the workspace, registered the `sec-indexer` process service via `register_user_service`, and the chat-invoked skills authenticated via the auto-injected `ZO_CLIENT_IDENTITY_TOKEN`. Indexed NVDA's 10-K in ~75s using `zo:openai/gpt-5.4-mini` (free tier).

Phase B shipped the remaining seven skills plus a 4-doc philosophy layer (`docs/PRINCIPLES.md`, `docs/DESIGN-LANGUAGE.md`, `docs/ALLOCATION-POLICY.md`, `docs/MISSION.md`). End-to-end Phase B validation on Zo is planned next.

`bun validate` is clean for all 10 skills. `external.yml` entries are minimal (`repository` + `skill`) — source SKILL.md carries `description`, `metadata.author=cis.zo.computer`, and `display-name`.