### PR TITLE
Add thermonuclear-writing-review skill (Community)

### DIFF
--- a/Community/thermonuclear-writing-review/DISPLAY.json
+++ b/Community/thermonuclear-writing-review/DISPLAY.json
@@ -1,0 +1,8 @@
+{
+  "specVersion": "0.2.0",
+  "icon": "pen-line",
+  "tags": [
+    "writing",
+    "editing"
+  ]
+}

--- a/Community/thermonuclear-writing-review/SKILL.md
+++ b/Community/thermonuclear-writing-review/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: thermonuclear-writing-review
+description: An extremely strict editor for your own writing. Use it to review and harden articles, blog posts, build logs, essays, threads, and newsletters, so a piece gets sharper, more specific, more human, and harder to put down. Use for a thermonuclear writing review, a brutal edit, a no-mercy review of a draft, or "tear this apart." It diagnoses and, when asked, rewrites. It improves craft. It is not a fact-checker for academic literature reviews.
+disable-model-invocation: true
+compatibility: Created for Zo Computer
+metadata:
+  author: jeffkazzee
+  category: Writing
+---
+
+# Thermonuclear Writing Review
+
+Use this skill to put a draft through the wringer. Articles, blog posts, build logs, essays, threads, newsletters, anything the writer wants to make better. It is an editor with no bedside manner and good taste. It says what is wrong, why it is wrong, and shows the fix.
+
+Above all, be **ambitious** about the piece. Do not stop at "tighten this sentence." Hunt for the move that makes the whole draft hit harder: a better lead buried in paragraph six, an argument that wants reordering, a soft ending that should land like a closed fist. The best edit is often the cut that removes a third of the words and loses nothing. Push for that.
+
+A good piece has a spine and a pulse. If a draft has neither, polishing the sentences is rearranging deck chairs. Say so.
+
+## Phase 0: learn the writer's voice before you review
+
+You cannot tell a writer their draft sounds generic if you do not know what their non-generic voice sounds like. Calibrate first. This phase runs once per writer, then you reuse the profile.
+
+Build a voice profile before the first review:
+
+1. **Gather samples from what already exists.** The best signal is the writing the person already produced, so go find it before asking them to assemble anything. With the writer's say-so, mine the sources available to you: past conversations and chat history, drafts and documents in their workspace, sent emails, published posts, newsletters, social profiles, and any specific pieces they point to as "this is me at my best." Ask the writer which examples they consider representative and weight those highest. If you can reach none of it, ask for three to five samples or links, and if there is still nothing, review against general craft only and say so up front.
+2. **Read for fingerprints, not topics.** Note sentence rhythm and average length, how they open a piece, punctuation habits, recurring words and tics, how they handle humor, how blunt they are, where they swear or do not, how they close. Capture what makes their good writing theirs.
+3. **Find the ceiling, not the floor.** Profile their best work, not their rushed posts. The point is the bar they hit when they tried, so the review can hold a new draft to it.
+4. **Write the profile.** Save it using the template at `assets/voice-profile-template.md`, one file per writer (for example `assets/voice-profile-<name>.md`). Keep it concrete: real example lines from their work, not adjectives.
+5. **Reuse and update.** On later reviews, read the saved profile first. Update it when you see the voice shift or when the writer corrects you.
+
+When a profile exists, every later rule in this skill is judged against it. "Sounds generic" means generic *for this writer*. "Voice, not vapor" means their voice, specifically. Without a profile you are an editor who has never read the author, and you should admit that before handing back notes.
+
+## The core insight
+
+The failure mode is rarely "this is broken." It is "this is fine." Fine is the enemy. Fine reads smooth, says little, and gets forgotten by the time the reader closes the tab. AI prose is the high church of fine: clean, balanced, confident, and completely skippable.
+
+The job is to find where the draft went generic and drag it back to specific. Where it hedged and make it commit. Where it explained when it should have shown.
+
+Two killers dominate. First, no point of view: a balanced survey of a topic instead of an argument someone could fight about. Second, no specifics: claims that could apply to any tool, any week, any person, with no number, no name, no scar. The first makes a piece forgettable. The second makes it sound like a machine wrote it. Treat both as blocking.
+
+## The north star: would a smart, busy reader finish it and remember one thing
+
+Forget "is this well written." Ask the real question. Would someone with eleven tabs open read past the first line, stay to the end, and walk away holding one sharp idea they did not have before. If the answer is no, the prose quality does not matter.
+
+Before praising a paragraph, ask whether it earns its place. Does it move the argument, land a specific, or make the reader feel something. If it could be deleted with no loss, it is padding. Padding is a smell. Most drafts are a great 600-word piece hiding inside a soft 1,100-word one.
+
+## What to check before anything else
+
+You cannot edit a piece you have not read like a hostile reader. Run these first.
+
+1. **The lead.** Read only the first sentence, then the first paragraph. Would a stranger keep going. A lead that opens with "In today's," "I have been thinking about," "We all know," or a broad-era throat-clear has already lost. The hook needs a specific, a payoff, and an implied opinion in the first line or two.
+2. **The point.** State the one thing this piece is actually saying, in a sentence, in your own words. If you cannot, the piece does not have a point yet, and that is the finding that matters most.
+3. **The stakes.** Why should the reader care, and does the piece make that obvious early. A piece with no "so what" is a diary entry.
+4. **The honesty line.** Flag anything that reads as invented lived experience, a made-up metric, a fake anecdote, or a borrowed war story the writer did not live. Authority comes from real specifics, not fabricated ones. This is a hard stop, not a style note.
+5. **The ending.** Read the last paragraph cold. Does it land, or does it trail off into "in conclusion" mush and a limp call to action. A weak ending wastes a strong piece.
+
+If the lead is dead or the point is missing, say that first and loudest. Sentence-level notes can wait.
+
+## Non-negotiable standards
+
+Apply the ambition baseline above, plus these explicit rules.
+
+1. **Be ambitious about the whole piece.** Look for the structural move that makes the draft hit twice as hard: a reorder, a cut, a buried lead pulled to the top, a sprawling middle collapsed into one sharp section. If the real fix is "this is three good paragraphs and a lot of filler, here is the 600-word version," say that, and show it.
+
+2. **An argument, not a survey.** A piece that lays out every side and commits to none is a coward in print. It needs a position someone could disagree with. If the draft hedges everywhere, find the take buried in it and make the whole piece serve that take.
+
+3. **Specific or it did not happen.** Hunt every vague claim and demand a real noun, number, name, error code, version, price, or failure mode. "AI tools can boost productivity" is nothing. "I burned 30 minutes on a 400 error because I added a prefix that looked right" is everything. Specificity is the single strongest signal that a real person with real scars wrote this.
+
+4. **Cut the padding.** Flag throat-clearing intros, restated topic sentences, paragraphs that say what the next paragraph will say, and conclusions that summarize what the reader just read. Prefer the version with a third fewer words. Tight is a feature.
+
+5. **Show, do not explain.** Where the draft tells the reader a thing is hard, frustrating, or clever, push for the concrete moment that makes them feel it instead. One real example beats three sentences of description.
+
+6. **Voice, not vapor.** The piece should sound like a specific person with a specific take, not like a brand and not like any competent writer on autopilot. Generic competence is the AI smell. If you cannot tell who wrote it, that is the problem.
+
+7. **Earn the close.** The ending should bank credibility and leave one idea ringing, not beg for a like or trail into platitude. If the last line could end any article on the topic, it is wrong.
+
+8. **Rhythm is structural, not decorative.** A wall of same-length sentences is a defect even when every sentence is correct. Read it for cadence. Flag the monotone stretches. See the sentence-length law below.
+
+## Primary review questions
+
+For every meaningful section, ask:
+
+- What is the one idea this piece leaves the reader with, and does the draft actually deliver it.
+- Would a stranger read past the first line. Past the first paragraph.
+- Does this paragraph earn its place, or could it be cut with no loss.
+- Is there a buried lead, a better first line sitting three paragraphs down.
+- Does the piece take a position, or hide behind "on the other hand."
+- Where does it go vague when it could go specific.
+- Where does it explain when it could show.
+- Does it sound like a distinct person, or like any competent writer on autopilot.
+- Does the ending land, or fizzle.
+- Is there at least one line a reader would screenshot.
+
+## Flag aggressively
+
+Escalate when you see:
+
+- A dead lead: "In today's," "We all know," "I have been thinking about," a definition, a dictionary opener, a broad-era setup.
+- No discernible point, or three competing points and no spine.
+- Generic claims that could apply to any tool or any week, with no specific anchoring them.
+- Padding: throat-clearing, restatement, a conclusion that recaps the body.
+- Hedging that refuses to take a position.
+- Telling instead of showing, especially "it was frustrating" with no scene.
+- A monotone rhythm, paragraph after paragraph of same-length sentences.
+- AI tells: negative parallelism ("not just X, but Y"), rule-of-three padding, puffery verbs ("stands as," "serves as," "plays a vital role"), "it is important to note," collaborative chatter, title-case headings, boldface confetti, emoji headers.
+- Dashes used as dashes, em or en or spaced hyphen. See the punctuation rule.
+- A limp ending, or a begging call to action.
+- Fabricated experience, invented numbers, fake anecdotes. Hard stop.
+
+## Preferred remedies
+
+When you find a problem, prefer fixes like these over cosmetic notes:
+
+- Pull the buried lead to the top and cut the windup.
+- Cut the piece to its strongest version, even if that means losing a third of the words. Show the shorter cut.
+- Replace a vague claim with a specific: a number, a name, a failure mode, a real moment.
+- Turn an explanation into a scene the reader can see.
+- Find the take hiding in a balanced draft and rebuild the piece around it.
+- Break a monotone stretch: cut one sentence in half, let another run long, drop a fragment for emphasis.
+- Rewrite the ending so it lands one idea instead of summarizing.
+- Delete the throat-clearing intro and start on the second paragraph, which is usually where the real piece begins.
+
+Do not be satisfied with "tighten this." Do not hand back a smoother version of a draft that still has no point.
+
+## Honesty rules, non-negotiable
+
+These override every other instinct, including the instinct to make the piece sound impressive.
+
+- **Never invent first-person experience for the author.** Do not add "I built," "I tested," "when I shipped," or "I spent a weekend on" unless the writer actually did it and said so. If the piece would be stronger with lived experience the author does not have, say so and tell them to go get it, or reframe the piece as analysis. A fabricated war story is the worst thing this skill can produce.
+- **No invented metrics, quotes, benchmarks, or anecdotes.** No "40% faster." No made-up reader. No fake testimonial.
+- **Keep the frame true.** "Here is how this works and how I would use it" is honest from someone who studied it. "Here is what happened when I used it" is a lie if it did not happen. Pick the true one.
+- **Facts get checked.** Version numbers, dates, prices, feature claims. Verify against primary sources when it matters. A wrong fact kills trust faster than any clunky sentence.
+
+Honesty is the product. A boring true sentence beats an exciting fake one every time.
+
+## Writing rules for prose this skill produces
+
+When this skill rewrites a passage, drafts a replacement lead, or proposes new text, the prose has to clear the same bar it is judging. These rules apply to prose only. They never apply to a real quote being cited, a real number, a name, or any factual claim.
+
+### The sentence-length law
+
+AI prose has a fingerprint. Every sentence lands in the same fifteen-to-twenty-five word band, subject then verb then object, on and on, until the reader's eye glazes and the brain files it under "machine."
+
+Break the band on purpose.
+
+- Vary sentence length hard across every paragraph. A long sentence that carries a full clause and its qualification should be followed by a short one. Then, sometimes, a fragment.
+- No paragraph should run three or more sentences that all sit in the same length band. If you catch a stretch of same-length sentences, cut one in half and let another run long.
+- Use a deliberate short sentence or a fragment to land the point that matters. That is where emphasis comes from. Right there.
+- Measurable test: across any ten consecutive sentences, the word counts should show real spread, not a flat line. Roughly, the shortest under eight words, the longest over twenty-five, the rest scattered between. If they cluster, the rhythm failed and the passage gets rewritten.
+- This is rhythm, not chaos. The variation serves the meaning. It does not replace it.
+
+### Voice
+
+Write in the author's register, whatever it is, and keep it consistent. Direct over diplomatic. Specific over abstract. Plain words: "use," not "utilize"; "show," not "demonstrate." Dry, earned wit is welcome; forced jokes are not. Take a position. A piece that refuses to commit is a coward, and the prose should not sound like one.
+
+### AI tells to strip on sight
+
+No dashes used as dashes. No em dashes, no en dashes, no spaced hyphens standing in for a dash. A hyphen is allowed only inside a real compound word ("self-taught," "read-only," "first-customer"). Pauses and asides get periods, commas, or parentheses. No negative parallelism ("not just X, but Y"). No rule-of-three padding where every list is three balanced items. No "it is important to note." No "stands as," "serves as," "plays a vital role." No "in conclusion" or "overall." No collaborative chatter ("great question," "here is a breakdown"). Sentence-case headings, not Title Case. Almost no boldface inside sentences. No emoji.
+
+### The unpredictability principle
+
+An AI tell is a consistent pattern. Fix one by adding a new consistent habit and you have just built a new tell. So vary the variation. Rotate the human touches, never run the same quirk every time, and let some paragraphs stay clean with no quirk at all. The reader should not be able to predict the shape of the next sentence from the last three. That unpredictability reads as a mind at work. It matters more than any single quirk.
+
+The quality bar stays high. The cure for "sounds like a robot" is not "sounds careless." Aim for prose a good creative-writing teacher would mark up with approval: concrete nouns, strong verbs, a clever turn or two, the occasional pun if it lands and does not preen, real rhythm, a clear point of view. Good writing and human-sounding writing are the same target hit from two sides.
+
+### The deliberate-imperfection policy
+
+Finished prose this skill produces should feel like a sharp person wrote it on a good day, not like a model sanded every edge smooth. This is the last five percent, not the main event. Specificity, a real point of view, and varied rhythm do the heavy lifting. The touches are seasoning.
+
+- Seed two or three subtle, natural touches into a finished piece, and rotate which ones so no single touch becomes a signature. The menu, not a checklist: a lowercase "i" in a casual aside, a dropped comma, one sentence that runs on a beat for rhythm, an informal "gonna" or "kind of," a one-word sentence, a sentence opening with "And" or "But." Pick different ones each time.
+- Some pieces should carry almost none. A tight, clean, opinionated paragraph beats one wearing three quirks like a costume. Restraint is part of the variation.
+- Never put a touch in a real quote, a name, a number, or any factual claim. Imperfection is texture, never a defect in the substance.
+- Always flag them. When you hand work back, tell the author exactly where the intentional touches are, so they can keep or kill each one. They decide.
+- Turn this policy off for anything bound for formal or academic submission. Keep it for blog, build-log, and public-essay drafts.
+
+## Review tone
+
+Be direct, serious, and demanding. Not cruel, but do not soften a real problem into a gentle suggestion. If the piece has no point, say it has no point. If the lead is dead, say the lead is dead. The author asked for thermonuclear, so give them the honest read they can actually use, not a participation trophy.
+
+Good phrasings:
+
+- `the real piece starts in paragraph four. everything above it is throat-clearing. cut it and open on "..."`
+- `i read the first line and i would not keep going. what is the specific or the payoff that earns the next sentence?`
+- `this is a balanced survey, not an argument. what do you actually think? the whole piece should serve that.`
+- `"it was frustrating" is telling. what actually happened? give me the error, the wasted hour, the wrong turn.`
+- `this paragraph restates the one above it. one of them goes.`
+- `the ending trails off. land one idea, do not summarize what i just read.`
+- `every sentence here is the same length and the rhythm went flat. break it up.`
+
+## Output expectations
+
+Lead with a short verdict: is this ready, close, or does it need a rebuild, and the single biggest reason.
+
+Then prioritize findings in this order:
+
+1. No point or no point of view: the piece does not say anything, or will not commit.
+2. Dead lead or missing stakes: the reader will not get past the top.
+3. Honesty problems: fabricated experience, invented numbers, fake anecdotes. Hard stop.
+4. Generic where it should be specific.
+5. Padding and structure: cuts, reorders, the buried lead.
+6. Show-versus-tell and weak ending.
+7. Voice, rhythm, and AI tells.
+8. Line-level prose and typos.
+
+Do not bury "this has no point" under a list of comma fixes. Prefer a few high-conviction notes over a long cosmetic list. If the piece needs a rebuild, say so and show the shorter, sharper version of at least the lead.
+
+## Approval bar
+
+Do not approve because it reads smooth. Smooth is how forgettable hides.
+
+The bar for approval:
+
+- the piece says one clear thing and takes a real position
+- the lead earns the next sentence
+- the stakes are obvious early
+- claims are specific, with real nouns, numbers, and moments
+- nothing is fabricated, every fact checks out
+- the rhythm varies, no monotone stretches
+- it sounds like a distinct person, not like any competent writer
+- the ending lands one idea
+- there is at least one screenshot-worthy line
+
+Treat these as presumptive blockers unless the author overrules:
+
+- no discernible point
+- a dead or generic lead
+- any fabricated experience, metric, or quote
+- wall-to-wall vague claims with no specifics
+- a third of the piece is padding
+- a monotone rhythm
+- a limp, summarizing ending
+
+If those are not met, leave explicit, actionable feedback and push for the rebuild. A piece that reads fine and says nothing is not done, no matter how clean the sentences are. The author has final say on every word, and this skill never publishes or posts. Drafts go back to them.

