### PR TITLE
Community: dreaming (workspace pattern-finding)

### DIFF
--- a/Community/dreaming/DISPLAY.json
+++ b/Community/dreaming/DISPLAY.json
@@ -1,0 +1,5 @@
+{
+  "specVersion": "0.2.0",
+  "icon": "moon",
+  "tags": ["workspace", "maintenance", "reflection", "automation", "agent-ops"]
+}

--- a/Community/dreaming/SKILL.md
+++ b/Community/dreaming/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: dreaming
+description: |
+  Background pattern-finding for a Zo Computer workspace, modeled on Anthropic's Dreaming feature for Claude Managed Agents (released 2026-05-06). Runs between sessions, reviews recent activity across projects plus Files, Skills, Personas, Rules, Automations, and hosted Sites, and surfaces cross-project bleed, drifted Rules, unused Skills, and other patterns the agent can't see in any single session. Asks the user before any destructive action. Triggers on "run dreaming", "let zo dream", "dream over my workspace", "consolidate the workspace", "what's drifting", or on a scheduled Automation.
+compatibility: Created for Zo Computer
+metadata:
+  author: jeffkazzee.zo.computer
+  category: Workspace
+---
+# Dreaming
+
+Background workspace consolidation for Zo. Borrowed from Anthropic's Dreaming feature for Claude Managed Agents — same four-phase pattern (Orient → Gather Signal → Consolidate → Surface), tailored for Zo's surfaces (Files, Skills, Personas, Rules, Automations, hosted Sites and Services).
+
+Dreaming is reflective, not reactive. It's not an audit that finds stale files. It reviews what actually happened across recent sessions and projects, finds patterns no in-session agent could spot (cross-project bleed, drifted Rules, recurring user corrections, visual style sticking across sites that should look distinct), and proposes refinements to the workspace itself.
+
+The skill never modifies anything destructively without user confirmation. It surfaces; the user decides.
+
+## Usage
+
+Install the skill and the agent picks it up on any matching prompt (`let zo dream`, `run dreaming`, `dream over my workspace`, `consolidate the workspace`, `what's drifting`). Run it manually for a deep interactive pass, or schedule it as a Zo Automation (recipes below in `## Two-mode recipes for Zo Automations`). Reports are written to `dream-reports/YYYY-MM-DD-dream.md` at the workspace root; create that directory the first time you run the skill. Companion skills `dreaming-operations-review` and `Chief Systems Officer` persona are optional.
+
+## When to run
+
+- **Daily light dream** — scheduled Automation, \~5 minute pass, writes a dream report only. Default for background runs.
+- **Weekly deep dream** — scheduled or on-demand, walks the user through findings interactively. Asks per item before any move, archive, or delete.
+- **On-demand** — when the user says "let zo dream" or "dream over my workspace", run the deep dream interactively.
+- **Executive operations review** — when Jeff asks for self-improvement, workspace critique, operating-system review, or "what's drifting," use the `Chief Systems Officer` persona and pair this skill with `dreaming-operations-review`.
+
+## The four phases
+
+### 1. Orient
+
+Read the current shape of the workspace before assuming anything is missing or stale:
+
+- Top-level project folders inside `Files/`
+- The `Skills/` folder (which Skills exist, when each was last edited)
+- The active Personas, Rules, and Automations
+- Hosted Sites and Services
+- Any prior dream reports (so this run picks up where the last one left off)
+
+Don't read file contents at this stage. Just structure.
+
+### 2. Gather signal
+
+Scan recent activity for patterns the agent couldn't see in any single session. The targets, in order of priority:
+
+- **Cross-project bleed** — content from one project surfacing in conversations or outputs about another. Most urgent because it can ship to public surfaces before the user notices.
+- **Visual style drift** — fonts, color palettes, layout choices repeating across sites that should look distinct. Especially when the user has explicitly said two sites should look different.
+- **Personal-detail intrusion** — user's name, location, or other personal identifiers showing up in copy that's supposed to read generic. The user did not ask for first-person attribution; the agent inserted it.
+- **Recurring user corrections** — same kind of correction made by the user across multiple sessions. Pattern means the agent is drifting in a way Rules or Skills should be updated to prevent.
+- **Workflow repetition** — same sequence of steps performed three or more times. Candidate for a new Skill (the third-strike rule).
+- **Idle Skills** — Skills that haven't been invoked in 60+ days. Candidates for retirement.
+- **Drifted Rules** — Rules that conflict with newer Rules or that the agent is no longer honoring.
+- **Stale Personas** — Personas tied to retired projects or never re-activated.
+- **Broken Automations** — Automations erroring on their last run, or pointing at projects that no longer exist.
+- **Quiet hosted Sites** — Sites that haven't been updated, that aren't reachable, or that nobody visits anymore.
+
+Use targeted scans. Don't read every file in the workspace.
+
+### 3. Consolidate
+
+Merge the signal into proposed refinements. For each finding:
+
+- **Bleed and drift findings** — propose a Rule update or Skill update that would prevent the pattern recurring. Show the proposed change before writing it.
+- **Skill candidates** — propose a `file SKILL.md` skeleton (name, description, body outline) for any workflow that fired three or more times.
+- **Idle Skills, drifted Rules, stale Personas, broken Automations, quiet Sites** — propose retire / pause / fix per item.
+- **Resolve contradictions** — if two Rules conflict, surface them together and ask which to keep.
+- **Remove dead references** — if a Skill points at a file that no longer exists, propose updating or retiring it.
+
+Never auto-apply. Every consolidation step shows the proposed change first.
+
+### 4. Surface
+
+Write the dream report. Path:
+
+```markdown
+dream-reports/YYYY-MM-DD-dream.md
+```
+
+Sections in this order:
+
+ 1. **Run summary** — date, scope of scan, time taken
+ 2. **Cross-project bleed** — files, conversations, or outputs that crossed project lines, with proposed moves
+ 3. **Visual style drift** — sites pulling similar fonts/palettes/layouts when they shouldn't
+ 4. **Personal-detail intrusion** — copy where the user's name or location appeared uninvited
+ 5. **Recurring user corrections** — patterns suggesting a Rule or Skill update
+ 6. **Skill candidates** — workflows that fired 3+ times
+ 7. **Idle Skills** — candidates for retirement
+ 8. **Drifted Rules** — Rules that conflict or aren't being honored
+ 9. **Stale Personas** — Personas to retire
+10. **Broken Automations** — Automations that need fix, pause, or delete
+11. **Quiet hosted Sites and Services** — propose keep / sleep / retire per item
+12. **Open decisions** — anything deferred from prior dream reports
+
+In light mode, this is the whole output (report only, no destructive prompts).
+
+In deep mode, walk the user through findings interactively. See `file references/cleanup-prompts.md` for literal interaction templates per finding type.
+
+## Boundaries
+
+- **Never modify anything destructively without explicit confirmation.** Require the user to type the literal item name to confirm any delete.
+- **Never auto-apply a Rule update, a Persona retirement, a Skill scaffold, or a hosted Site change.** Show the proposed change; let the user accept, modify, or reject.
+- **If yesterday's dream report shows decisions the user never resolved, mention them at the top of today's report.** Don't re-surface the same item every day silently.
+- **If the workspace shape has changed significantly since the last dream**, stop and ask. Something may have moved deliberately that dreaming shouldn't be flagging as drift.
+
+## After a deep dream run
+
+- Append one line to the user's main memory file: "Dream YYYY-MM-DD:  bleed findings resolved,  Skill candidates accepted,  Rules updated,  deferred."
+- If a new Skill or Rule was created, link to it from the report.
+- If the dream proposed a Skill but the user deferred for the third time, soften next time's proposal: ask whether to retire the candidate rather than keep re-suggesting it.
+- If safe changes were implemented, record which Skills, Personas, Rules, routes, files, or services changed.
+
+## Two-mode recipes for Zo Automations
+
+**Daily light dream:**
+
+> Run the dreaming skill in light mode. Write the report to `dream-reports/`. DM me only if there's a critical finding (cross-project bleed flagged, hosted Site unreachable, Automation erroring three days running).
+
+**Weekly deep dream:**
+
+> Run the dreaming skill in deep mode. Walk me through findings interactively. Save decisions to today's report and update memory.
+
+## Lineage
+
+This skill is a port of Anthropic's Dreaming feature for Claude Managed Agents (announced 2026-05-06) into a Zo-specific Skill. Same conceptual model: asynchronous, reflective, learns-from-past-sessions, refines the durable layer of the workspace without modifying the underlying agent. Different surfaces — Anthropic's version operates over agent memory and session transcripts; this version operates over Zo's Files, Skills, Personas, Rules, Automations, and hosted Sites.
+
+The four-phase pattern (Orient → Gather Signal → Consolidate → Surface) mirrors Claude Code's AutoDream consolidation pass. The user-control posture (auto-report by default, ask-before-anything-destructive) mirrors Anthropic's "you decide how much control you want" framing.
+
+For the underlying inspiration, see Anthropic's [Dreams documentation](https://platform.claude.com/docs/en/managed-agents/dreams).

