### PR TITLE
Sync clarion-setup: resolve data root for /home/workspace layout

### DIFF
--- a/External/clarion-setup/SKILL.md
+++ b/External/clarion-setup/SKILL.md
@@ -79,10 +79,10 @@ Use the `register_user_service` agent tool with these exact parameters (also pri
 - **mode**: `process`
 - **entrypoint**: `sec-indexer`
 - **workdir**: `/home/workspace`
-- **env_vars**: `{"ZO_API_KEY": "$ZO_API_KEY"}`
+- **env_vars**: copy verbatim from the `SERVICE_REGISTRATION` envelope printed by `setup.py` — includes `ZO_API_KEY` plus a `CLARION_DATA_ROOT` value resolved at setup time (e.g. `/home/workspace/clarion` on Zo)
 - **description**: `Clarion sec-indexer — background SEC EDGAR filing indexer`
 
-The `$ZO_API_KEY` value is shell-style syntax telling Zo to resolve from the user's secret of the same name (created in Step 3) at service start. Use the snake_case parameter names exactly — `workdir` and `env_vars` — these are the canonical keys Zo's tool accepts.
+The `$ZO_API_KEY` value is shell-style syntax telling Zo to resolve from the user's secret of the same name (created in Step 3) at service start. The `CLARION_DATA_ROOT` value is a literal path — it pins the indexer's writes to the same data root chat skills read from, so SEC filings land in the user-visible workspace and not in `/root/clarion/` when the service runs as root. Use the snake_case parameter names exactly — `workdir` and `env_vars` — these are the canonical keys Zo's tool accepts.
 
 Confirm registration succeeded (the tool should return a service ID like `svc_…`).
 
@@ -101,7 +101,7 @@ Tell the user:
 > Clarion is set up.
 >
 > - Source: `/home/workspace/clarion-intelligence-system/`
-> - Workspace data: `~/clarion/`
+> - Workspace data: the path printed in the `[2/6] Creating data tree under …` line from setup.py (typically `/home/workspace/clarion/` on Zo, `~/clarion/` on a local machine — auto-detected)
 > - Background service: `sec-indexer` (running)
 > - Skills installed under `/home/workspace/Skills/`: every sibling `clarion-*` skill from the repo (regime-check, sec-research, single-stock-eval, expected-return-calc, value-screener, thesis-write, thesis-monitor, watchlist-update, living-letter-update). List the actual names returned in the `[5/6] Installing sibling clarion-* skills ...` block from setup.py.
 >

--- a/External/clarion-setup/scripts/setup.py
+++ b/External/clarion-setup/scripts/setup.py
@@ -35,7 +35,23 @@ LIB_DIR = REPO_ROOT / "lib"
 SKILLS_SRC_DIR = REPO_ROOT / "skills"
 SKILLS_INSTALL_DIR = Path("/home/workspace/Skills")
 SETUP_SKILL_NAME = "clarion-setup"  # excluded from auto-install (it's the bootstrap)
-WORKSPACE = Path.home() / "clarion"
+
+
+def _clarion_home() -> Path:
+    """Resolve the Clarion data root: env var > Zo auto-detect > $HOME/clarion.
+
+    Inlined here because setup.py runs BEFORE the ai_buffett_zo library is
+    pip-installed. Keep behavior in sync with lib/ai_buffett_zo/_paths.py.
+    """
+    env = os.environ.get("CLARION_DATA_ROOT", "").strip()
+    if env:
+        return Path(env).expanduser()
+    if Path("/home/workspace").is_dir():
+        return Path("/home/workspace/clarion")
+    return Path.home() / "clarion"
+
+
+WORKSPACE = _clarion_home()
 DATA_SUBDIRS = (
     "data/equities",
     "sec",
@@ -58,7 +74,11 @@ SERVICE_REGISTRATION_PARAMS: dict = {
     "mode": "process",
     "entrypoint": "sec-indexer",
     "workdir": "/home/workspace",
-    "env_vars": {"ZO_API_KEY": "$ZO_API_KEY"},
+    # CLARION_DATA_ROOT is pinned to whatever WORKSPACE resolved to at setup
+    # time so the indexer's writes land in the same tree chat skills read from.
+    # Without this the indexer inherits the service-runner's env (e.g. root)
+    # and silently writes to /root/clarion/sec/.
+    "env_vars": {"ZO_API_KEY": "$ZO_API_KEY", "CLARION_DATA_ROOT": str(WORKSPACE)},
     "description": "Clarion sec-indexer — background SEC EDGAR filing indexer",
 }
 


### PR DESCRIPTION
Syncs \`External/clarion-setup/\` to upstream [\`jingerzz/clarion-intelligence-system@eb12359\`](https://github.com/jingerzz/clarion-intelligence-system/commit/eb12359ae9f39a66bd3a1997e975e5674bd9c346) (PR [#2](https://github.com/jingerzz/clarion-intelligence-system/pull/2)).

## Bug

On Zo, skills run as root, so \`Path.home()\` resolves to \`/root\`. Clarion's lib used \`Path.home() / "clarion"\` for every default data root, which dropped theses, letters, watchlists, and SEC filings into \`/root/clarion/\` — **outside** the user-visible \`/home/workspace\` file browser. Effectively invisible.

## Fix landing in this sync

The lib-level fix lives in the source repo and reaches users via \`git pull\`. **Only the bootstrap (\`clarion-setup\`) needs syncing here** because:

1. **\`setup.py\`** now inlines a 3-tier resolver (env var → \`/home/workspace\` auto-detect → \`$HOME/clarion\` fallback) so the script can resolve the data root before the lib is pip-installed.
2. **\`SERVICE_REGISTRATION_PARAMS.env_vars\`** now pins \`CLARION_DATA_ROOT=<resolved-WORKSPACE>\`. Without this the \`sec-indexer\` background process inherits the service-runner's env and silently writes to \`/root/clarion/sec/\` even though chat skills read from \`/home/workspace/clarion/sec/\` — a split-brain that hid filings from the user.
3. **\`SKILL.md\`** documents the new \`env_vars\` entry and the auto-detected data root in the post-setup message.

The other nine \`clarion-*\` skills consume \`DEFAULT_*_ROOT\` from the lib, which now reads the same resolver. No registry update needed for those — they pick up the fix from the cloned source.

## Validation

- \`bun validate\` — no warnings on \`clarion-setup\` (15 pre-existing warnings on other skills, all unrelated).
- Upstream test suite: 573 passed (567 prior baseline + 6 new tests for the resolver).