### PR TITLE
Community: HyperFrames video toolkit (5 skills)

### DIFF
--- a/Community/gsap/DISPLAY.json
+++ b/Community/gsap/DISPLAY.json
@@ -1,0 +1,5 @@
+{
+  "specVersion": "0.2.0",
+  "icon": "wand-sparkles",
+  "tags": ["animation", "gsap", "motion", "frontend"]
+}

--- a/Community/gsap/SKILL.md
+++ b/Community/gsap/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: gsap
+description: |
+  GSAP animation reference for HyperFrames and frontend motion work. Use for tween methods, timeline sequencing, easing, transforms, stagger, matchMedia, cleanup, performance, and deterministic video-safe GSAP choreography.
+compatibility: Created for Zo Computer
+metadata:
+  author: jeffkazzee.zo.computer
+  category: Video
+---
+
+# GSAP Motion Reference
+
+## Usage
+
+Consult this skill any time the agent is writing or reviewing GSAP code, especially for HyperFrames video work. Load `references/hyperframes-gsap-rules.md` first when the target is a HyperFrames composition (capture-engine constraints make many normal GSAP idioms unsafe). Use `references/timeline-patterns.md` for sequencing, `references/easing.md` to choose curves with intent, `references/effects.md` for typewriter/visualizer/morph patterns, and `references/performance.md` before shipping motion-heavy work.
+
+## Core tween methods
+
+- `gsap.to(targets, vars)` — animate from current state to `vars`. Most common.
+- `gsap.from(targets, vars)` — animate from `vars` to current state. Use for entrances.
+- `gsap.fromTo(targets, fromVars, toVars)` — explicit start and end.
+- `gsap.set(targets, vars)` — immediate set, duration 0.
+
+Always use camelCase property names: `backgroundColor`, `rotationX`, `transformOrigin`.
+
+## Common vars
+
+- `duration` — seconds; default is 0.5.
+- `delay` — seconds before start. Prefer timeline position parameters instead.
+- `ease` — e.g. `power1.out`, `power3.inOut`, `back.out(1.7)`, `elastic.out(1, 0.3)`, `none`.
+- `stagger` — number or object: `{ amount: 0.3, from: "center" }`, `{ each: 0.1, from: "random" }`.
+- `overwrite` — `false`, `true`, or `"auto"`.
+- `repeat` — number. In HyperFrames, never `-1`.
+- `yoyo` — alternates direction with repeat.
+- `onComplete`, `onStart`, `onUpdate` — callbacks.
+- `immediateRender` — default true for `from()` / `fromTo()`. Set `false` on later tweens targeting the same property + element to avoid overwrite.
+
+## Transform aliases
+
+Prefer GSAP transform aliases over raw transform strings:
+
+| GSAP property | Equivalent |
+|---|---|
+| `x`, `y`, `z` | `translateX/Y/Z` in px |
+| `xPercent`, `yPercent` | translate in percent |
+| `scale`, `scaleX`, `scaleY` | scale |
+| `rotation` | rotate in degrees |
+| `rotationX`, `rotationY` | 3D rotate |
+| `skewX`, `skewY` | skew |
+| `transformOrigin` | CSS transform origin |
+
+Use `autoAlpha` instead of opacity when visibility should also toggle at 0. Use CSS variables like `"--hue": 180` when animating custom props.
+
+## Timelines
+
+Prefer timelines over chained delays.
+
+```js
+const tl = gsap.timeline({ defaults: { duration: 0.5, ease: "power2.out" } });
+tl.to(".a", { x: 100 })
+  .to(".b", { y: 50 })
+  .to(".c", { opacity: 0 });
+```
+
+Position parameter:
+
+- `1` — absolute time at 1s.
+- `"+=0.5"` — after previous end.
+- `"-=0.2"` — before previous end.
+- `"intro"`, `"intro+=0.3"` — labels.
+- `"<"` — same start as previous.
+- `">"` — after previous ends.
+- `"<0.2"` — 0.2s after previous starts.
+
+Use labels for readable sequencing:
+
+```js
+tl.addLabel("intro", 0);
+tl.to(".a", { x: 100 }, "intro");
+tl.addLabel("outro", "+=0.5");
+tl.play("outro");
+```
+
+## HyperFrames-specific GSAP rules
+
+- Timelines must be created synchronously and paused: `gsap.timeline({ paused: true })`.
+- Register every timeline: `window.__timelines["composition-id"] = tl`.
+- Do not call media playback methods.
+- Do not animate `display` or `visibility`; use `autoAlpha` or opacity unless the framework owns visibility.
+- Use `tl.set()` at or after clip start for later scene clip elements. Do not `gsap.set()` future clip elements at page load.
+- Never use infinite repeats. Use `repeat: Math.ceil(duration / cycleDuration) - 1`.
+
+## Performance
+
+- Prefer `x`, `y`, `scale`, `rotation`, and `opacity`.
+- Avoid `width`, `height`, `top`, and `left` when transforms can solve it.
+- Use `will-change: transform` only on elements that actually animate.
+- Use `stagger` instead of many manual tweens.
+- Use `gsap.quickTo()` for frequent pointer or input updates.
+- Kill offscreen or no-longer-needed animations.
+
+## References
+
+- `references/easing.md` — built-in eases and emotional use.
+- `references/timeline-patterns.md` — labels, nesting, position parameter examples.
+- `references/performance.md` — compositor-safe animation and cleanup.
+- `references/hyperframes-gsap-rules.md` — video-safe GSAP constraints.
+- `references/effects.md` — drop-in effects: typewriter text, audio visualizer, and reusable snippets.

--- a/Community/gsap/references/easing.md
+++ b/Community/gsap/references/easing.md
@@ -1,0 +1,20 @@
+# GSAP Easing
+
+Built-ins: `power1`-`power4`, `back`, `bounce`, `circ`, `elastic`, `expo`, `sine`. Most support `.in`, `.out`, and `.inOut`.
+
+## Practical choices
+
+- `power1.out` — default, mild.
+- `power2.out` — clean UI motion.
+- `power3.out` — strong entrance.
+- `power4.out` — dramatic snap.
+- `expo.out` — premium, decisive.
+- `sine.inOut` — ambient loops and floating.
+- `back.out(1.2)` — tactile card entrance.
+- `back.out(1.7)` — playful; use carefully.
+- `elastic.out(1, 0.3)` — special effect only.
+- `none` — progress bars, scanning, mechanical motion.
+
+## Rule
+
+Vary eases inside a scene when multiple elements enter. Reusing one ease everywhere makes the frame feel generated rather than directed.

--- a/Community/gsap/references/effects.md
+++ b/Community/gsap/references/effects.md
@@ -1,0 +1,44 @@
+# GSAP Effects
+
+## Typewriter text
+
+Use for short phrases only. Long typewriter copy is usually a pacing crime.
+
+```js
+const text = "Built with Zo.";
+const el = document.querySelector(".typewriter");
+tl.to({ n: 0 }, {
+  n: text.length,
+  duration: 1.1,
+  ease: "none",
+  onUpdate() {
+    el.textContent = text.slice(0, Math.round(this.targets()[0].n));
+  }
+}, 0.4);
+```
+
+## Audio visualizer bars
+
+Use finite repeats or explicit beat timing. No random heights unless seeded.
+
+```js
+const bars = gsap.utils.toArray(".bar");
+tl.to(bars, {
+  scaleY: (i) => [0.4, 0.9, 0.6, 1.0, 0.5][i % 5],
+  transformOrigin: "50% 100%",
+  duration: 0.18,
+  stagger: 0.035,
+  yoyo: true,
+  repeat: 8,
+  ease: "sine.inOut"
+}, 0.2);
+```
+
+## Directional rotation
+
+Use directional suffixes:
+
+```js
+gsap.to(".dial", { rotation: "360_cw", duration: 1.2 });
+gsap.to(".needle", { rotation: "-170_short", duration: 0.6 });
+```

--- a/Community/gsap/references/hyperframes-gsap-rules.md
+++ b/Community/gsap/references/hyperframes-gsap-rules.md
@@ -1,0 +1,51 @@
+# HyperFrames GSAP Rules
+
+## Video-safe timeline construction
+
+```js
+window.__timelines = window.__timelines || {};
+const tl = gsap.timeline({ paused: true });
+window.__timelines["composition-id"] = tl;
+```
+
+Build synchronously. No `async`, `await`, promises, `setTimeout`, font loading waits, or timeline creation after page load. The capture engine reads `window.__timelines` synchronously.
+
+## Allowed animation properties
+
+Animate visual properties:
+
+- `opacity`, `autoAlpha`
+- `x`, `y`, `z`
+- `scale`, `scaleX`, `scaleY`
+- `rotation`, `rotationX`, `rotationY`
+- `color`, `backgroundColor`
+- `borderRadius`
+- transforms and CSS variables
+
+Do not animate `display` or framework-owned media playback state.
+
+## Repeats
+
+Never use `repeat: -1`.
+
+```js
+const repeat = Math.ceil(duration / cycleDuration) - 1;
+tl.to(".orb", { y: -10, yoyo: true, repeat, duration: cycleDuration / 2 }, 0);
+```
+
+## Future clip elements
+
+Do not use `gsap.set()` at page load on clip elements from later scenes. They may not exist yet.
+
+Use timeline-positioned sets:
+
+```js
+tl.set("#later-scene .thing", { opacity: 0 }, sceneStart);
+```
+
+## Animation conflicts
+
+Never animate the same property on the same element from multiple timelines simultaneously. If needed, split wrapper vs child:
+
+- wrapper animates `x`/`y`
+- child animates `scale`/`opacity`

--- a/Community/gsap/references/performance.md
+++ b/Community/gsap/references/performance.md
@@ -1,0 +1,52 @@
+# GSAP Performance
+
+## Prefer compositor-safe properties
+
+Use:
+
+- `x`
+- `y`
+- `scale`
+- `rotation`
+- `opacity`
+- `autoAlpha`
+
+Avoid when possible:
+
+- `width`
+- `height`
+- `top`
+- `left`
+- layout-heavy box changes
+
+## `will-change`
+
+Use only on elements that animate:
+
+```css
+.card { will-change: transform; }
+```
+
+Do not blanket `will-change` across the page.
+
+## Frequent updates
+
+Use `gsap.quickTo()` for pointer-driven or frequent updates:
+
+```js
+const xTo = gsap.quickTo("#id", "x", { duration: 0.4, ease: "power3" });
+const yTo = gsap.quickTo("#id", "y", { duration: 0.4, ease: "power3" });
+container.addEventListener("mousemove", (e) => {
+  xTo(e.pageX);
+  yTo(e.pageY);
+});
+```
+
+## Cleanup
+
+Store tween/timeline return values when controlling playback. Kill animations when no longer needed.
+
+```js
+const tween = gsap.to(".box", { x: 100 });
+tween.kill();
+```