--- a/Community/dreaming/references/cleanup-prompts.md
+++ b/Community/dreaming/references/cleanup-prompts.md
@@ -1,0 +1,107 @@
+# Cleanup Interaction Prompts
+
+Use these literal prompt templates when running the `dreaming` skill in deep mode. Adjust wording for tone, but preserve the structure.
+
+## Per Stale Folder
+
+> Folder: `<path>`
+> Last touched: `<date>` (`<N>` days ago)
+> Contents: `<file count>` files, `<size>` total
+> Best guess at purpose: `<one line>`
+>
+> Choose:
+> 1. **Archive** → move to `Archive/<YYYY>/<folder name>/` and add a one-line note in the heartbeat report
+> 2. **Delete** → `rm -rf <path>` (requires you to type the literal folder name to confirm)
+> 3. **Keep** → record "still needed as of <today>" so the next heartbeat won't surface it
+> 4. **Defer** → leave it, surface again next run
+>
+> Reply with 1, 2, 3, or 4.
+
+## Per Context-Bleed File
+
+> File: `<source path>`
+> Suspected correct location: `<destination path>`
+> Why I think it's misplaced: `<one-line reason>`
+>
+> Choose:
+> 1. **Move** → relocate to suggested path
+> 2. **Keep here** → record an exception so I stop flagging it
+> 3. **Different location** → tell me where
+> 4. **Defer** → surface again next run
+
+## Per Skill Candidate
+
+> Workflow detected: `<short name>`
+> Occurrences in last 30 days: `<count>` (`<dates>`)
+> Proposed scope: `<project | global>`
+>
+> Proposed `SKILL.md` skeleton:
+> ```
+> ---
+> name: <slug>
+> description: <one line>
+> ---
+> # <Title>
+> ## When to use
+> ## Steps
+> ## Output
+> ```
+>
+> Choose:
+> 1. **Scaffold it** → create the SKILL.md and open for me to flesh out
+> 2. **Defer** → keep watching, surface again if it happens a 4th time
+> 3. **Reject** → mark as "not a skill, just a coincidence" so I stop suggesting it
+
+## Per Idle Automation
+
+> `<name>` last fired: `<date>` (`<N>` days ago)
+> Last status: `<ok | error | throttled>`
+> Runs: `<what it does in one line>`
+>
+> Choose:
+> 1. **Pause** → disable but keep the config
+> 2. **Delete** → remove entirely
+> 3. **Fix** → leave running, but tell me what to look at
+> 4. **Defer** → leave it, surface again next run
+
+## Per Stale Persona
+
+> `<persona name>` last activated: `<date>` (`<N>` days ago)
+> Purpose: `<one line from the Persona description>`
+>
+> Choose:
+> 1. **Retire** → remove the Persona
+> 2. **Keep** → record "still needed as of <today>"
+> 3. **Defer** → surface again next run
+
+## Per Stale Rule
+
+> Rule: `<rule text>`
+> Added: `<date>` (`<N>` days ago)
+> Conflict: `<other rule or skill that may supersede this, or "none">`
+>
+> Choose:
+> 1. **Remove** → rule no longer applies
+> 2. **Keep** → still relevant
+> 3. **Edit** → tell me how to adjust the wording
+> 4. **Defer** → surface again next run
+
+## Per Hosted Site / Service
+
+> `<URL>` last updated: `<date>` (`<N>` days ago)
+> Reachable: `<yes | no | timeout>`
+> Purpose: `<one line, or "unclear">`
+>
+> Choose:
+> 1. **Keep** → still in use
+> 2. **Sleep** → take down the public surface but keep the files
+> 3. **Retire** → remove the hosted service entirely (after typed confirmation)
+> 4. **Defer** → surface again next run
+
+## Confirmation Discipline
+
+For any **Delete** choice, require the user to type the literal item name back. Examples:
+
+> To confirm deleting `Active Projects/Old Campaign/`, type: `Active Projects/Old Campaign/`
+
+This prevents fast-yes mistakes. The friction is the feature.

