### PR TITLE
Sync clarion-setup: refresh SKILL.md frontmatter description

### DIFF
--- a/External/clarion-setup/SKILL.md
+++ b/External/clarion-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clarion-setup
-description: Bootstraps the Clarion Intelligence System on Zo Computer. Run this once after installing the skill — clones the source repo, installs the ai_buffett_zo Python library, creates the ~/clarion/ workspace, writes default config, and registers the sec-indexer background service. Idempotent (safe to re-run). Use when the user asks to "set up Clarion", "install Clarion", or after they install any other clarion-* skill before it has been bootstrapped.
+description: Bootstraps the Clarion Intelligence System on Zo Computer. Run this once after installing — clones the source repo, installs the ai_buffett_zo Python library, creates the workspace data tree under /home/workspace/clarion/ (auto-detected on Zo), auto-installs all nine sibling clarion-* skills (regime-check, sec-research, single-stock-eval, expected-return-calc, value-screener, thesis-write, thesis-monitor, watchlist-update, living-letter-update) under /home/workspace/Skills/, and registers the sec-indexer background service. Idempotent (safe to re-run; refreshes installed skills with upstream copies). This is the only Clarion skill a user needs to install manually — every other clarion-* skill is installed by this one. Use when the user asks to "set up Clarion" or "install Clarion".
 metadata:
   author: cis.zo.computer
   category: External


### PR DESCRIPTION
Syncs \`External/clarion-setup/SKILL.md\` to upstream [\`jingerzz/clarion-intelligence-system@1448fcf\`](https://github.com/jingerzz/clarion-intelligence-system/commit/1448fcf00078f0483eb1e62789ceda663be0740e) (PR [#4](https://github.com/jingerzz/clarion-intelligence-system/pull/4)).

## Why this matters

The SKILL.md \`description:\` frontmatter field hadn't been updated since the original drop, even though PRs [#79](https://github.com/zocomputer/skills/pull/79) (auto-install of sibling skills) and [#80](https://github.com/zocomputer/skills/pull/80) (data-root resolution) shipped real behavior changes. The bodies of those PRs updated the SKILL.md prose; the frontmatter drifted.

Because \`manifest.json\` is regenerated from frontmatter, the registry catalog has been advertising pre-#79 capabilities — no sibling-skill auto-install, no Zo data-root auto-detect, plus a trigger phrase ("after they install any other clarion-* skill before it has been bootstrapped") that no longer makes sense now that setup installs them all.

## Diff

One line, frontmatter only. Old description vs new:

**Old:**
> Bootstraps the Clarion Intelligence System on Zo Computer. Run this once after installing the skill — clones the source repo, installs the ai_buffett_zo Python library, creates the ~/clarion/ workspace, writes default config, and registers the sec-indexer background service. Idempotent (safe to re-run). Use when the user asks to "set up Clarion", "install Clarion", or after they install any other clarion-* skill before it has been bootstrapped.

**New:**
> Bootstraps the Clarion Intelligence System on Zo Computer. Run this once after installing — clones the source repo, installs the ai_buffett_zo Python library, creates the workspace data tree under /home/workspace/clarion/ (auto-detected on Zo), auto-installs all nine sibling clarion-* skills (regime-check, sec-research, single-stock-eval, expected-return-calc, value-screener, thesis-write, thesis-monitor, watchlist-update, living-letter-update) under /home/workspace/Skills/, and registers the sec-indexer background service. Idempotent (safe to re-run; refreshes installed skills with upstream copies). This is the only Clarion skill a user needs to install manually — every other clarion-* skill is installed by this one. Use when the user asks to "set up Clarion" or "install Clarion".

## Validation

\`bun validate\` — clean on clarion-setup (the 15 pre-existing warnings on other skills are untouched).

After merge, the \`chore: regenerate manifest.json [skip ci]\` bot should fire and refresh the registry-facing description.