--- a/Community/gsap/references/timeline-patterns.md
+++ b/Community/gsap/references/timeline-patterns.md
@@ -1,0 +1,51 @@
+# GSAP Timeline Patterns
+
+## Default timeline
+
+```js
+const tl = gsap.timeline({
+  paused: true,
+  defaults: { duration: 0.5, ease: "power2.out" }
+});
+```
+
+## Position parameter
+
+```js
+tl.to(".a", { x: 100 }, 0);
+tl.to(".b", { y: 50 }, "<");
+tl.to(".c", { opacity: 0 }, "<0.2");
+tl.to(".d", { scale: 1.1 }, "+=0.4");
+```
+
+Use labels for scenes:
+
+```js
+tl.addLabel("scene-1", 0);
+tl.from("#s1-title", { y: 48, opacity: 0 }, "scene-1+=0.2");
+tl.addLabel("scene-2", 6.8);
+tl.from("#s2-title", { x: -40, opacity: 0 }, "scene-2+=0.25");
+```
+
+## Nesting timelines
+
+```js
+const master = gsap.timeline({ paused: true });
+const child = gsap.timeline();
+child.to(".a", { x: 100 }).to(".b", { y: 50 });
+master.add(child, 0);
+```
+
+In HyperFrames, do not manually add sub-composition timelines to a parent. The framework auto-nests them.
+
+## Playback control
+
+```js
+tl.play();
+tl.pause();
+tl.reverse();
+tl.restart();
+tl.time(2);
+tl.progress(0.5);
+tl.kill();
+```

--- a/Community/hyperframes-cli/DISPLAY.json
+++ b/Community/hyperframes-cli/DISPLAY.json
@@ -1,0 +1,5 @@
+{
+  "specVersion": "0.2.0",
+  "icon": "terminal",
+  "tags": ["video", "cli", "hyperframes", "tooling"]
+}

--- a/Community/hyperframes-cli/SKILL.md
+++ b/Community/hyperframes-cli/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: hyperframes-cli
+description: |
+  Command workflow for HyperFrames projects using npx hyperframes: init, lint, validate, inspect, preview, render, transcribe, TTS, doctor, and handoff URLs. Use whenever operating the HyperFrames CLI.
+compatibility: Created for Zo Computer
+metadata:
+  author: jeffkazzee.zo.computer
+  category: Video
+---
+
+# HyperFrames CLI
+
+## Usage
+
+Use this skill whenever the workflow requires `npx hyperframes` commands — scaffolding (`init`), validation (`lint`, `validate`, `inspect`), preview, render, TTS, transcription, or diagnostics. Requires Node 22+ and network access on first run. The full command surface lives in `references/commands.md`; consult it before running anything other than the obvious `lint`/`validate`/`inspect`.
+
+Everything runs through `npx hyperframes`. Requires Node.js >= 22 and FFmpeg.
+
+## Standard workflow
+
+1. Scaffold: `npx hyperframes init <project>`.
+2. Author HTML/CSS/GSAP composition using the `hyperframes` skill.
+3. Lint: `npx hyperframes lint`.
+4. Validate: `npx hyperframes validate`.
+5. Visual inspect: `npx hyperframes inspect`.
+6. Preview: `npx hyperframes preview --port <port>`.
+7. Render only on explicit request: `npx hyperframes render`.
+
+Lint and inspect before preview. Render after preview approval unless the user explicitly asked for an MP4.
+
+## Scaffold
+
+```bash
+npx hyperframes init my-video
+npx hyperframes init my-video --example warm-grain
+npx hyperframes init my-video --video clip.mp4
+npx hyperframes init my-video --audio track.mp3
+npx hyperframes init my-video --non-interactive
+```
+
+Templates: `blank`, `warm-grain`, `play-mode`, `swiss-grid`, `vignelli`, `decision-tree`, `kinetic-type`, `product-promo`, `nyt-graph`.
+
+Use `init` instead of hand-building a project. It creates structure, copies media, can transcribe audio, and installs AI coding skills.
+
+## Lint and validate
+
+```bash
+npx hyperframes lint
+npx hyperframes lint ./my-project
+npx hyperframes lint --verbose
+npx hyperframes lint --json
+
+npx hyperframes validate
+npx hyperframes validate --no-contrast
+```
+
+Lint catches missing `data-composition-id`, overlapping tracks, bad attributes, and unregistered timelines. Validate includes WCAG contrast checks by default.
+
+## Visual inspect
+
+```bash
+npx hyperframes inspect
+npx hyperframes inspect ./my-project
+npx hyperframes inspect --json
+npx hyperframes inspect --samples 15
+npx hyperframes inspect --at 1.5,4,7.25
+```
+
+Use this after lint and validate, especially with speech bubbles, cards, captions, tight typography, and dynamic text. `npx hyperframes layout` is a compatibility alias.
+
+## Preview handoff
+
+```bash
+npx hyperframes preview
+npx hyperframes preview --port 4567
+```
+
+When handing a project back, report the Studio project URL:
+
+```text
+http://localhost:<port>/#project/<project-name>
+```
+
+Use the actual port from preview output and the project directory name. Do not hand off `index.html` as the preview surface.
+
+## Rendering
+
+```bash
+npx hyperframes render
+npx hyperframes render --output final.mp4
+npx hyperframes render --quality draft
+npx hyperframes render --fps 60 --quality high
+npx hyperframes render --format webm
+npx hyperframes render --docker
+```
+
+Quality guidance: draft for iteration, standard for review, high for final delivery. 60fps roughly doubles render cost.
+
+## Audio, transcription, and TTS
+
+```bash
+npx hyperframes transcribe audio.mp3
+npx hyperframes transcribe video.mp4 --model medium.en --language en
+npx hyperframes transcribe subtitles.srt
+npx hyperframes transcribe subtitles.vtt
+npx hyperframes transcribe openai-response.json
+
+npx hyperframes tts "Text here" --voice af_nova --output narration.wav
+npx hyperframes tts script.txt --voice bf_emma
+npx hyperframes tts --list
+```
+
+## Troubleshooting
+
+```bash
+npx hyperframes doctor
+npx hyperframes browser
+npx hyperframes info
+npx hyperframes upgrade
+npx hyperframes compositions
+npx hyperframes docs
+npx hyperframes benchmark .
+```
+
+Run `doctor` first if rendering fails. Common issues: missing FFmpeg, missing Chrome, low memory, wrong Node version.
+
+## Reference
+
+Read `references/commands.md` for command details and flags.

--- a/Community/hyperframes-cli/references/commands.md
+++ b/Community/hyperframes-cli/references/commands.md
@@ -1,0 +1,110 @@
+# HyperFrames Commands
+
+## Init
+
+```bash
+npx hyperframes init my-video
+npx hyperframes init my-video --example warm-grain
+npx hyperframes init my-video --video clip.mp4
+npx hyperframes init my-video --audio track.mp3
+npx hyperframes init my-video --non-interactive
+```
+
+Examples: `blank`, `warm-grain`, `play-mode`, `swiss-grid`, `vignelli`, `decision-tree`, `kinetic-type`, `product-promo`, `nyt-graph`.
+
+## Lint
+
+```bash
+npx hyperframes lint
+npx hyperframes lint ./my-project
+npx hyperframes lint --verbose
+npx hyperframes lint --json
+```
+
+## Validate
+
+```bash
+npx hyperframes validate
+npx hyperframes validate --no-contrast
+```
+
+Use `--no-contrast` only during rapid iteration.
+
+## Inspect
+
+```bash
+npx hyperframes inspect
+npx hyperframes inspect ./my-project
+npx hyperframes inspect --json
+npx hyperframes inspect --samples 15
+npx hyperframes inspect --at 1.5,4,7.25
+```
+
+`npx hyperframes layout` is an alias.
+
+## Preview
+
+```bash
+npx hyperframes preview
+npx hyperframes preview --port 4567
+```
+
+Handoff URL:
+
+```text
+http://localhost:<port>/#project/<project-name>
+```
+
+## Render
+
+```bash
+npx hyperframes render
+npx hyperframes render --output final.mp4
+npx hyperframes render --quality draft
+npx hyperframes render --fps 60 --quality high
+npx hyperframes render --format webm
+npx hyperframes render --docker
+npx hyperframes render --gpu
+npx hyperframes render --strict
+npx hyperframes render --strict-all
+```
+
+Flags:
+
+| Flag | Options | Default | Notes |
+|---|---|---|---|
+| `--output` | path | `renders/name_timestamp.mp4` | Output path |
+| `--fps` | 24, 30, 60 | 30 | 60fps doubles render time |
+| `--quality` | draft, standard, high | standard | draft for iteration |
+| `--format` | mp4, webm | mp4 | WebM supports transparency |
+| `--workers` | 1-8 or auto | auto | Each spawns Chrome |
+| `--docker` | flag | off | Reproducible output |
+| `--gpu` | flag | off | GPU encoding |
+| `--strict` | flag | off | Fail on lint errors |
+| `--strict-all` | flag | off | Fail on errors and warnings |
+
+## Transcribe and TTS
+
+```bash
+npx hyperframes transcribe audio.mp3
+npx hyperframes transcribe video.mp4 --model medium.en --language en
+npx hyperframes transcribe subtitles.srt
+npx hyperframes transcribe subtitles.vtt
+npx hyperframes transcribe openai-response.json
+
+npx hyperframes tts "Text here" --voice af_nova --output narration.wav
+npx hyperframes tts script.txt --voice bf_emma
+npx hyperframes tts --list
+```
+
+## Troubleshooting
+
+```bash
+npx hyperframes doctor
+npx hyperframes browser
+npx hyperframes info
+npx hyperframes upgrade
+npx hyperframes compositions
+npx hyperframes docs
+npx hyperframes benchmark .
+```

--- a/Community/hyperframes-registry/DISPLAY.json
+++ b/Community/hyperframes-registry/DISPLAY.json
@@ -1,0 +1,5 @@
+{
+  "specVersion": "0.2.0",
+  "icon": "package",
+  "tags": ["video", "hyperframes", "registry", "components"]
+}