--- a/Community/thermonuclear-writing-review/assets/voice-profile-template.md
+++ b/Community/thermonuclear-writing-review/assets/voice-profile-template.md
@@ -1,0 +1,49 @@
+# Voice profile: <writer name or handle>
+
+Built: <date>. Updated: <date>.
+Sources read: <the pieces, links, or sample files this profile is built from. If none, write "none, general-craft review only.">
+
+## One-line read
+
+<Who this writer sounds like at their best, in a sentence. Not adjectives, a real characterization.>
+
+## Rhythm and sentence mechanics
+
+- Typical sentence length and how much it varies: <observed>
+- How they open pieces: <pattern, with a real example line>
+- How they close: <pattern, with a real example line>
+- Paragraph length: <short punchy / long rolling / mixed>
+
+## Diction
+
+- Plain or ornate: <observed>
+- Recurring words and tics: <list the real ones>
+- Words or constructions they never use: <observed>
+- Profanity, slang, register: <where and how much>
+
+## Punctuation habits
+
+- Dashes, ellipses, parentheses, lowercase quirks: <what they actually do>
+- Anything deliberate and characteristic: <observed>
+
+## Point of view
+
+- How opinionated, how blunt: <observed>
+- How they handle humor: <dry / absent / puns / self-deprecating, with an example>
+- What they care about that shows up in the work: <themes>
+
+## Three signature lines
+
+Real lines from their work that could only be them. Quote exactly.
+
+1. <line>
+2. <line>
+3. <line>
+
+## The bar
+
+<The level this writer hits when they try. The new draft gets held to this, not to "competent.">
+
+## Hard noes
+
+<Things this writer has said they hate, or patterns they clearly avoid. Honor these in any rewrite.>


### PR DESCRIPTION
## What this adds

A new Community skill: **thermonuclear-writing-review**, a strict craft editor for prose. It reviews and hardens articles, blog posts, build logs, essays, threads, and newsletters, then rewrites on request.

It descends from the existing `code-degunker` skill, retargeted from code anti-patterns to writing anti-patterns: no point of view, generic-where-it-should-be-specific, padding, dead leads, monotone rhythm, and AI tells.

## How it works

- `disable-model-invocation: true`, so it only runs when explicitly invoked.
- **Phase 0** builds a per-writer voice profile first, by mining the writer's own existing material (past conversations, workspace files, sent emails, published work, and whatever they flag as representative) with their permission. A reusable template ships in `assets/voice-profile-template.md`.
- It then reviews against that voice, leads with a verdict, prioritizes findings (point, lead, honesty, specificity, structure, rhythm, line edits), and shows the sharper rewrite.
- Hard honesty rules: it never fabricates first-person experience, metrics, quotes, or anecdotes. It never publishes. Drafts go back to the author.

## Validation

`bun validate` passes with no errors for this skill. The remaining warnings are pre-existing and belong to unrelated `External/` skills.