--- a/Community/dreaming/references/skill-extraction.md
+++ b/Community/dreaming/references/skill-extraction.md
@@ -1,0 +1,71 @@
+# Skill Extraction
+
+How to spot a workflow worth promoting to a Skill, and how to scaffold the SKILL.md.
+
+## The Three-Strike Rule
+
+A workflow earns a Skill when it has been done **three times the same way**. Not the first time. Not the second time. The third time.
+
+- First time = exploration. Don't generalize from one example.
+- Second time = coincidence. Watch it.
+- Third time = pattern. Promote it.
+
+This rule alone prevents Skills folders full of speculative scaffolding that no agent ever invokes.
+
+## How To Detect Repetition
+
+Scan the last 30 days of memory files (`memory/YYYY-MM-DD.md` or equivalent) for sequences that share at least three of:
+
+- Same starting trigger (e.g. "user asks for a campaign brief")
+- Same intermediate steps (in roughly the same order)
+- Same output shape (a file, a report, a decision, a handoff)
+
+Don't require exact word matches. The shape is what counts. If the user has run "research → outline → draft → brand voice review → schedule" three times, that's a pattern even if the topic differed.
+
+## What To Capture In The Skeleton
+
+A SKILL.md only needs:
+
+- `name` — slug, lowercase, dash-separated
+- `description` — one line that tells Zo when to load this skill (Zo's progressive loading reads this first)
+- A short body with **When to use**, **Steps**, **Output**, and **Boundaries**
+
+Aim for 90% signal, 10% readability. No filler.
+
+## Scope: Project Or Global?
+
+Default to project-scoped. A skill should only be promoted to global if:
+
+- More than one project has used it
+- Its behavior doesn't depend on a specific project's files
+- It's at no risk of being misused by the wrong agent in the wrong workspace
+
+When in doubt, project-scope it. You can always promote later. You can rarely demote without confusion.
+
+## Mirror Rule
+
+Once a skill exists, the Skill is the source of truth. Prompts and memory files should mirror the skill, not duplicate it. If a workflow rule appears in three places (skill + prompt + memory), it will drift. Centralize.
+
+## After A Skill Is Created
+
+- Test it on the next real instance of the workflow it captures
+- If it fails or feels wrong, edit the skill, don't work around it
+- If a fourth occurrence of the underlying workflow doesn't trigger the skill, the skill's `description` is wrong — fix the description first
+
+## Promotion Loop
+
+If a skill repeatedly proves useful across multiple Zo projects:
+
+1. Document why it's worth promoting (in a workspace-level memory file)
+2. If the skill currently lives in a project-specific location, move it to the top-level `Skills/<skill>/` directory in your Zo computer
+3. Update its description to reflect cross-project applicability — Zo's progressive loading reads the description first, so it's the only thing that decides whether the skill fires
+
+## Skill Demotion / Deletion
+
+A skill should be retired when:
+
+- It hasn't been invoked in 60+ days
+- The workflow it captured is no longer how you do the work
+- A newer skill subsumes it
+
+Demotion goes: global → project-scoped → archived → deleted. Don't skip steps. Each demotion is a chance to confirm the skill is really dead.


### PR DESCRIPTION
## Skill Submission: dreaming

**Author:** @Jeff-Kazzee
**Category:** automation

### What it does

Background pattern-finding for a Zo Computer workspace, modeled on Anthropic's [Dreaming feature for Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/dreams) (released 2026-05-06). Runs between sessions, reviews recent activity across projects plus Files, Skills, Personas, Rules, Automations, and hosted Sites, and surfaces cross-project bleed, drifted Rules, unused Skills, and other patterns the agent can't see in any single session.

Uses the same four-phase pattern as Anthropic's version (Orient → Gather Signal → Consolidate → Surface), tailored for Zo's surfaces. Non-destructive by default — surfaces findings, asks the user before any move/archive/delete.

### Requirements

- No external API keys.
- Optional: pair with a Zo Automation for daily light dreams and weekly deep dreams (recipes are included in `SKILL.md`).
- Optional companion: `dreaming-operations-review` skill and a `Chief Systems Officer` persona for executive ops reviews.

### Usage Example

```bash
# Install
slug="dreaming"; dest="Skills"; manifest_url="https://raw.githubusercontent.com/zocomputer/skills/main/manifest.json"
mkdir -p "$dest" && tarball_url="$(curl -fsSL "$manifest_url" | jq -r '.tarball_url')"
archive_root="$(curl -fsSL "$manifest_url" | jq -r '.archive_root')"
curl -L "$tarball_url" | tar -xz -C "$dest" --strip-components=1 "$archive_root/Community/dreaming"
```

Then in your Zo agent:

> let zo dream over my workspace

Or schedule as a weekly Automation:

> Run the dreaming skill in deep mode. Walk me through findings interactively. Save decisions to today's report and update memory.

### Files

- `SKILL.md` — four-phase workflow, two-mode recipes, boundaries
- `DISPLAY.json` — icon + tags
- `references/cleanup-prompts.md` — literal interaction templates for deep mode
- `references/skill-extraction.md` — three-strike rule for scaffolding new skills from repeated workflows

Runtime `dream-reports/` directory is created by the skill at the workspace root; not bundled with the submission.

### Notes

- Block-scalar (`|`) description in frontmatter avoids YAML colon ambiguity from the `(released 2026-05-06)` parenthetical.
- Local registry `bun validate` passes with zero new errors.