--- a/Community/hyperframes-registry/SKILL.md
+++ b/Community/hyperframes-registry/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: hyperframes-registry
+description: |
+  Use when working with the HyperFrames registry, `hyperframes add`, blocks, components, registry manifests, install locations, or wiring installed HyperFrames items into a composition.
+compatibility: Created for Zo Computer
+metadata:
+  author: jeffkazzee.zo.computer
+  category: Video
+---
+
+# HyperFrames Registry
+
+## Usage
+
+Use this skill when the agent should install or wire HyperFrames blocks/components instead of writing them from scratch. Start with `references/discovery.md` to inspect the registry manifest, then `references/wiring-blocks.md` for sub-composition installs or `references/wiring-components.md` for snippet installs. `references/install-locations.md` covers the on-disk layout `hyperframes add` uses.
+
+The registry provides reusable blocks and components installable with `hyperframes add <name>`.
+
+## When to use
+
+Use this skill when:
+
+- The user mentions `hyperframes add`, blocks, components, registry, or `hyperframes.json`.
+- CLI output from `hyperframes add` appears in the session.
+- You need to wire an installed item into an existing composition.
+- You want to discover what is available in the registry.
+
+## Blocks vs components
+
+- **Blocks** are standalone sub-compositions. They have their own dimensions, duration, and timeline. Include them with `data-composition-src`.
+- **Components** are effect snippets. They do not own dimensions. Paste their HTML/CSS/JS into a host composition.
+
+## Quick commands
+
+```bash
+hyperframes add data-chart
+hyperframes add grain-overlay
+hyperframes add data-chart --dir .
+hyperframes add data-chart --json
+hyperframes add data-chart --no-clipboard
+```
+
+The CLI prints written files and a paste snippet. The snippet is only a starting point. You still need to add or verify `data-composition-id`, `data-start`, `data-duration`, `data-track-index`, `data-width`, and `data-height`.
+
+## Install locations
+
+By default:
+
+- Blocks: `compositions/<name>.html`
+- Components: `compositions/components/<name>.html`
+
+Configurable in `hyperframes.json`:
+
+```json
+{
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "paths": {
+    "blocks": "compositions",
+    "components": "compositions/components",
+    "assets": "assets"
+  }
+}
+```
+
+## Wiring a block
+
+```html
+<div
+  data-composition-id="data-chart"
+  data-composition-src="compositions/data-chart.html"
+  data-start="2"
+  data-duration="15"
+  data-track-index="1"
+  data-width="1920"
+  data-height="1080"
+></div>
+```
+
+`data-composition-id` must match the block's internal composition ID.
+
+## Wiring a component
+
+1. Read the installed component file, usually `compositions/components/<name>.html`.
+2. Copy HTML elements into the host composition's `div[data-composition-id]`.
+3. Copy styles into the host style block.
+4. Copy script content before your timeline code if the component has JS.
+5. If the snippet exposes timeline integration hooks, add those calls to the host timeline.
+
+## Discovery
+
+```bash
+curl -s https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry/registry.json
+```
+
+Each `registry-item.json` contains name, type, title, description, tags, dimensions, duration, and file list.
+
+## References
+
+- `references/discovery.md` — finding items by type and tag.
+- `references/wiring-blocks.md` — complete block wiring rules.
+- `references/wiring-components.md` — component paste and timeline integration.
+- `references/install-locations.md` — custom registry paths.

--- a/Community/hyperframes-registry/references/discovery.md
+++ b/Community/hyperframes-registry/references/discovery.md
@@ -1,0 +1,26 @@
+# HyperFrames Registry Discovery
+
+Read the registry manifest:
+
+```bash
+curl -s https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry/registry.json
+```
+
+Inspect item metadata:
+
+- name
+- type: block or component
+- title
+- description
+- tags
+- dimensions, for blocks
+- duration, for blocks
+- file list
+
+Filter mentally by need:
+
+- Scene-level reusable piece: block.
+- Effect inside existing scene: component.
+- Data visualization: search tags like `data`, `chart`, `graph`.
+- Texture: search `grain`, `noise`, `overlay`.
+- Emphasis: search `highlight`, `marker`, `annotation`.

--- a/Community/hyperframes-registry/references/install-locations.md
+++ b/Community/hyperframes-registry/references/install-locations.md
@@ -1,0 +1,28 @@
+# Install Locations
+
+Default registry paths:
+
+- Blocks: `compositions/<name>.html`
+- Components: `compositions/components/<name>.html`
+- Assets: `assets/`
+
+Configurable in `hyperframes.json`:
+
+```json
+{
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "paths": {
+    "blocks": "compositions",
+    "components": "compositions/components",
+    "assets": "assets"
+  }
+}
+```
+
+When targeting a specific project:
+
+```bash
+hyperframes add grain-overlay --dir /path/to/project
+```
+
+Use `--json` when scripting and `--no-clipboard` in headless/CI contexts.

--- a/Community/hyperframes-registry/references/wiring-blocks.md
+++ b/Community/hyperframes-registry/references/wiring-blocks.md
@@ -1,0 +1,32 @@
+# Wiring Blocks
+
+Blocks are standalone sub-compositions.
+
+## Include pattern
+
+```html
+<div
+  data-composition-id="data-chart"
+  data-composition-src="compositions/data-chart.html"
+  data-start="2"
+  data-duration="15"
+  data-track-index="1"
+  data-width="1920"
+  data-height="1080"
+></div>
+```
+
+## Required checks
+
+- `data-composition-id` matches the block's internal composition ID.
+- `data-composition-src` points to the installed file.
+- `data-start` aligns with host timeline and transitions.
+- `data-duration` fits the host scene.
+- Same-track clips do not overlap.
+- CSS `z-index` handles visual layer; `data-track-index` is timing track, not z-order.
+
+## Do not
+
+- Manually add the block timeline to the parent timeline.
+- Wrap media inside timed containers that fight the framework.
+- Assume CLI paste snippets are finished.

--- a/Community/hyperframes-registry/references/wiring-components.md
+++ b/Community/hyperframes-registry/references/wiring-components.md
@@ -1,0 +1,19 @@
+# Wiring Components
+
+Components are snippets pasted into a host composition.
+
+## Process
+
+1. Read installed component file, usually `compositions/components/<name>.html`.
+2. Copy component HTML into the host `div[data-composition-id]`.
+3. Copy component CSS into the host style block.
+4. Copy component JS before the host timeline code if needed.
+5. Add component animation calls to the host timeline if the snippet exposes them.
+6. Run lint, validate, and inspect.
+
+## Integration checks
+
+- Class names do not collide with host scene names.
+- Component colors come from `DESIGN.md` variables or palette.
+- Component motion does not conflict with existing tweens on the same properties.
+- Decorative overflow is marked `data-layout-ignore` if inspect should ignore it.

--- a/Community/hyperframes/DISPLAY.json
+++ b/Community/hyperframes/DISPLAY.json
@@ -1,0 +1,5 @@
+{
+  "specVersion": "0.2.0",
+  "icon": "film",
+  "tags": ["video", "animation", "html", "gsap", "hyperframes"]
+}

--- a/Community/hyperframes/SKILL.md
+++ b/Community/hyperframes/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: hyperframes
+description: |
+  Primary workflow skill for creating and editing HyperFrames videos: HTML compositions with data-* timing attributes, GSAP timelines, CSS layout, scene transitions, validation, visual inspection, and preview handoff. Use whenever the user asks to make, edit, validate, storyboard, or render a HyperFrames video.
+compatibility: Created for Zo Computer
+metadata:
+  author: jeffkazzee.zo.computer
+  category: Video
+---
+
+# HyperFrames
+
+## Usage
+
+Install this skill into your Zo workspace and the agent will route HyperFrames video work through it. Invoke implicitly by asking for a new HyperFrames project, edits to an existing composition, animation map / inspection, or video validation. The skill loads only the references it needs per task — start with `references/composition-contract.md` for any new HTML, `references/visual-identity-gate.md` before writing styles, and `references/quality-checks.md` before handing the project back.
+
+Companion skills: `gsap`, `hyperframes-cli`, `hyperframes-registry`, `website-to-video`. Install the ones you need; this skill calls out which one applies per step.
+
+HyperFrames videos are authored as HTML. The HTML is the source of truth: data attributes define timing, CSS defines the finished frame, and GSAP defines motion. The framework owns clip visibility, media playback, and timeline sync.
+
+## Always start here
+
+For any new or significant video task:
+
+1. Read the project docs if the video already exists: `README.md`, `DESIGN.md`, `visual-style.md`, `SCRIPT.md`, `STORYBOARD.md`, and existing composition HTML.
+2. Read `references/composition-contract.md` before writing or editing composition HTML.
+3. Read `references/visual-identity-gate.md` before any new composition.
+4. For multi-scene work, read `references/transitions.md`.
+5. For text-heavy work, read `references/typography.md`.
+6. Use the companion skills as needed:
+   - `gsap` for tween/timeline choreography.
+   - `hyperframes-cli` for scaffold/lint/inspect/preview/render.
+   - `hyperframes-registry` for `hyperframes add`, blocks, and components.
+   - `website-to-video` when starting from a URL.
+
+Small edits may skip the full workflow, but not the relevant rule. A color tweak still must respect `DESIGN.md`. A timing tweak still must preserve the timeline contract.
+
+## Core workflow
+
+1. **What** — define what the viewer should experience: narrative arc, key moments, emotional beats.
+2. **Structure** — decide compositions, sub-compositions, tracks, captions, overlays, audio, and video.
+3. **Timing** — determine clip durations, transitions, beat pacing, and which media drives length.
+4. **Layout** — build the end-state first. Every scene must look correct as static HTML/CSS at its hero frame before animation.
+5. **Animate** — add entrances, transitions, and final-scene exits using GSAP.
+6. **Validate** — run lint, validate, inspect, and animation-map when applicable.
+7. **Preview handoff** — give the HyperFrames Studio URL first. Render MP4 only when explicitly requested.
+
+## Non-negotiables
+
+- Every composition must have a visual identity source: `DESIGN.md`, `visual-style.md`, or explicit user direction.
+- Layout comes before animation. CSS defines the final visible position; GSAP animates from or to that state.
+- All timelines use `{ paused: true }` and register synchronously at `window.__timelines[compositionId]`.
+- Duration comes from `data-duration`, not empty GSAP tweens.
+- Video is muted and `playsinline`; audio uses a separate `<audio>` element.
+- Use `data-track-index`, never `data-layer`. Use `data-duration`, never `data-end`.
+- No `Math.random()`, `Date.now()`, async timeline construction, `setTimeout`, promises, or media `.play()`/`.pause()` calls.
+- No `repeat: -1`; calculate finite repeat counts.
+- Do not animate layout properties when transforms work.
+- Do not animate a video element's dimensions. Animate a wrapper.
+- Multi-scene compositions always use transitions. No jump cuts.
+- Every scene element enters via `gsap.from()`. No fully-formed elements appearing from nowhere.
+- No exit animations before scene transitions. The transition is the exit. Only the final scene may fade or animate out.
+- Do not use `<template>` in a standalone root `index.html`. Use `<template>` only for sub-composition files.
+
+## Output checklist
+
+Before calling work done:
+
+- `npx hyperframes lint` passes.
+- `npx hyperframes validate` passes with zero errors; contrast warnings are addressed, not ignored.
+- `npx hyperframes inspect` passes, or intentional overflows are marked with `data-layout-allow-overflow` / `data-layout-ignore`.
+- For new compositions or major animation work, run the animation map and review every flag.
+- Provide the active Studio URL: `http://localhost:<port>/#project/<project-name>`.
+- Do not label `index.html` as the preview surface. It is source code, not the project handoff.
+
+## Reference map
+
+- `references/composition-contract.md` — timing attributes, composition structure, media rules, timeline contract.
+- `references/visual-identity-gate.md` — required design source before writing HTML.
+- `references/layout-before-animation.md` — static hero-frame-first layout process.
+- `references/transitions.md` — multi-scene transition rules and patterns.
+- `references/typography.md` — typography, fitText, caption/text sizing rules.
+- `references/quality-checks.md` — lint, validate, inspect, contrast, animation-map.
+- `references/captions.md` — captions, subtitles, lyrics, and karaoke timing.
+- `references/tts.md` — text-to-speech workflow.
+- `references/audio-reactive.md` — audio-reactive animation guidance.
+- `references/css-patterns.md` — deterministic CSS/GSAP emphasis effects.
+- `references/motion-principles.md` — choreography, pacing, easing, and anti-patterns.
+- `references/visual-styles.md` — named visual styles for generating `DESIGN.md`.
+- `references/house-style.md` — default motion/sizing/style when no style is provided.
+- `references/patterns.md` — PiP, title cards, slideshow, data, and product patterns.

--- a/Community/hyperframes/references/audio-reactive.md
+++ b/Community/hyperframes/references/audio-reactive.md
@@ -1,0 +1,25 @@
+# Audio-Reactive Animation
+
+Use this when visuals should respond to music, voice, or sound.
+
+## Rules
+
+- Keep it deterministic and seekable.
+- Precompute audio features when possible instead of live random behavior.
+- Map only a few properties: scale, y, opacity, glow strength, stroke width, or CSS variables.
+- Do not let audio-reactive motion compete with captions or narration.
+
+## Bands
+
+- Low band: bass, impact, scale pulses, shadow bloom.
+- Mid band: voice/body, card emphasis, waveform thickness.
+- High band: sparkle, line flicker, particle accents.
+
+## Good mappings
+
+```js
+tl.to(".pulse", { scale: 1.08, duration: 0.12, ease: "power2.out" }, beatTime);
+tl.to(".pulse", { scale: 1, duration: 0.22, ease: "sine.out" }, beatTime + 0.12);
+```
+
+Use exact beat times from analysis or transcript. Avoid frame-by-frame noise unless the effect is intentionally raw.

--- a/Community/hyperframes/references/audio-visualizer-placeholder.md
+++ b/Community/hyperframes/references/audio-visualizer-placeholder.md
@@ -1,0 +1,5 @@
+# Effects Placeholder
+
+This skill stack includes the routing point for drop-in HyperFrames effects. If a project needs a ready-made typewriter, visualizer, waveform, particle accent, or shader-style emphasis, first inspect existing project components and the HyperFrames registry before writing custom code.
+
+Use `hyperframes-registry` to search and install blocks/components when available.

--- a/Community/hyperframes/references/captions.md
+++ b/Community/hyperframes/references/captions.md
@@ -1,0 +1,39 @@
+# Captions and Subtitles
+
+Use this when adding captions, subtitles, lyrics, karaoke text, or transcript-synced typography.
+
+## Principles
+
+- Captions are design elements, not afterthoughts.
+- Use real transcript timing when available.
+- Group words into readable phrases unless karaoke emphasis is the point.
+- Captions must never clip, overlap key visuals, or drift off safe areas.
+
+## Placement
+
+- Landscape: bottom safe area, usually 96-140px from bottom.
+- Portrait: lower third, but leave room for platform UI if targeting TikTok/Reels/Stories.
+- Keep captions inside a `max-width` container.
+- Avoid absolute top/left caption placement unless the shot demands it.
+
+## Styling
+
+- 34-48px for landscape captions.
+- 42-64px for portrait captions.
+- Use high contrast and validate.
+- Consider translucent backing, shadow, stroke, or blur card only when needed.
+- Do not use generic black boxes unless the aesthetic calls for broadcast-style captions.
+
+## Animation
+
+- Caption entrance must align with speech timing.
+- Word-level highlight can use `color`, `backgroundColor`, `scale`, or clipping masks.
+- Captions must have guaranteed exit before the next caption occupies the same space.
+- Avoid long fade-outs that linger under new words.
+
+## Overflow prevention
+
+- Use `max-width`.
+- Use natural wrapping.
+- Avoid `<br>` except deliberate short title cards.
+- For dynamic lines, use `window.__hyperframes.fitTextFontSize(...)`.

--- a/Community/hyperframes/references/composition-contract.md
+++ b/Community/hyperframes/references/composition-contract.md
@@ -1,0 +1,114 @@
+# HyperFrames Composition Contract
+
+## Source of truth
+
+A HyperFrames video is HTML. A composition is an HTML file with:
+
+- `data-*` attributes for timing and media sync.
+- CSS for final visual layout.
+- A GSAP timeline for animation.
+
+The framework handles clip visibility, media playback, and timeline sync.
+
+## Data attributes
+
+### All clips
+
+| Attribute | Required | Values |
+|---|---:|---|
+| `id` | yes | Unique identifier |
+| `data-start` | yes | Seconds or clip ID reference: `"el-1"`, `"intro + 2"` |
+| `data-duration` | required for img/div/compositions | Seconds. Video/audio defaults to media duration. |
+| `data-track-index` | yes | Integer. Same-track clips cannot overlap. |
+| `data-media-start` | no | Trim offset into source, seconds |
+| `data-volume` | no | 0-1, default 1 |
+
+`data-track-index` does not control visual stacking. Use CSS `z-index`.
+
+### Composition clips
+
+| Attribute | Required | Values |
+|---|---:|---|
+| `data-composition-id` | yes | Unique composition ID |
+| `data-start` | yes | Root composition uses `0` |
+| `data-duration` | yes | Takes precedence over GSAP timeline length |
+| `data-width` / `data-height` | yes | `1920x1080`, `1080x1920`, etc. |
+| `data-composition-src` | no | Path to external HTML file |
+
+## Standalone vs sub-composition structure
+
+Standalone `index.html` must not wrap the root composition in `<template>`:
+
+```html
+<body>
+  <div data-composition-id="main" data-start="0" data-duration="10" data-width="1920" data-height="1080">
+    <!-- content -->
+  </div>
+</body>
+```
+
+Sub-compositions loaded via `data-composition-src` use a `<template>` wrapper:
+
+```html
+<template id="my-comp-template">
+  <div data-composition-id="my-comp" data-width="1920" data-height="1080">
+    <!-- content -->
+    <style>
+      [data-composition-id="my-comp"] { }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      window.__timelines["my-comp"] = tl;
+    </script>
+  </div>
+</template>
+```
+
+Root inclusion:
+
+```html
+<div
+  id="el-1"
+  data-composition-id="my-comp"
+  data-composition-src="compositions/my-comp.html"
+  data-start="0"
+  data-duration="10"
+  data-track-index="1"
+></div>
+```
+
+## Video and audio
+
+Video must be muted and `playsinline`. Audio is always separate:
+
+```html
+<video id="el-v" data-start="0" data-duration="30" data-track-index="0" src="video.mp4" muted playsinline></video>
+<audio id="el-a" data-start="0" data-duration="30" data-track-index="2" src="video.mp4" data-volume="1"></audio>
+```
+
+Add `crossorigin="anonymous"` to external media.
+
+## Timeline contract
+
+- All timelines start `{ paused: true }`.
+- Register every timeline: `window.__timelines["<composition-id>"] = tl`.
+- Framework auto-nests sub-timelines. Do not manually add them.
+- Duration comes from `data-duration`, not GSAP timeline length.
+- Never create empty tweens to set duration.
+
+## Never do this
+
+- Forget `window.__timelines` registration.
+- Use video for audio.
+- Nest video inside a timed div. Use a non-timed wrapper.
+- Use `data-layer`; use `data-track-index`.
+- Use `data-end`; use `data-duration`.
+- Animate video element dimensions. Animate a wrapper.
+- Call media play/pause/seek.
+- Create a top-level container without `data-composition-id`.
+- Use `repeat: -1`.
+- Build timelines asynchronously.
+- Use `gsap.set()` on future clip elements at page load; use `tl.set()` at or after the clip start.
+- Use `<br>` in normal content text. Let text wrap via max-width. Exception: deliberate short display titles.

--- a/Community/hyperframes/references/css-patterns.md
+++ b/Community/hyperframes/references/css-patterns.md
@@ -1,0 +1,37 @@
+# CSS + GSAP Emphasis Patterns
+
+Use these for deterministic visual emphasis.
+
+## Highlight sweep
+
+HTML:
+
+```html
+<span class="mark">important phrase</span>
+```
+
+CSS:
+
+```css
+.mark {
+  background: linear-gradient(90deg, var(--accent) 0 0) left bottom / 0% 0.24em no-repeat;
+}
+```
+
+GSAP:
+
+```js
+tl.to(".mark", { backgroundSize: "100% 0.24em", duration: 0.42, ease: "power3.out" }, 1.2);
+```
+
+## Circle annotation
+
+Use SVG with `stroke-dasharray` and animate `strokeDashoffset`.
+
+## Burst
+
+Use a fixed set of lines or dots. No random generation. If variety is needed, use a seeded PRNG.
+
+## Sketchout
+
+Animate clip-path or SVG stroke, but keep it readable. A scribble that hides the word is not emphasis; it is sabotage.

--- a/Community/hyperframes/references/effects.md
+++ b/Community/hyperframes/references/effects.md
@@ -1,0 +1,60 @@
+# HyperFrames Effects
+
+Use these as starting patterns when a project needs reusable visual effects. Prefer registry components when available.
+
+## Typewriter
+
+Use only for short text.
+
+```js
+const text = "Make the invisible obvious.";
+const state = { n: 0 };
+const el = document.querySelector(".typewriter");
+tl.to(state, {
+  n: text.length,
+  duration: 1.1,
+  ease: "none",
+  onUpdate: () => {
+    el.textContent = text.slice(0, Math.round(state.n));
+  }
+}, 0.4);
+```
+
+## Visualizer bars
+
+Use deterministic values.
+
+```js
+const pattern = [0.4, 0.9, 0.62, 1, 0.55, 0.76];
+tl.to(".bar", {
+  scaleY: (i) => pattern[i % pattern.length],
+  transformOrigin: "50% 100%",
+  duration: 0.18,
+  stagger: 0.035,
+  yoyo: true,
+  repeat: 8,
+  ease: "sine.inOut"
+}, 0.2);
+```
+
+## Grain overlay
+
+Prefer a CSS texture or registry component. Mark decorative overlays with `data-layout-ignore` so inspect does not audit them.
+
+## Light sweep
+
+```css
+.sweep::after {
+  content: "";
+  position: absolute;
+  inset: -20%;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,.28), transparent);
+  transform: translateX(-120%) rotate(12deg);
+}
+```
+
+```js
+tl.to(".sweep::after", { xPercent: 240, duration: 0.9, ease: "power3.inOut" }, 2.1);
+```
+
+Pseudo-elements can be awkward to animate directly. If needed, use a real child element instead.

--- a/Community/hyperframes/references/house-style.md
+++ b/Community/hyperframes/references/house-style.md
@@ -1,0 +1,42 @@
+# HyperFrames House Style
+
+Use this only when the project lacks explicit animation direction. Visual identity still comes from `DESIGN.md` or `visual-style.md`.
+
+## Default motion
+
+- First scene motion starts at 0.15s.
+- Primary headline: `y: 48`, `opacity: 0`, `duration: 0.72`, `ease: "expo.out"`.
+- Supporting text: `y: 28`, `opacity: 0`, `duration: 0.52`, `ease: "power3.out"`.
+- Cards: `y: 36`, `scale: 0.96`, `opacity: 0`, `duration: 0.56`, `ease: "back.out(1.25)"`.
+- Small labels: `y: 14`, `opacity: 0`, `duration: 0.34`, `ease: "power2.out"`.
+- Decoratives: slower, lower opacity, ambient only after content is readable.
+
+## Default spacing
+
+Use a 4px base scale: 4, 8, 12, 16, 24, 32, 48, 64, 96, 128, 160.
+
+For 1920x1080:
+
+- Safe outer padding: 96-160px.
+- Dense data padding: 72-112px.
+- Caption bottom safe area: 96-140px.
+
+For 1080x1920:
+
+- Safe outer padding: 72-96px.
+- Keep primary content between 18% and 78% of height unless the format is intentionally poster-like.
+
+## Default text hierarchy
+
+- Hero title: 96-150px.
+- Section title: 64-96px.
+- Body: 28-42px.
+- Caption: 34-48px.
+- Label: 18-24px.
+
+## Default visual treatment
+
+- Prefer solid canvas plus localized glow, grain, or physical texture.
+- Avoid full-screen dark linear gradients.
+- Use depth layers: background texture, soft shape, main content, annotations, transition layer.
+- Keep accents constrained. One accent should do a job, not wander around like a lost intern.

--- a/Community/hyperframes/references/layout-before-animation.md
+++ b/Community/hyperframes/references/layout-before-animation.md
@@ -1,0 +1,59 @@
+# Layout Before Animation
+
+Position every element where it should be at its most visible moment: the hero frame. Write static HTML and CSS first. Add GSAP only after the layout works.
+
+## Why
+
+If you position elements at their animated start state, offscreen or invisible, you are guessing the final layout. Overlaps and clipping appear only after render. Build the end state first so layout problems are visible before motion hides them.
+
+## Process
+
+1. Identify the hero frame for each scene: the moment when the most important elements are simultaneously visible.
+2. Write static CSS for that frame.
+3. Ensure `.scene-content` fills the scene:
+
+```css
+.scene-content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 120px 160px;
+  gap: 24px;
+  box-sizing: border-box;
+}
+```
+
+4. Use padding to push content inward. Do not absolutely position a main content container with hardcoded `top` and `left`.
+5. Use `position: absolute` for decoratives, overlays, and depth layers only.
+6. Add entrances with `gsap.from()` from offscreen/invisible to the CSS position.
+7. Add exits only on the final scene. For multi-scene videos, transitions handle scene exits.
+
+## Wrong
+
+```css
+.scene-content {
+  position: absolute;
+  top: 200px;
+  left: 160px;
+  width: 1920px;
+  height: 1080px;
+}
+```
+
+This breaks across canvas sizes and causes overflow when content changes.
+
+## Correct entrance pattern
+
+```js
+tl.from(".title", { y: 60, opacity: 0, duration: 0.6, ease: "power3.out" }, 0.2);
+tl.from(".subtitle", { y: 40, opacity: 0, duration: 0.5, ease: "power2.out" }, 0.45);
+tl.from(".logo", { scale: 0.8, opacity: 0, duration: 0.4, ease: "back.out(1.4)" }, 0.65);
+```
+
+CSS defines the landing positions. Tween values define the journey.
+
+## Intentional overlap
+
+Layered glow, shadows, cards, z-stacks, highlight marks, and depth layers may overlap intentionally. The layout pass catches accidental overlap: headline over stat, label under card, caption off-frame, etc.

--- a/Community/hyperframes/references/motion-principles.md
+++ b/Community/hyperframes/references/motion-principles.md
@@ -1,0 +1,53 @@
+# Motion Principles
+
+Motion is not decoration. It tells the viewer where to look and how to feel.
+
+## Easing as emotion
+
+- `power2.out` — clean, reliable, neutral.
+- `power3.out` — confident entrance.
+- `expo.out` — decisive, high-end, editorial.
+- `back.out(1.2-1.7)` — playful or tactile.
+- `elastic.out(1, 0.3)` — use sparingly; it can become clown furniture.
+- `sine.inOut` — ambient, breathing, gentle loops.
+- `none` — mechanical, data, scanline, progress.
+
+## Timing as weight
+
+- Fast objects feel light.
+- Slow objects feel heavy or important.
+- 0.2s is a flick.
+- 0.5-0.8s is a readable entrance.
+- 1.0s+ is cinematic or heavy. Use intentionally.
+
+## Choreography as hierarchy
+
+The most important element should either move first, move most, or settle last. Do not animate everything with identical timing unless the point is synchronized force.
+
+## Scene pacing
+
+- Give the first scene 0.1-0.3s before first motion.
+- Avoid dead zones longer than 1s unless holding for narration or emphasis.
+- Layer motion: primary, secondary, ambient.
+- Do not make every element bounce. The viewer has eyes, not a pinball machine.
+
+## Ambient motion
+
+Ambient motion should be finite in HyperFrames. Calculate repeat count from duration:
+
+```js
+const cycleDuration = 2.4;
+const repeats = Math.ceil(sceneDuration / cycleDuration) - 1;
+tl.to(".orb", { y: -12, duration: cycleDuration / 2, yoyo: true, repeat: repeats, ease: "sine.inOut" }, 0);
+```
+
+Never use `repeat: -1`.
+
+## Anti-patterns
+
+- Same entrance on every element.
+- Animating layout properties instead of transforms.
+- Hiding outgoing scenes before transitions.
+- Slow fades everywhere.
+- Motion without narrative purpose.
+- Motion so busy it fights narration.

--- a/Community/hyperframes/references/patterns.md
+++ b/Community/hyperframes/references/patterns.md
@@ -1,0 +1,41 @@
+# HyperFrames Patterns
+
+## Title card
+
+Use for opening hooks and section breaks.
+
+- One dominant typographic idea.
+- One supporting line or label.
+- Entrance: primary title first, support second, accent last.
+- Transition out handles exit.
+
+## Picture-in-picture
+
+Use for product tours or website capture.
+
+- Background carries brand atmosphere.
+- PiP frame carries website/media.
+- Add motion to the wrapper, not the video/image itself.
+- Use pointer, zoom crop, or annotation sparingly.
+
+## Slideshow
+
+Use only if each slide has motion purpose.
+
+- Image wrapper gets parallax, scale, mask reveal, or depth.
+- Text gets independent entrance.
+- Transition between slides must bridge the beat.
+
+## Product promo
+
+- Hook: problem or promise.
+- Proof: interface, result, or concrete detail.
+- Mechanism: show the feature.
+- Close: memorable line or CTA.
+
+## Data in motion
+
+- Numbers use tabular numerals.
+- Animate count-ups only if the number matters.
+- Prefer line drawing, bar growth, or panel shifts over decoration.
+- Labels must remain readable throughout the animation.

--- a/Community/hyperframes/references/quality-checks.md
+++ b/Community/hyperframes/references/quality-checks.md
@@ -1,0 +1,80 @@
+# Quality Checks
+
+Run these before handing back a HyperFrames project.
+
+## Required commands
+
+```bash
+npx hyperframes lint
+npx hyperframes validate
+npx hyperframes inspect
+```
+
+For new compositions and significant animation changes, also run the animation map:
+
+```bash
+node /home/workspace/Skills/hyperframes/scripts/animation-map.mjs <composition-dir> --out <composition-dir>/.hyperframes/anim-map
+```
+
+If the project has its own installed animation-map script, use the project-local version.
+
+## Lint
+
+Lint catches structural problems:
+
+- Missing `data-composition-id`.
+- Overlapping same-track clips.
+- Bad timing attributes.
+- Unregistered timelines.
+- Deprecated attributes like `data-layer` or `data-end`.
+
+Fix errors. Warnings should be fixed unless explicitly justified.
+
+## Validate and contrast
+
+`npx hyperframes validate` runs WCAG contrast audit by default. It seeks to sampled timestamps, screenshots the page, samples background pixels behind text, and computes contrast ratios.
+
+If warnings appear:
+
+- On dark backgrounds: brighten failing text color until it clears 4.5:1 for normal text or 3:1 for large text.
+- On light backgrounds: darken it.
+- Stay in the palette family. Adjust existing colors instead of inventing new ones.
+- Re-run validate until clean.
+
+Use `--no-contrast` only for rapid iteration, never final delivery.
+
+## Visual inspect
+
+```bash
+npx hyperframes inspect --json
+npx hyperframes inspect --samples 15
+npx hyperframes inspect --at 1.5,4,7.25
+```
+
+Fix:
+
+- Text spilling outside cards, bubbles, or canvas.
+- Fixed-width or fixed-height boxes clipping text.
+- Children escaping clipping containers.
+- Captions or labels moving off-frame.
+
+Fixes usually mean increasing container size or padding, reducing font size or letter spacing, adding `max-width`, or using `window.__hyperframes.fitTextFontSize(...)`.
+
+If overflow is intentional:
+
+- Add `data-layout-allow-overflow` to the element or ancestor.
+- Add `data-layout-ignore` to decoratives that should not be audited.
+
+## Animation map review
+
+Read `animation-map.json`. Check:
+
+- Per-tween summaries.
+- ASCII Gantt chart for choreography rhythm.
+- Stagger intervals.
+- Dead zones longer than 1s.
+- Element lifecycle: first/last animation time and final visibility.
+- Scene snapshots at key timestamps.
+- Flags: offscreen, collision, invisible, paced-fast, paced-slow.
+
+Fix or justify every flag. Do not hand back mystery choreography.

--- a/Community/hyperframes/references/transitions.md
+++ b/Community/hyperframes/references/transitions.md
@@ -1,0 +1,57 @@
+# Scene Transitions
+
+Every multi-scene composition must use transitions. No jump cuts.
+
+## Non-negotiables
+
+1. Always use transitions between scenes.
+2. Always use entrance animations on every scene.
+3. Every element enters via `gsap.from()`.
+4. Never use exit animations except on the final scene.
+5. The outgoing scene must still be fully visible when the transition starts.
+6. The transition is the exit.
+
+## Wrong
+
+```js
+tl.to("#s1-title", { opacity: 0, y: -40, duration: 0.4 }, 6.5);
+tl.to("#s1-subtitle", { opacity: 0, duration: 0.3 }, 6.7);
+// transition fires on an empty scene
+```
+
+## Right
+
+```js
+tl.from("#s1-title", { y: 50, opacity: 0, duration: 0.7, ease: "power3.out" }, 0.3);
+tl.from("#s1-subtitle", { y: 30, opacity: 0, duration: 0.5, ease: "power2.out" }, 0.6);
+// no exit tweens; transition handles scene change
+
+tl.from("#s2-heading", { x: -40, opacity: 0, duration: 0.6, ease: "expo.out" }, 8.0);
+```
+
+## Transition types
+
+Use the transition type that matches the scene energy:
+
+- **Crossfade** — calm, editorial, reflective.
+- **Wipe** — structured, product-demo, guide-like.
+- **Mask reveal** — premium, cinematic, identity-driven.
+- **Match cut** — same shape/object carries across scenes.
+- **Light sweep / shader reveal** — high-energy or tech/launch material.
+- **Card slide / pane shift** — UI, product tours, data explanations.
+
+## Rules for choosing
+
+- The transition should bridge narrative beats, not just hide a cut.
+- Do not use the same transition repeatedly unless repetition is the aesthetic.
+- Avoid full-screen linear gradients on dark backgrounds; H.264 banding makes them ugly. Use radial light, solids, texture, localized glow, or shader motion.
+- If using shader transitions, read `@hyperframes/shader-transitions` package source instead of guessing from memory.
+
+## Entrance guardrails
+
+- Offset first animation 0.1-0.3s from scene start.
+- Use at least three different eases per scene when there are enough elements.
+- Do not repeat the same entrance pattern within a scene.
+- Headlines: 60px+.
+- Body: 20px+.
+- Data labels: 16px+.

--- a/Community/hyperframes/references/tts.md
+++ b/Community/hyperframes/references/tts.md
@@ -1,0 +1,35 @@
+# Text-to-Speech
+
+Use this when generating narration or voiceover for a HyperFrames project.
+
+## Commands
+
+```bash
+npx hyperframes tts "Text here" --voice af_nova --output narration.wav
+npx hyperframes tts script.txt --voice bf_emma
+npx hyperframes tts --list
+```
+
+## Workflow
+
+1. Write `SCRIPT.md` first.
+2. Generate narration from the approved script.
+3. Transcribe the output to get timing:
+
+```bash
+npx hyperframes transcribe narration.wav --model medium.en --language en
+```
+
+4. Map transcript timings to storyboard beats.
+5. Update `STORYBOARD.md` with actual beat durations.
+6. Build composition timings from the real audio, not guessed duration.
+
+## Voice choice
+
+Choose voice based on project mood:
+
+- Crisp product demo: clear, neutral voice.
+- Cinematic teaser: slower, lower, more space.
+- Social ad: faster, hook-oriented, fewer clauses.
+
+If a read sounds rushed, shorten the script before stretching timing. Slow bad copy is still bad copy, merely with more room to disappoint.

--- a/Community/hyperframes/references/typography.md
+++ b/Community/hyperframes/references/typography.md
@@ -1,0 +1,55 @@
+# Typography
+
+Every HyperFrames composition with text needs deliberate typography. Video punishes timid type.
+
+## Minimum sizes
+
+- Headlines: 60px+.
+- Body text: 20px+.
+- Data labels and captions: 16px+.
+- Number columns: `font-variant-numeric: tabular-nums`.
+
+## Font rule
+
+Fonts are written directly in CSS. The compiler embeds supported fonts automatically and warns when a font is not supported.
+
+Do not default to Roboto, Inter, Arial, or system UI unless the project brand explicitly requires it.
+
+## Text wrapping
+
+Do not use `<br>` in normal content. Let text wrap naturally with `max-width`. Forced line breaks plus natural wrapping cause unintended extra breaks and overlap.
+
+Exception: short display titles where each word is deliberately on its own line, such as:
+
+```text
+THE
+IMMORTAL
+GAME
+```
+
+## Dynamic text
+
+For dynamic text overflow, use:
+
+```js
+window.__hyperframes.fitTextFontSize(text, {
+  maxWidth,
+  fontFamily,
+  fontWeight
+});
+```
+
+Use this for captions, cards, stats, imported headlines, and anything generated from a transcript or website capture.
+
+## Dark background adjustment
+
+On dark canvases:
+
+- Increase font weight slightly.
+- Avoid thin gray text.
+- Use warmer off-white rather than pure white when the design allows.
+- Check contrast with `npx hyperframes validate`.
+
+## Hierarchy test
+
+Squint at the hero frame. If h1, h2, body, captions, and labels do not separate immediately, the hierarchy fails.

--- a/Community/hyperframes/references/visual-identity-gate.md
+++ b/Community/hyperframes/references/visual-identity-gate.md
@@ -1,0 +1,34 @@
+# Visual Identity Gate
+
+Before writing any composition HTML, define visual identity. Do not write default or generic colors.
+
+## Check in order
+
+1. `DESIGN.md` exists in the project: read it and use exact colors, fonts, motion rules, and "What NOT to Do" constraints.
+2. `visual-style.md` exists: read it and apply `style_prompt_full` plus structured fields.
+3. User named a style: read `visual-styles.md` and generate a minimal `DESIGN.md` with:
+   - `## Style Prompt`
+   - `## Colors` — 3-5 hex values with roles
+   - `## Typography` — 1-2 font families
+   - `## What NOT to Do` — 3-5 anti-patterns
+4. None of the above: ask exactly three questions before writing HTML:
+   - What's the mood: explosive, cinematic, fluid, technical, chaotic, warm?
+   - Light or dark canvas?
+   - Any brand colors, fonts, or visual references?
+
+Then generate a minimal `DESIGN.md` from the answers.
+
+## Required traceability
+
+Every composition must trace palette and typography back to one of:
+
+- `DESIGN.md`
+- `visual-style.md`
+- explicit user direction
+
+If you reach for `#333`, `#3b82f6`, Roboto, Inter, Arial, or generic blue-purple gradients, you skipped the gate.
+
+## Division of responsibility
+
+- `DESIGN.md` defines what the video looks like: palette, typography, visual references, anti-patterns.
+- `house-style.md` defines how things move when no specific animation direction is provided.

--- a/Community/hyperframes/references/visual-styles.md
+++ b/Community/hyperframes/references/visual-styles.md
@@ -1,0 +1,67 @@
+# Visual Styles
+
+Use these presets when the user names a style or gives a vague direction. Generate a project-specific `DESIGN.md`; do not treat this file as the final design.
+
+## 1. Swiss Pulse
+
+- Mood: precise, typographic, confident, grid-aware.
+- Palette: ink `#111111`, paper `#F2EFE7`, signal red `#E53935`, steel `#7B838C`, line `#D6D0C4`.
+- Type: Neue Haas Grotesk / Satoshi for sans; IBM Plex Mono for labels.
+- Motion: crisp wipes, grid reveals, `expo.out`, short staggers.
+- Do not: use gradients, soft blob backgrounds, centered SaaS hero layouts.
+
+## 2. Velvet Standard
+
+- Mood: cinematic, premium, low-key, editorial.
+- Palette: black plum `#130D14`, ivory `#F4EBDD`, wine `#7A1F3D`, brass `#C9A35A`, smoke `#8B8280`.
+- Type: Canela / Instrument Serif for display; Satoshi for body.
+- Motion: slow mask reveals, light sweeps, `power3.inOut`, gentle parallax.
+- Do not: overuse glow, neon, or bouncy motion.
+
+## 3. Deconstructed
+
+- Mood: raw, spatial, poster-like, intentionally fractured.
+- Palette: bone `#EFE9DA`, black `#151515`, hazard `#F4B000`, blue pencil `#1B5DFF`, concrete `#B8B1A5`.
+- Type: Syne / Space Grotesk for display; JetBrains Mono for annotations.
+- Motion: abrupt slides, clipped masks, rotated labels, `power4.out`.
+- Do not: make it tidy or symmetrical without tension.
+
+## 4. Maximalist Type
+
+- Mood: loud, rhythmic, type-as-image.
+- Palette: midnight `#080812`, cream `#FFF3D6`, acid green `#B7FF2A`, hot coral `#FF4D6D`, violet `#7C3AED`.
+- Type: Fraunces / Obviously / Syne display; compact sans for support.
+- Motion: kinetic type, scale punches, hard cuts hidden by transitions.
+- Do not: fill every frame with equal noise. Hierarchy still matters.
+
+## 5. Data Drift
+
+- Mood: analytical, luminous, system-map, quietly futuristic.
+- Palette: carbon `#0A0F14`, mist `#DDE8EA`, cyan `#37D5F2`, amber `#F5B84B`, grid `#24313A`.
+- Type: IBM Plex Sans / Geist; JetBrains Mono for numbers.
+- Motion: line drawing, number ticks, panel drift, `none` and `power2.out`.
+- Do not: turn it into generic cybersecurity blue mush.
+
+## 6. Soft Signal
+
+- Mood: warm, humane, calm, luminous.
+- Palette: oat `#F5ECDC`, cocoa `#3E3027`, clay `#C8734A`, moss `#7C8C5A`, cream `#FFF8EA`.
+- Type: Newsreader / Fraunces display; Satoshi body.
+- Motion: soft fades, gentle y entrances, radial light shifts, `sine.inOut`.
+- Do not: make it beige and dead. It still needs contrast.
+
+## 7. Folk Frequency
+
+- Mood: tactile, handmade, patterned, rooted.
+- Palette: linen `#F2E4C8`, indigo `#253A5C`, madder `#A03A2D`, marigold `#D89B2B`, pine `#2E5A47`.
+- Type: Fraunces / Cooper-like display; readable sans body.
+- Motion: paper slides, pattern reveals, hand-drawn accents.
+- Do not: use fake rustic gimmicks. Texture, not costume.
+
+## 8. Shadow Cut
+
+- Mood: noir, sharp, political-thriller, high contrast.
+- Palette: black `#050505`, chalk `#F3F0E8`, red `#C1121F`, gray `#3F4045`, sodium `#FFB703`.
+- Type: condensed grotesk display; serif captions optional.
+- Motion: hard masks, spotlight reveals, shutter cuts, `power4.inOut`.
+- Do not: rely on opacity fades. Cut with purpose.

--- a/Community/hyperframes/scripts/animation-map.mjs
+++ b/Community/hyperframes/scripts/animation-map.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, readdirSync, writeFileSync, statSync } from "node:fs";
+import { basename, extname, join, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+const projectDir = resolve(args[0] || ".");
+const outIndex = args.indexOf("--out");
+const outDir = resolve(outIndex >= 0 && args[outIndex + 1] ? args[outIndex + 1] : join(projectDir, ".hyperframes", "anim-map"));
+
+function walk(dir) {
+  const entries = [];
+  for (const name of readdirSync(dir)) {
+    if (["node_modules", ".git", ".hyperframes", "renders"].includes(name)) continue;
+    const path = join(dir, name);
+    const stat = statSync(path);
+    if (stat.isDirectory()) entries.push(...walk(path));
+    else if (extname(path).toLowerCase() === ".html") entries.push(path);
+  }
+  return entries;
+}
+
+function findCompositionId(html, file) {
+  const match = html.match(/data-composition-id=["']([^"']+)["']/);
+  return match?.[1] || basename(file, ".html");
+}
+
+function findDuration(html) {
+  const match = html.match(/data-duration=["']([0-9.]+)["']/);
+  return match ? Number(match[1]) : null;
+}
+
+function splitArgs(source) {
+  const parts = [];
+  let current = "";
+  let depth = 0;
+  let quote = null;
+  for (let i = 0; i < source.length; i += 1) {
+    const char = source[i];
+    const prev = source[i - 1];
+    if (quote) {
+      current += char;
+      if (char === quote && prev !== "\\") quote = null;
+      continue;
+    }
+    if (["'", '"', "`"].includes(char)) {
+      quote = char;
+      current += char;
+      continue;
+    }
+    if (["(", "{", "["].includes(char)) depth += 1;
+    if ([")", "}", "]"].includes(char)) depth -= 1;
+    if (char === "," && depth === 0) {
+      parts.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim()) parts.push(current.trim());
+  return parts;
+}
+
+function parseVars(varsSource) {
+  const vars = {};
+  const propPattern = /([A-Za-z_$][\w$-]*)\s*:\s*([^,}\n]+)/g;
+  for (const match of varsSource.matchAll(propPattern)) {
+    vars[match[1]] = match[2].trim().replace(/^['"]|['"]$/g, "");
+  }
+  return vars;
+}
+
+function extractTweens(html) {
+  const tweens = [];
+  const callPattern = /(?:tl|gsap)\.(to|from|fromTo|set)\s*\(([^;]+?)\)\s*;?/gs;
+  for (const match of html.matchAll(callPattern)) {
+    const method = match[1];
+    const args = splitArgs(match[2]);
+    const target = args[0]?.trim() || "unknown";
+    const varsSource = method === "fromTo" ? args[2] || "{}" : args[1] || "{}";
+    const vars = parseVars(varsSource);
+    const positionSource = method === "fromTo" ? args[3] : args[2];
+    const duration = Number(vars.duration ?? (method === "set" ? 0 : 0.5));
+    const position = positionSource ? positionSource.trim().replace(/^['"]|['"]$/g, "") : null;
+    const properties = Object.keys(vars).filter((key) => !["duration", "delay", "ease", "stagger", "overwrite", "repeat", "yoyo", "onComplete", "onStart", "onUpdate", "immediateRender"].includes(key));
+    tweens.push({ method, target, duration, ease: vars.ease || null, position, properties, vars });
+  }
+  return tweens;
+}
+
+function numericPosition(position, fallback) {
+  if (!position) return fallback;
+  if (/^[0-9.]+$/.test(position)) return Number(position);
+  const relative = position.match(/^[<>]?\+=([0-9.]+)$/);
+  if (relative) return fallback + Number(relative[1]);
+  return fallback;
+}
+
+function buildTimeline(tweens, duration) {
+  let cursor = 0;
+  return tweens.map((tween) => {
+    const start = numericPosition(tween.position, cursor);
+    const end = start + tween.duration;
+    cursor = Math.max(cursor, end);
+    const flags = [];
+    if (tween.duration > 0 && tween.duration < 0.2) flags.push("paced-fast");
+    if (tween.duration > 2) flags.push("paced-slow");
+    if (String(tween.vars.repeat) === "-1") flags.push("infinite-repeat");
+    if (["display", "visibility", "width", "height", "top", "left"].some((prop) => tween.properties.includes(prop))) flags.push("layout-or-visibility-property");
+    return { ...tween, start, end, flags };
+  });
+}
+
+function asciiTimeline(items, duration) {
+  const total = duration || Math.max(1, ...items.map((item) => item.end));
+  const width = 80;
+  return items.map((item, index) => {
+    const start = Math.max(0, Math.floor((item.start / total) * width));
+    const end = Math.min(width, Math.max(start + 1, Math.ceil((item.end / total) * width)));
+    const bar = `${" ".repeat(start)}${"█".repeat(end - start)}`.padEnd(width, " ");
+    return `${String(index + 1).padStart(2, "0")} ${bar} ${item.method} ${item.target}`;
+  });
+}
+
+function summarize(item) {
+  const props = item.properties.length ? item.properties.join("+") : "no visual props detected";
+  return `${item.target} ${item.method} animates ${props} over ${item.duration.toFixed(2)}s at ${item.start.toFixed(2)}s${item.ease ? ` using ${item.ease}` : ""}.`;
+}
+
+const files = walk(projectDir);
+const compositions = files.map((file) => {
+  const html = readFileSync(file, "utf8");
+  const compositionId = findCompositionId(html, file);
+  const duration = findDuration(html);
+  const timeline = buildTimeline(extractTweens(html), duration);
+  const deadZones = [];
+  const sorted = [...timeline].sort((a, b) => a.start - b.start);
+  for (let i = 1; i < sorted.length; i += 1) {
+    const gap = sorted[i].start - sorted[i - 1].end;
+    if (gap > 1) deadZones.push({ from: sorted[i - 1].end, to: sorted[i].start, duration: gap });
+  }
+  return {
+    file,
+    compositionId,
+    duration,
+    tweenCount: timeline.length,
+    summaries: timeline.map(summarize),
+    timeline,
+    ascii: asciiTimeline(timeline, duration),
+    flags: timeline.flatMap((item) => item.flags.map((flag) => ({ flag, target: item.target, start: item.start, properties: item.properties }))),
+    deadZones
+  };
+});
+
+const result = {
+  projectDir,
+  generatedAt: new Date().toISOString(),
+  note: "Static GSAP scanner. Use with hyperframes inspect/validate; this does not replace visual review.",
+  compositions
+};
+
+mkdirSync(outDir, { recursive: true });
+const outputFile = join(outDir, "animation-map.json");
+writeFileSync(outputFile, `${JSON.stringify(result, null, 2)}\n`);
+console.log(outputFile);

--- a/Community/website-to-video/DISPLAY.json
+++ b/Community/website-to-video/DISPLAY.json
@@ -1,0 +1,5 @@
+{
+  "specVersion": "0.2.0",
+  "icon": "video",
+  "tags": ["video", "marketing", "hyperframes", "workflow", "url"]
+}

--- a/Community/website-to-video/SKILL.md
+++ b/Community/website-to-video/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: website-to-video
+description: |
+  Capture a website and turn it into a professional HyperFrames video. Use when the user asks to make a product launch video, product tour, social ad, brand reel, or teaser from a URL.
+compatibility: Created for Zo Computer
+metadata:
+  author: jeffkazzee.zo.computer
+  category: Video
+---
+
+# Website to Video
+
+## Usage
+
+Use this skill end-to-end when the user wants a video from a URL. It assumes the `hyperframes`, `gsap`, and `hyperframes-cli` skills are also installed. Each step has its own reference (`references/step-1-capture.md` through `references/step-7-validate.md`); read the relevant one before the step, do the work, hit the gate, then advance. Do not skip the `DESIGN.md`/`SCRIPT.md`/`STORYBOARD.md` artifacts — they are the difference between a real video and a screen recording with delusions of grandeur.
+
+Use this skill when the user says things like:
+
+- "Capture https://... and make me a 25-second product launch video."
+- "Turn this website into a 15-second social ad for Instagram."
+- "Create a 30-second product tour from https://..."
+
+The workflow has seven gated steps. Each step produces an artifact that gates the next. Do not skip documents because the video will otherwise become a pretty screen recording with delusions of grandeur.
+
+## Seven-step workflow
+
+### 1. Capture and understand
+
+Read `references/step-1-capture.md`.
+
+Run the capture, read extracted data, and build a working summary using the write-down-and-forget method.
+
+Gate: print the site summary:
+
+- name
+- top colors
+- fonts
+- key assets
+- one-sentence vibe
+
+### 2. Write `DESIGN.md`
+
+Read `references/step-2-design.md`.
+
+Write a simple brand reference for the captured website. Six sections, about 90 lines. This is the cheat sheet, not the creative plan.
+
+Gate: `DESIGN.md` exists in the project directory.
+
+### 3. Write `SCRIPT.md`
+
+Read `references/step-3-script.md`.
+
+Write the narration script. Scene durations come from narration, not guessing.
+
+Gate: `SCRIPT.md` exists in the project directory.
+
+### 4. Write `STORYBOARD.md`
+
+Read `references/step-4-storyboard.md` and, for technique ideas, `references/techniques.md`.
+
+Write beat-by-beat creative direction: mood, camera, animation, transitions, assets, depth layers, SFX, and an asset audit.
+
+Gate: `STORYBOARD.md` exists with beat-by-beat direction and an asset audit table.
+
+### 5. Generate VO and map timing
+
+Read `references/step-5-vo.md`.
+
+Generate TTS audio, transcribe word timings, and map timestamps to beats. Update `STORYBOARD.md` with real durations.
+
+Gate: `narration.wav` or `narration.mp3` exists, transcript JSON exists, and beat timings are updated.
+
+### 6. Build compositions
+
+Read the `hyperframes` skill and `references/step-6-build.md`.
+
+Build each composition from the storyboard. After each composition, self-review layout, asset placement, and animation quality.
+
+Gate: every composition self-reviewed. No overlapping elements, misplaced assets, or static images without motion.
+
+### 7. Validate and deliver
+
+Read `references/step-7-validate.md`.
+
+Run lint, validate, inspect, and preview. Deliver the localhost Studio project URL first:
+
+```text
+http://localhost:<port>/#project/<project-name>
+```
+
+Only render MP4 on explicit request.
+
+Gate: `npx hyperframes lint` and `npx hyperframes validate` pass with zero errors, and the final response includes the active Studio project URL.
+
+## Video type defaults
+
+| Type | Duration | Beats | Narration |
+|---|---:|---:|---|
+| Social ad | 10-15s | 3-4 | Optional hook sentence |
+| Product demo | 30-60s | 5-8 | Full narration |
+| Feature announcement | 15-30s | 3-5 | Full narration |
+| Brand reel | 20-45s | 4-6 | Optional, music focus |
+| Launch teaser | 10-20s | 2-4 | Minimal, high energy |
+
+## Format defaults
+
+- Landscape: 1920x1080
+- Portrait: 1080x1920
+- Square: 1080x1080
+
+Ask only if the format affects the work. If the user said Instagram Stories or TikTok, use portrait. If they said launch video or product tour, use landscape unless otherwise specified.
+
+## References
+
+- `references/step-1-capture.md`
+- `references/step-2-design.md`
+- `references/step-3-script.md`
+- `references/step-4-storyboard.md`
+- `references/step-5-vo.md`
+- `references/step-6-build.md`
+- `references/step-7-validate.md`
+- `references/techniques.md`

--- a/Community/website-to-video/references/step-1-capture.md
+++ b/Community/website-to-video/references/step-1-capture.md
@@ -1,0 +1,48 @@
+# Step 1 — Capture and Understand
+
+Goal: capture enough of the website to understand brand, product, assets, and story hooks.
+
+## Inputs
+
+- URL
+- Target format if provided: landscape, portrait, square
+- Desired duration if provided
+- Audience or platform if provided
+
+## Process
+
+1. Create or enter the HyperFrames project directory.
+2. Capture the website with the available HyperFrames capture tooling or browser workflow.
+3. Save captured artifacts inside the project: screenshots, extracted text, asset list, colors, fonts.
+4. Read the extracted data.
+5. Use write-down-and-forget: summarize what matters, then work from the summary rather than repeatedly rereading everything.
+
+## Required summary gate
+
+Print this before moving on:
+
+```md
+## Site summary
+- Name:
+- Product/category:
+- Top colors:
+- Fonts:
+- Key assets:
+- Primary promise:
+- One-sentence vibe:
+- Video angle:
+```
+
+## What to look for
+
+- Hero headline and subhead.
+- CTA wording.
+- Product screenshots or UI surfaces.
+- Logos, icons, illustrations, photos.
+- Color and typography choices.
+- Social proof, concrete claims, stats.
+- Visual metaphors already present in the site.
+
+## Risk
+
+Do not overfit the video to screenshots. A website capture is raw material, not direction. The creative plan comes in `STORYBOARD.md`.

--- a/Community/website-to-video/references/step-2-design.md
+++ b/Community/website-to-video/references/step-2-design.md
@@ -1,0 +1,36 @@
+# Step 2 — Write DESIGN.md
+
+Goal: create a compact brand reference from the captured website.
+
+`DESIGN.md` is a cheat sheet. It is not the storyboard.
+
+## Required sections
+
+```md
+# DESIGN
+
+## Brand read
+
+## Colors
+
+## Typography
+
+## Asset language
+
+## Motion implications
+
+## What NOT to Do
+```
+
+## Guidance
+
+- Keep it around 90 lines.
+- Include 3-5 hex colors with roles.
+- Name 1-2 font families and fallbacks.
+- Describe how assets should be used: UI crops, screenshots, logo, illustration, texture.
+- Define what the site feels like in plain language.
+- Include anti-patterns so the build does not drift into generic AI video.
+
+## Gate
+
+`DESIGN.md` exists before any composition HTML is written.

--- a/Community/website-to-video/references/step-3-script.md
+++ b/Community/website-to-video/references/step-3-script.md
@@ -1,0 +1,39 @@
+# Step 3 — Write SCRIPT.md
+
+Goal: write the narration backbone.
+
+Scene durations come from narration. Do not guess scene duration before the script exists.
+
+## Script structure
+
+```md
+# SCRIPT
+
+## Video target
+- Type:
+- Duration target:
+- Format:
+- Audience:
+
+## Narration
+
+[Final narration text]
+
+## Beat draft
+
+| Beat | Approx duration | Narration | Visual purpose |
+|---|---:|---|---|
+```
+
+## Writing rules
+
+- Short sentences.
+- Concrete claims from the website.
+- No generic SaaS fog.
+- One idea per beat.
+- If it is a social ad, hook fast.
+- If it is a product tour, make the sequence understandable.
+
+## Gate
+
+`SCRIPT.md` exists before `STORYBOARD.md`.

--- a/Community/website-to-video/references/step-4-storyboard.md
+++ b/Community/website-to-video/references/step-4-storyboard.md
@@ -1,0 +1,45 @@
+# Step 4 — Write STORYBOARD.md
+
+Goal: write beat-by-beat creative direction. This is the north star for the engineer.
+
+## Required structure
+
+```md
+# STORYBOARD
+
+## Project facts
+- Duration:
+- Format:
+- Visual identity source:
+- Audio plan:
+
+## Beats
+
+### Beat 1 — [name]
+- Time:
+- Narration:
+- Mood:
+- Camera / composition:
+- Assets:
+- Animation:
+- Transition:
+- SFX / audio notes:
+- Quality risks:
+
+## Asset audit
+
+| Asset | Source | Use | Risk | Status |
+|---|---|---|---|---|
+```
+
+## Requirements
+
+- Every beat needs a visual job.
+- Every scene needs entrance animation.
+- Every multi-scene cut needs a transition.
+- Identify depth layers: background, subject, overlays, annotations, transition layer.
+- Mark assets that need cropping, cleanup, or replacement.
+
+## Gate
+
+`STORYBOARD.md` exists with beat-by-beat direction and an asset audit table before building composition HTML.

--- a/Community/website-to-video/references/step-5-vo.md
+++ b/Community/website-to-video/references/step-5-vo.md
@@ -1,0 +1,34 @@
+# Step 5 — Generate VO and Map Timing
+
+Goal: turn script into real timing.
+
+## Commands
+
+```bash
+npx hyperframes tts SCRIPT.md --voice af_nova --output narration.wav
+npx hyperframes transcribe narration.wav --model medium.en --language en
+```
+
+Use the right voice for the project mood. Check available voices:
+
+```bash
+npx hyperframes tts --list
+```
+
+## Process
+
+1. Generate narration.
+2. Transcribe narration for word-level timing.
+3. Map transcript timestamps to storyboard beats.
+4. Update `STORYBOARD.md` with actual beat time ranges.
+5. Use the real timings for `data-start` and `data-duration`.
+
+## Gate
+
+- `narration.wav` or `.mp3` exists.
+- Transcript JSON exists.
+- Beat timings in `STORYBOARD.md` are updated.
+
+## Pushback
+
+If the narration runs too long, shorten the script. Do not simply make the video longer unless the user requested a longer format.

--- a/Community/website-to-video/references/step-6-build.md
+++ b/Community/website-to-video/references/step-6-build.md
@@ -1,0 +1,42 @@
+# Step 6 — Build Compositions
+
+Goal: build the video from the storyboard with HyperFrames HTML/CSS/GSAP.
+
+## Before writing HTML
+
+Read:
+
+- `DESIGN.md`
+- `SCRIPT.md`
+- `STORYBOARD.md`
+- `Skills/hyperframes/SKILL.md`
+- `Skills/hyperframes/references/composition-contract.md`
+- `Skills/hyperframes/references/layout-before-animation.md`
+- `Skills/hyperframes/references/transitions.md`
+- `Skills/hyperframes/references/quality-checks.md`
+
+## Build process
+
+1. Scaffold with `npx hyperframes init` if not already scaffolded.
+2. Build static hero-frame layout first.
+3. Add GSAP entrance animations.
+4. Add scene transitions.
+5. Add media and separate audio tracks.
+6. Add captions if needed.
+7. Run lint/validate/inspect after each substantial composition.
+8. Self-review before proceeding to the next composition.
+
+## Self-review checklist
+
+- Does the hero frame match `STORYBOARD.md`?
+- Does palette/typography trace to `DESIGN.md`?
+- Does every element enter?
+- Are there transitions between scenes?
+- Are there accidental overlaps?
+- Are assets placed intentionally, not just pasted in?
+- Is there motion on screenshots or static images?
+- Are captions readable and inside safe areas?
+
+## Gate
+
+Every composition is self-reviewed. No overlapping elements, misplaced assets, or static images without motion.

--- a/Community/website-to-video/references/step-7-validate.md
+++ b/Community/website-to-video/references/step-7-validate.md
@@ -1,0 +1,50 @@
+# Step 7 — Validate and Deliver
+
+Goal: prove the project works before handoff.
+
+## Required commands
+
+```bash
+npx hyperframes lint
+npx hyperframes validate
+npx hyperframes inspect
+```
+
+For new or major animation work:
+
+```bash
+node /home/workspace/Skills/hyperframes/scripts/animation-map.mjs <project-dir> --out <project-dir>/.hyperframes/anim-map
+```
+
+If the script does not exist in this workspace, use project-local tooling or note that animation-map was unavailable.
+
+## Preview
+
+```bash
+npx hyperframes preview --port <port>
+```
+
+Deliver the Studio project URL:
+
+```text
+http://localhost:<port>/#project/<project-name>
+```
+
+Do not deliver `index.html` as the preview link.
+
+## Render
+
+Only render MP4 when explicitly requested:
+
+```bash
+npx hyperframes render --quality high --fps 60 --output final.mp4
+```
+
+## Final report
+
+Include:
+
+- Studio URL.
+- Validation status.
+- Any remaining warnings and why they are acceptable.
+- Render status only if MP4 was requested.

--- a/Community/website-to-video/references/techniques.md
+++ b/Community/website-to-video/references/techniques.md
@@ -1,0 +1,43 @@
+# Website-to-Video Techniques
+
+Use these in `STORYBOARD.md` and build planning.
+
+## 1. Website hero reconstruction
+
+Rebuild the hero as designed typography and extracted assets instead of showing a flat screenshot. Use the screenshot as reference, not prison.
+
+## 2. Product UI PiP
+
+Place the website or app screenshot inside a device/browser frame. Animate the wrapper with scale, parallax, or crop reveal.
+
+## 3. SVG drawing
+
+Use SVG paths for arrows, circles, underlines, or process diagrams. Animate `strokeDashoffset`.
+
+## 4. Canvas texture
+
+Use deterministic canvas or CSS texture for grain/noise. Avoid random frame-to-frame flicker unless seeded and intentional.
+
+## 5. 3D card stack
+
+Layer screenshots/cards with `rotationX`, `rotationY`, `z`, and shadows. Keep text readable.
+
+## 6. Kinetic typography
+
+Use for hooks, promises, and final lines. Keep it short.
+
+## 7. Screenshot crop tour
+
+Move a viewport over a large screenshot by animating a wrapper with `x`, `y`, and `scale`. Do not animate raw image dimensions.
+
+## 8. Marker emphasis
+
+Use highlight sweeps, circles, and burst markers from `css-patterns.md`.
+
+## 9. Data proof
+
+Turn stats into a chart, count-up, or label cluster. Use tabular numerals.
+
+## 10. Transition as metaphor
+
+Choose transitions that connect beats: wipe for process, mask reveal for premium identity, match cut for repeated shapes, shader for high energy.


### PR DESCRIPTION
## Skill Submission: HyperFrames Video Toolkit (5 skills)

**Author:** @Jeff-Kazzee
**Category:** media

### What it does

A coordinated family of five Community skills for creating and editing HTML/GSAP-driven videos with the [HyperFrames](https://www.npmjs.com/package/hyperframes) framework. Each skill works standalone; together they form a complete video authoring workflow:

| Skill | Role |
| --- | --- |
| `hyperframes` | Primary workflow: composition contract, layout-before-animation, transitions, typography, validation, plus a static GSAP `animation-map.mjs` scanner |
| `gsap` | Tween/timeline reference: methods, easing, performance, HyperFrames-safe constraints |
| `hyperframes-cli` | `npx hyperframes` command surface (init, lint, validate, inspect, preview, render, TTS, transcribe, doctor) |
| `hyperframes-registry` | Working with `hyperframes add`, blocks, components, install locations |
| `website-to-video` | Seven-step gated workflow from URL → DESIGN.md → SCRIPT.md → STORYBOARD.md → VO → build → validated handoff |

### Requirements

- Node.js ≥ 22 (for `npx hyperframes`)
- FFmpeg (for render / transcribe)
- No API keys required for the core workflow. Network access on first `npx hyperframes` run to fetch the CLI.

### Usage Example

```bash
# Install the toolkit
slug="hyperframes"; dest="Skills"; manifest_url="https://raw.githubusercontent.com/zocomputer/skills/main/manifest.json"
mkdir -p "$dest" && tarball_url="$(curl -fsSL "$manifest_url" | jq -r '.tarball_url')" && archive_root="$(curl -fsSL "$manifest_url" | jq -r '.archive_root')"
for s in hyperframes gsap hyperframes-cli hyperframes-registry website-to-video; do
  curl -L "$tarball_url" | tar -xz -C "$dest" --strip-components=1 "$archive_root/Community/$s"
done

# Then in your Zo agent:
# "Make me a 25-second product launch video from https://example.com"
# (website-to-video routes through the other four skills)
```

### Notes

- All five SKILL.md files use block-scalar (`|`) frontmatter descriptions to avoid YAML colon ambiguity.
- DISPLAY.json provided for each skill with icon + tags.
- `hyperframes/scripts/animation-map.mjs` is a static GSAP timeline scanner (no shell exec, no eval). It reads HTML files and emits an `animation-map.json` for choreography review.
- Local registry `bun validate` passes with zero new errors (the 15 pre-existing warnings on `External/` are unchanged).

### Why a bundle PR rather than five separate PRs

These skills cross-reference each other (`hyperframes` calls out `gsap`, `hyperframes-cli`, `hyperframes-registry`, and `website-to-video` by name in its workflow). Reviewing them as one coherent family matches their actual usage and precedent set by the Clarion family in `External/`. Happy to split if maintainers prefer.
