### PR TITLE
Add wiki-llm skill (Community)

### DIFF
--- a/Community/wiki-llm/DISPLAY.json
+++ b/Community/wiki-llm/DISPLAY.json
@@ -1,0 +1,10 @@
+{
+  "specVersion": "0.2.0",
+  "icon": "book-open",
+  "tags": [
+    "knowledge",
+    "documentation",
+    "developer-tools",
+    "automation"
+  ]
+}

--- a/Community/wiki-llm/SKILL.md
+++ b/Community/wiki-llm/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: wiki-llm
+description: Build and maintain an LLM-authored persistent wiki for any project folder. The wiki is a structured, interlinked set of markdown files that incrementally accumulates knowledge about a codebase, research topic, or document collection — so future sessions don't have to rescan the project from scratch. Use when the user asks to set up a wiki for a project, ingest a new source into an existing wiki, query the wiki, lint it for staleness/contradictions, list/recover deleted source files from wiki trash, or register/unregister a project for the Claude Code Stop-hook auto-update flow. Supports any folder type (web app, CLI tool, data pipeline, research notes, plain documents) — the init flow adapts its questions accordingly.
+compatibility: Created for Zo Computer
+metadata:
+  author: wedding.zo.computer
+  category: Knowledge
+  display-name: Wiki-LLM
+---
+
+# wiki-llm
+
+Persistent LLM-maintained wiki for a project. Pattern based on the LLM Wiki concept (incremental compounding knowledge base — see `references/CONCEPT.md`).
+
+## Architecture
+
+Three layers per project:
+1. **Raw sources** — the project files themselves (read-only from the wiki's POV).
+2. **The wiki** — markdown files the LLM writes/maintains at the user-chosen wiki location (default `/home/workspace/wiki/<project-slug>/`).
+3. **The schema** — `<wiki>/AGENTS.md` tells future agent sessions how the wiki is structured and what conventions to follow.
+
+Per-project registry lives at `~/.wiki-llm/registry.json`. Wiki internals live at `<wiki>/.wiki-llm/` (state, trash, queue, manifest).
+
+## Subcommands
+
+The CLI is `scripts/wiki` (Bun). All commands work on a registered project; pass `--project <path>` or run from inside one.
+
+| Command | Purpose |
+|---|---|
+| `wiki init [path]` | Interactive setup: detect project type, ask scope/ingest/exclude questions, scaffold wiki dirs + AGENTS.md, register project. |
+| `wiki status` | Show registered projects + pending updates + trash count. |
+| `wiki ingest <file>` | Mark a source file (relative to project) as needing ingestion. Outputs the source content + existing wiki context for the agent to synthesize. |
+| `wiki update` | Run git diff vs last snapshot. List added/modified/deleted files. Archive deletions to trash. Output a structured "what changed" report for the agent to act on. |
+| `wiki query "..."` | Search the wiki via qmd (hybrid BM25+vector). Falls back to ripgrep if qmd missing. |
+| `wiki lint` | Health check: orphan pages, stale claims (sources newer than dependent pages), missing cross-refs, contradictions to investigate. |
+| `wiki list-deleted` | List files archived in wiki trash with timestamps. |
+| `wiki recover <relpath>` | Restore a deleted source file from wiki trash to its original location. |
+| `wiki register [path]` | Add project to registry. Idempotent. |
+| `wiki unregister [path]` | Remove project from registry (does not delete the wiki). |
+| `wiki hook` | Stop-hook entrypoint. For each registered project: detect git changes, archive deletions to trash, queue updates. Cheap, non-LLM. |
+| `wiki install-hook` | Add the Stop hook to `~/.claude/settings.json`. Idempotent. |
+| `wiki uninstall-hook` | Remove the Stop hook. |
+
+## Init flow — questions asked
+
+`wiki init` first inspects the folder to guess project type, then asks:
+
+**Always:**
+1. Project path (defaults to cwd)
+2. Wiki location (default `/home/workspace/wiki/<project-slug>/`)
+3. Ingest scope — what to include:
+   - For a **code project** (detected via `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, etc.): code architecture, runtime state, ops history, docs
+   - For a **research/notes folder** (mostly `.md`/`.pdf`/`.txt`): documents, web sources, notes
+   - For a **data folder** (mostly `.csv`/`.parquet`/`.duckdb`): schemas, sample queries, lineage
+   - For an **unknown/mixed folder**: free-form scope description
+4. Include globs (default inferred from project type, e.g. `**/*.{ts,tsx,js,py,md}` for code)
+5. Exclude globs (default: `node_modules/**`, `.git/**`, `dist/**`, `build/**`, `__pycache__/**`, plus user additions)
+6. Auto-update trigger: on-demand only, or Stop-hook auto-detect (default: hook)
+7. Backfill — should the agent seed the wiki with any pre-existing ops history / git log highlights? (default: yes)
+
+The init flow is non-interactive when run via `wiki init --json <answers.json>`, so the agent can drive it after collecting answers in chat.
+
+## Deleted-file recovery
+
+Whenever the Stop hook detects a tracked source file was deleted (`git status` shows D), it copies the last-known content into `<wiki>/.wiki-llm/trash/<timestamp>/<relpath>` and appends to `<wiki>/.wiki-llm/trash/manifest.jsonl`. `wiki recover <relpath>` restores the most recent archived copy. This is independent of git history.
+
+## Stop-hook semantics
+
+The hook fires after Claude Code finishes a turn. It does only cheap, deterministic work:
+- For each registered project: snapshot current `git rev-parse HEAD` + dirty files
+- Diff vs last snapshot in `<wiki>/.wiki-llm/state.json`
+- Archive any deletions to trash
+- Append a pending-update entry to `<wiki>/.wiki-llm/queue.jsonl`
+- Print a single-line summary to stderr (visible in next-turn context if user runs commands)
+
+It does NOT call any LLM. Actual wiki regeneration happens when the user (or the agent in a later turn) runs `wiki update`, which reads the queue and produces an instruction block for the agent to ingest changed files.
+
+## qmd integration
+
+If `qmd` is on PATH, `wiki query` uses it. If not, it falls back to ripgrep + a simple ranked-by-headings heuristic. Install qmd via `wiki install-qmd` (best-effort: tries `cargo install qmd` or downloads from releases). On Zo Computer the install runs once at skill init.
+
+## Conventions for the wiki
+
+Every wiki has the same skeleton (see `assets/wiki-template/`):
+- `AGENTS.md` — schema and conventions for the agent
+- `index.md` — catalog of all pages with one-line summaries, grouped by category
+- `log.md` — chronological log of ingests, queries, lint passes, ops events (`## [YYYY-MM-DD HH:MM] <kind> | <subject>`)
+- `pages/` — entity, concept, and source-summary pages
+- `pages/sources/` — one summary page per ingested raw source
+- `pages/entities/` — one page per distinct entity (file, module, person, concept, etc.)
+- `pages/topics/` — synthesis/comparison pages
+- `.wiki-llm/` — state, trash, queue, manifest (agent should never edit by hand)
+
+## When to use this skill
+
+User says any of:
+- "Set up a wiki for this project / for `<path>`"
+- "Ingest `<file>` into the wiki"
+- "Query the wiki for ..."
+- "Lint the wiki"
+- "What deleted files do I have in the wiki trash?"
+- "Recover the deleted file `<relpath>`"
+- "Register this project for auto-wiki updates"
+
+If the user references "wiki" without context and a project is registered, default to operating on that project. If multiple are registered, ask which.

--- a/Community/wiki-llm/SKILL.md
+++ b/Community/wiki-llm/SKILL.md
@@ -40,6 +40,8 @@ The CLI is `scripts/wiki` (Bun). All commands work on a registered project; pass
 | `wiki hook` | Stop-hook entrypoint. For each registered project: detect git changes, archive deletions to trash, queue updates. Cheap, non-LLM. |
 | `wiki install-hook` | Add the Stop hook to `~/.claude/settings.json`. Idempotent. |
 | `wiki uninstall-hook` | Remove the Stop hook. |
+| `wiki doctor [--fix]` | Check required (`bun`, `git`) and optional (`qmd`, `ripgrep`, `rustup`, `cargo`) deps. With `--fix`, best-effort install missing ones (qmd via npm/bun → cargo → rustup+cargo; git/ripgrep via apt). |
+| `wiki install-qmd` | Best-effort install of qmd search backend (npm/bun → cargo → bootstrap rustup then cargo). |
 
 ## Init flow — questions asked
 
@@ -77,7 +79,16 @@ It does NOT call any LLM. Actual wiki regeneration happens when the user (or the
 
 ## qmd integration
 
-If `qmd` is on PATH, `wiki query` uses it. If not, it falls back to ripgrep + a simple ranked-by-headings heuristic. Install qmd via `wiki install-qmd` (best-effort: tries `cargo install qmd` or downloads from releases). On Zo Computer the install runs once at skill init.
+If `qmd` is on PATH, `wiki query` uses it. If not, it falls back to ripgrep + a simple ranked-by-headings heuristic. Install qmd via `wiki install-qmd` (best-effort: tries `bun add -g qmd` → `npm i -g qmd` → `cargo install qmd` → bootstraps rustup if cargo is missing and retries). On Zo Computer the install runs once at skill init.
+
+## First-run dependency preflight
+
+The first time `wiki <anything>` runs in a fresh Zo Computer instance (detected by absence of `~/.wiki-llm/registry.json`), the CLI auto-runs `doctor --fix` to install missing deps. The check covers:
+
+- **Required**: `bun` (script runtime), `git` (diff/recovery)
+- **Optional**: `qmd` (hybrid search; ripgrep fallback), `ripgrep` (search fallback), `rustup` + `cargo` (only used if qmd can't install via npm/bun)
+
+After the first successful run, dependency checks are skipped on subsequent invocations — re-run `wiki doctor` manually to re-check. The hook entrypoint (`wiki hook`) explicitly skips preflight to keep Stop-hook latency minimal.
 
 ## Conventions for the wiki
 

--- a/Community/wiki-llm/assets/wiki-template/AGENTS.md
+++ b/Community/wiki-llm/assets/wiki-template/AGENTS.md
@@ -1,0 +1,98 @@
+# Wiki schema — agent instructions
+
+This wiki is maintained by an LLM agent using the `wiki-llm` skill. **You** (the agent) are the maintainer. The human curates sources and asks questions; you do all the bookkeeping.
+
+## Project
+- **Name:** {{PROJECT_NAME}}
+- **Path:** {{PROJECT_PATH}}
+- **Type:** {{PROJECT_TYPE}}
+- **Scope:** {{INGEST_SCOPE}}
+- **Wiki root:** {{WIKI_ROOT}}
+
+## Layout
+
+```
+{{WIKI_ROOT}}/
+├── AGENTS.md           # this file — schema + conventions
+├── index.md            # catalog of all pages (read this first when answering queries)
+├── log.md              # chronological event log (append-only)
+├── pages/
+│   ├── sources/        # one summary page per ingested raw source (filename mirrors source path with / → __)
+│   ├── entities/       # one page per distinct entity (file, module, function, person, concept)
+│   └── topics/         # synthesis pages, comparisons, analyses
+└── .wiki-llm/          # state, trash, queue, manifest — never edit by hand
+    ├── state.json
+    ├── queue.jsonl
+    ├── trash/
+    │   ├── manifest.jsonl
+    │   └── <timestamp>/<original-relpath>
+    └── config.json
+```
+
+## Conventions
+
+**Page frontmatter** — every page in `pages/` starts with YAML:
+```yaml
+---
+title: <human-readable title>
+kind: source | entity | topic
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+sources: [<paths into pages/sources/ that informed this page>]
+tags: [<freeform>]
+---
+```
+
+**Cross-references** — use `[[wiki-links]]` for internal references, regular markdown links for external. When you create or update a page, walk inbound references in any page that mentions the same entity and add a link.
+
+**Log entries** — every meaningful action gets a log line:
+```
+## [YYYY-MM-DD HH:MM] <kind> | <subject>
+- <one-line summary>
+- pages touched: pages/sources/foo.md, pages/entities/bar.md
+```
+Kinds: `ingest`, `query`, `lint`, `ops`, `delete`, `recover`.
+
+**Index entries** — when you create a page, add a line under the right category:
+```
+- [<title>](pages/<kind>/<slug>.md) — <one-line summary>
+```
+
+## Workflows
+
+### Ingest (`wiki ingest <file>` or auto-triggered)
+1. Read the source.
+2. Decide: does it warrant a new `sources/` summary page? (Usually yes.)
+3. Write the summary page with frontmatter, key facts, open questions.
+4. Identify entities mentioned. For each: create a new `entities/` page if absent, or update the existing one. Add the source to its `sources:` frontmatter.
+5. Update relevant `topics/` pages if the new source changes a synthesis or contradicts a prior claim. Note contradictions explicitly with `> ⚠️ Contradicts:` blockquotes.
+6. Update `index.md` with any new pages.
+7. Append to `log.md`.
+
+### Query (`wiki query "..."`)
+1. Read `index.md` first.
+2. Use `wiki query` (qmd) to find candidate pages.
+3. Read those pages.
+4. Synthesize an answer with citations as `[page-title](relative/path.md)`.
+5. If the answer is substantive and reusable, file it as a new `topics/` page. Update index + log.
+
+### Lint (`wiki lint`)
+Check for:
+- Orphan pages (no inbound links from index or other pages)
+- Stale pages (last `updated` older than a source they cite)
+- Contradictions (pages making opposing claims about the same entity)
+- Missing entity pages (entities mentioned ≥3 times across `sources/` with no dedicated page)
+- Broken `[[wiki-links]]`
+
+Output a short report and append `[YYYY-MM-DD HH:MM] lint | <N> issues` to the log.
+
+### Stop-hook auto-update
+The hook detects file changes in the project and writes pending entries to `.wiki-llm/queue.jsonl`. When the agent runs `wiki update`, it reads the queue, decides what needs re-ingesting, and processes it. Deleted files are archived to `.wiki-llm/trash/` automatically by the hook — no LLM involvement needed for that step.
+
+## Style
+
+- Concise. Wiki pages are reference material, not essays.
+- Lead with the fact, then evidence.
+- Mark uncertainty explicitly: `> 🟡 Unverified:` blockquote.
+- Mark contradictions explicitly: `> ⚠️ Contradicts:` blockquote.
+- Cite the source page for any non-obvious claim.

--- a/Community/wiki-llm/assets/wiki-template/index.md
+++ b/Community/wiki-llm/assets/wiki-template/index.md
@@ -1,0 +1,12 @@
+# {{PROJECT_NAME}} — wiki index
+
+Content-oriented catalog of every page in this wiki. Read this first when answering a query.
+
+## Sources
+<!-- one line per page in pages/sources/ -->
+
+## Entities
+<!-- one line per page in pages/entities/ -->
+
+## Topics
+<!-- one line per page in pages/topics/ -->

--- a/Community/wiki-llm/assets/wiki-template/log.md
+++ b/Community/wiki-llm/assets/wiki-template/log.md
@@ -1,0 +1,8 @@
+# {{PROJECT_NAME}} — log
+
+Chronological event log. Append-only. Grep with `grep "^## \[" log.md | tail -10`.
+
+## [{{INIT_TIMESTAMP}}] init | wiki created
+- Project: {{PROJECT_PATH}}
+- Type: {{PROJECT_TYPE}}
+- Scope: {{INGEST_SCOPE}}

--- a/Community/wiki-llm/references/CONCEPT.md
+++ b/Community/wiki-llm/references/CONCEPT.md
@@ -1,0 +1,32 @@
+# LLM Wiki — concept
+
+Source: the user's llm-wiki idea doc (paraphrased, condensed).
+
+## Core idea
+
+LLM incrementally builds and maintains a persistent wiki rather than re-deriving knowledge from raw sources on every query. The wiki is the compounding artifact: cross-references already there, contradictions already flagged, synthesis already reflects everything ingested.
+
+## Layers
+
+1. **Raw sources** — immutable, owned by the user.
+2. **Wiki** — markdown, owned and maintained by the LLM.
+3. **Schema** — `AGENTS.md` in the wiki root, tells the LLM how the wiki is organized and what workflows to follow.
+
+## Operations
+
+- **Ingest** — read a new source, write a summary page, update affected entity/concept pages, append to log.
+- **Query** — search wiki first (via `index.md` or qmd), then read relevant pages, synthesize. Good answers can be filed back as new pages.
+- **Lint** — find orphans, stale claims, contradictions, missing cross-references, gaps worth filling.
+
+## Index vs log
+
+- `index.md` is **content-oriented** — a catalog of pages, organized by category. Read first when querying.
+- `log.md` is **chronological** — append-only `## [YYYY-MM-DD HH:MM] kind | subject` entries. Grep-friendly. Read to understand the wiki's evolution.
+
+## Maintenance burden
+
+Humans abandon wikis because the bookkeeping (cross-refs, summary updates, consistency) grows faster than the value. LLMs don't get bored. The wiki stays maintained because maintenance is near-zero cost.
+
+## What's left to the human
+
+Source curation, asking good questions, deciding emphasis. Not the bookkeeping.

--- a/Community/wiki-llm/scripts/wiki
+++ b/Community/wiki-llm/scripts/wiki
@@ -559,14 +559,120 @@ function cmdUninstallHook() {
 }
 
 // ----- install-qmd -----
-function cmdInstallQmd() {
-  if (spawnSync("which", ["qmd"]).status === 0) { console.log("qmd already installed"); return; }
-  const cargo = spawnSync("which", ["cargo"]);
-  if (cargo.status === 0) {
-    console.log("attempting `cargo install qmd`...");
-    const r = spawnSync("cargo", ["install", "qmd"], { stdio: "inherit" });
-    if (r.status === 0) return;
+function which(bin: string): string | null {
+  const r = spawnSync("which", [bin]);
+  if (r.status === 0) {
+    const out = r.stdout.toString().trim();
+    if (out) return out;
   }
+  // Probe well-known install locations not always on PATH
+  for (const dir of [join(homedir(), ".cargo", "bin"), join(homedir(), ".bun", "bin"), "/usr/local/bin"]) {
+    const cand = join(dir, bin);
+    if (existsSync(cand)) {
+      if (!process.env.PATH?.split(":").includes(dir)) process.env.PATH = `${dir}:${process.env.PATH}`;
+      return cand;
+    }
+  }
+  return null;
+}
+function tryInstallQmd(): boolean {
+  if (which("qmd")) return true;
+  // Prefer npm/bun (qmd is published as @tobi/qmd; tobi/qmd also publishes prebuilt binaries)
+  if (which("bun")) {
+    console.log("→ trying `bun add -g qmd`...");
+    if (spawnSync("bun", ["add", "-g", "qmd"], { stdio: "inherit" }).status === 0 && which("qmd")) return true;
+  }
+  if (which("npm")) {
+    console.log("→ trying `npm i -g qmd`...");
+    if (spawnSync("npm", ["i", "-g", "qmd"], { stdio: "inherit" }).status === 0 && which("qmd")) return true;
+  }
+  // Cargo fallback (requires rustup/cargo on PATH)
+  if (which("cargo")) {
+    console.log("→ trying `cargo install qmd`...");
+    if (spawnSync("cargo", ["install", "qmd"], { stdio: "inherit" }).status === 0 && which("qmd")) return true;
+  }
+  return false;
+}
+function tryInstallRustup(): boolean {
+  if (which("rustup") && which("cargo")) return true;
+  console.log("→ installing rustup (non-interactive, default profile)...");
+  const r = spawnSync("bash", ["-lc", "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal"], { stdio: "inherit" });
+  if (r.status !== 0) return false;
+  // Make cargo available in current process for downstream installs
+  const cargoBin = join(homedir(), ".cargo", "bin");
+  process.env.PATH = `${cargoBin}:${process.env.PATH}`;
+  return Boolean(which("cargo"));
+}
+function aptInstall(pkg: string): boolean {
+  if (which(pkg)) return true;
+  if (which("apt-get") && process.getuid?.() === 0) {
+    console.log(`→ apt-get install -y ${pkg}...`);
+    spawnSync("apt-get", ["update", "-y"], { stdio: "ignore" });
+    if (spawnSync("apt-get", ["install", "-y", pkg], { stdio: "inherit" }).status === 0) return Boolean(which(pkg));
+  }
+  return false;
+}
+type DepStatus = { name: string; ok: boolean; required: boolean; version?: string; note?: string };
+function checkDeps(): DepStatus[] {
+  const out: DepStatus[] = [];
+  const ver = (bin: string, arg = "--version") => {
+    try { return execSync(`${bin} ${arg} 2>/dev/null`).toString().trim().split("\n")[0]; } catch { return undefined; }
+  };
+  out.push({ name: "bun",   required: true,  ok: !!which("bun"),   version: ver("bun") });
+  out.push({ name: "git",   required: true,  ok: !!which("git"),   version: ver("git") });
+  out.push({ name: "qmd",   required: false, ok: !!which("qmd"),   version: ver("qmd"), note: "search backend (hybrid BM25+vector); ripgrep fallback if missing" });
+  out.push({ name: "rg",    required: false, ok: !!which("rg"),    version: ver("rg"),  note: "fallback search if qmd missing" });
+  out.push({ name: "rustup",required: false, ok: !!which("rustup"),version: ver("rustup"), note: "only needed if qmd can't install via npm/bun" });
+  out.push({ name: "cargo", required: false, ok: !!which("cargo"), version: ver("cargo"), note: "only needed if qmd can't install via npm/bun" });
+  return out;
+}
+function cmdDoctor(args: string[]) {
+  const fix = args.includes("--fix") || args.includes("--install");
+  const quiet = args.includes("--quiet");
+  let deps = checkDeps();
+  if (fix) {
+    if (!deps.find(d => d.name === "bun")?.ok) console.error("bun is required and must be installed manually (https://bun.sh)");
+    if (!deps.find(d => d.name === "git")?.ok) aptInstall("git");
+    if (!deps.find(d => d.name === "rg")?.ok)  aptInstall("ripgrep");
+    if (!deps.find(d => d.name === "qmd")?.ok) {
+      if (!tryInstallQmd()) {
+        // Last resort: install rustup so cargo path works
+        if (tryInstallRustup()) tryInstallQmd();
+      }
+    }
+    deps = checkDeps();
+  }
+  if (quiet) {
+    const missingReq = deps.filter(d => d.required && !d.ok);
+    if (missingReq.length) { console.error(`missing required: ${missingReq.map(d => d.name).join(", ")}`); process.exit(1); }
+    return;
+  }
+  const lines = deps.map(d => `  ${d.ok ? "✓" : (d.required ? "✗" : "·")} ${d.name.padEnd(7)} ${d.ok ? (d.version || "") : (d.required ? "MISSING (required)" : "missing (optional)")}${d.note && !d.ok ? `  — ${d.note}` : ""}`);
+  console.log("wiki-llm dependency check:\n" + lines.join("\n"));
+  const missingReq = deps.filter(d => d.required && !d.ok);
+  if (missingReq.length) {
+    console.error(`\nmissing required dependency: ${missingReq.map(d => d.name).join(", ")}. Re-run \`wiki doctor --fix\` to attempt install.`);
+    process.exit(1);
+  }
+  const missingOpt = deps.filter(d => !d.required && !d.ok);
+  if (missingOpt.length && !fix) {
+    console.log(`\nhint: run \`wiki doctor --fix\` to install optional deps (${missingOpt.map(d => d.name).join(", ")}).`);
+  }
+}
+function ensureDepsForFirstRun() {
+  // Auto-preflight on the first ever invocation in a fresh Zo instance: no registry yet.
+  if (existsSync(REGISTRY)) return;
+  const deps = checkDeps();
+  const needFix = deps.some(d => !d.ok);
+  if (!needFix) return;
+  console.error("first run detected — checking dependencies (run `wiki doctor` anytime to re-check)...");
+  cmdDoctor(["--fix"]);
+}
+function cmdInstallQmd() {
+  if (which("qmd")) { console.log("qmd already installed"); return; }
+  if (tryInstallQmd()) { console.log(`qmd installed at ${which("qmd")}`); return; }
+  console.log("qmd install via npm/bun/cargo failed; bootstrapping rustup then retrying...");
+  if (tryInstallRustup() && tryInstallQmd()) { console.log(`qmd installed at ${which("qmd")}`); return; }
   console.error("qmd install failed. Manual install: https://github.com/tobi/qmd. Skill will fall back to ripgrep search.");
   process.exit(1);
 }
@@ -588,7 +694,11 @@ const cmds: Record<string, (a: string[]) => any> = {
   "install-hook": () => cmdInstallHook(),
   "uninstall-hook": () => cmdUninstallHook(),
   "install-qmd": () => cmdInstallQmd(),
+  doctor: cmdDoctor,
 };
+// Preflight: on the first ever run (no registry), check + offer to install missing deps.
+// Skip for the doctor command itself (to avoid recursion) and the hook (cheap path).
+if (cmd && cmd !== "doctor" && cmd !== "hook" && cmds[cmd]) ensureDepsForFirstRun();
 if (!cmd || cmd === "--help" || cmd === "-h" || !cmds[cmd]) {
   console.log(`wiki — LLM-maintained wiki for any project folder
 
@@ -608,7 +718,8 @@ Commands:
   hook                   Stop-hook entrypoint (cheap, non-LLM, called by Claude Code)
   install-hook           Add Stop hook to ~/.claude/settings.json
   uninstall-hook         Remove Stop hook
-  install-qmd            Best-effort install of qmd search backend
+  install-qmd            Best-effort install of qmd search backend (tries npm/bun → cargo → rustup+cargo)
+  doctor [--fix]         Check (and optionally install) deps: bun, git, qmd, ripgrep, rustup/cargo
 
 Common flags: --project <path>  --json <answers.json>  --commit
 `);

--- a/Community/wiki-llm/scripts/wiki
+++ b/Community/wiki-llm/scripts/wiki
@@ -1,0 +1,617 @@
+#!/usr/bin/env bun
+// wiki-llm CLI — see ../SKILL.md
+import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync, readdirSync, copyFileSync, rmSync, appendFileSync } from "node:fs";
+import { join, dirname, basename, resolve, relative } from "node:path";
+import { execSync, spawnSync } from "node:child_process";
+import { homedir } from "node:os";
+
+const REGISTRY = join(homedir(), ".wiki-llm", "registry.json");
+const TEMPLATE_DIR = resolve(import.meta.dir, "..", "assets", "wiki-template");
+
+function globToRegex(g: string): RegExp {
+  // minimal glob: **/ -> (?:.*/)?, ** -> .*, * -> [^/]*, {a,b} -> (a|b)
+  let s = g.replace(/[.+^$()|\\]/g, "\\$&");
+  s = s.replace(/\{([^}]+)\}/g, (_, alts) => "(" + alts.split(",").map((x: string) => x.trim()).join("|") + ")");
+  // **/ matches zero or more directory segments (so **/*.ts matches root-level too)
+  s = s.replace(/\*\*\//g, "::DSSLASH::");
+  s = s.replace(/\*\*/g, "::DOUBLESTAR::");
+  s = s.replace(/\*/g, "[^/]*");
+  s = s.replaceAll("::DSSLASH::", "(?:.*/)?");
+  s = s.replaceAll("::DOUBLESTAR::", ".*");
+  return new RegExp("^" + s + "$");
+}
+function matchesAny(path: string, globs: string[]): boolean {
+  return globs.some(g => globToRegex(g).test(path) || globToRegex(g).test(path.replace(/\/$/, "")));
+}
+function recoverDeletedContent(projectPath: string, relpath: string, lastHead?: string): string | null {
+  // try HEAD first (file existed in latest commit, just deleted from worktree)
+  // then last_head, then the last commit that touched the path
+  const refs = ["HEAD", lastHead].filter((x): x is string => Boolean(x));
+  for (const ref of refs) {
+    try {
+      const out = execSync(`git -C ${JSON.stringify(projectPath)} show ${ref}:${JSON.stringify(relpath)} 2>/dev/null`).toString();
+      if (out.length > 0 || out === "") return out;
+    } catch {}
+  }
+  try {
+    const lastCommit = execSync(`git -C ${JSON.stringify(projectPath)} log -n 1 --pretty=format:%H -- ${JSON.stringify(relpath)} 2>/dev/null`).toString().trim();
+    if (lastCommit) {
+      const out = execSync(`git -C ${JSON.stringify(projectPath)} show ${lastCommit}:${JSON.stringify(relpath)} 2>/dev/null`).toString();
+      return out;
+    }
+  } catch {}
+  return null;
+}
+
+function filterChanges(p: Project, files: string[]): string[] {
+  // exclude wins; include must match if non-empty
+  return files.filter(f => {
+    if (f.endsWith("/")) return false; // bare dir entries from porcelain
+    if (p.exclude?.length && matchesAny(f, p.exclude)) return false;
+    if (p.include?.length && !matchesAny(f, p.include)) return false;
+    return true;
+  });
+}
+
+type Project = {
+  path: string;
+  wiki: string;
+  name: string;
+  type: string;
+  scope: string;
+  include: string[];
+  exclude: string[];
+  registered_at: string;
+};
+type Registry = { projects: Project[] };
+
+function loadRegistry(): Registry {
+  if (!existsSync(REGISTRY)) {
+    mkdirSync(dirname(REGISTRY), { recursive: true });
+    return { projects: [] };
+  }
+  return JSON.parse(readFileSync(REGISTRY, "utf-8"));
+}
+function saveRegistry(r: Registry) {
+  mkdirSync(dirname(REGISTRY), { recursive: true });
+  writeFileSync(REGISTRY, JSON.stringify(r, null, 2));
+}
+function findProject(pathOrCwd?: string): Project | null {
+  const r = loadRegistry();
+  const target = resolve(pathOrCwd || process.cwd());
+  // exact match first
+  let p = r.projects.find(p => resolve(p.path) === target);
+  if (p) return p;
+  // ancestor match
+  p = r.projects.find(p => target.startsWith(resolve(p.path) + "/"));
+  return p || null;
+}
+function requireProject(flagPath?: string): Project {
+  const p = findProject(flagPath);
+  if (!p) {
+    console.error(`error: no registered wiki-llm project at or above ${resolve(flagPath || process.cwd())}`);
+    console.error(`hint: run \`wiki init\` first, or pass --project <path>`);
+    process.exit(1);
+  }
+  return p;
+}
+function nowISO() { return new Date().toISOString().replace("T", " ").slice(0, 16); }
+function nowFile() { return new Date().toISOString().replace(/[:T]/g, "-").slice(0, 19); }
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+function detectProjectType(path: string): { type: string; defaultInclude: string[]; defaultExclude: string[] } {
+  const has = (f: string) => existsSync(join(path, f));
+  const exclude = ["node_modules/**", ".git/**", "dist/**", "build/**", "__pycache__/**", ".next/**", ".venv/**", "venv/**", ".wiki-llm/**", "Trash/**"];
+  if (has("package.json")) return { type: "js-ts-project", defaultInclude: ["**/*.{ts,tsx,js,jsx,mjs,cjs,md,json}"], defaultExclude: exclude };
+  if (has("pyproject.toml") || has("requirements.txt") || has("setup.py")) return { type: "python-project", defaultInclude: ["**/*.{py,md,toml,yaml,yml}"], defaultExclude: exclude };
+  if (has("Cargo.toml")) return { type: "rust-project", defaultInclude: ["**/*.{rs,toml,md}"], defaultExclude: exclude };
+  if (has("go.mod")) return { type: "go-project", defaultInclude: ["**/*.{go,md,mod,sum}"], defaultExclude: exclude };
+  // data folder
+  try {
+    const files = readdirSync(path).slice(0, 50);
+    const dataFiles = files.filter(f => /\.(csv|parquet|duckdb|sqlite|jsonl|tsv)$/.test(f));
+    if (dataFiles.length >= 2) return { type: "data-folder", defaultInclude: ["**/*.{md,sql,py,yaml,json}", "schema*.yaml", "README*"], defaultExclude: exclude };
+    const mdFiles = files.filter(f => /\.(md|txt|pdf)$/.test(f));
+    if (mdFiles.length >= 2) return { type: "notes-folder", defaultInclude: ["**/*.{md,txt}"], defaultExclude: exclude };
+  } catch {}
+  return { type: "generic-folder", defaultInclude: ["**/*"], defaultExclude: exclude };
+}
+
+// ----- init -----
+async function cmdInit(args: string[]) {
+  const jsonFlag = args.indexOf("--json");
+  if (jsonFlag >= 0) {
+    const answersPath = args[jsonFlag + 1];
+    if (!answersPath || !existsSync(answersPath)) { console.error("error: --json requires a path to an existing answers file"); process.exit(1); }
+    const a = JSON.parse(readFileSync(answersPath, "utf-8"));
+    return doInit(a);
+  }
+  // interactive
+  const proj = resolve(args[0] || process.cwd());
+  if (!existsSync(proj)) { console.error(`error: ${proj} does not exist`); process.exit(1); }
+  const det = detectProjectType(proj);
+  const name = basename(proj);
+  const wiki = join("/home/workspace/wiki", slugify(name));
+  console.log(JSON.stringify({
+    detected_type: det.type,
+    suggested_wiki: wiki,
+    suggested_include: det.defaultInclude,
+    suggested_exclude: det.defaultExclude,
+    questions: [
+      { id: "project_path", default: proj },
+      { id: "wiki_path", default: wiki },
+      { id: "include_globs", default: det.defaultInclude },
+      { id: "exclude_globs", default: det.defaultExclude },
+      { id: "scope", help: "code/docs/runtime/ops/notes/data/all", default: det.type.includes("project") ? "code+ops" : "all" },
+      { id: "auto_update", default: "hook" },
+      { id: "backfill", default: "yes" }
+    ],
+    hint: "Run again with --json <answers.json> to actually scaffold."
+  }, null, 2));
+}
+function doInit(a: any) {
+  const projPath = resolve(a.project_path);
+  const wikiPath = resolve(a.wiki_path);
+  const name = a.name || basename(projPath);
+  const type = a.type || detectProjectType(projPath).type;
+  mkdirSync(join(wikiPath, "pages", "sources"), { recursive: true });
+  mkdirSync(join(wikiPath, "pages", "entities"), { recursive: true });
+  mkdirSync(join(wikiPath, "pages", "topics"), { recursive: true });
+  mkdirSync(join(wikiPath, ".wiki-llm", "trash"), { recursive: true });
+  // copy template files with substitution
+  const subs = {
+    PROJECT_NAME: name,
+    PROJECT_PATH: projPath,
+    PROJECT_TYPE: type,
+    INGEST_SCOPE: a.scope || "all",
+    WIKI_ROOT: wikiPath,
+    INIT_TIMESTAMP: nowISO(),
+  };
+  for (const f of ["AGENTS.md", "index.md", "log.md"]) {
+    let body = readFileSync(join(TEMPLATE_DIR, f), "utf-8");
+    for (const [k, v] of Object.entries(subs)) body = body.replaceAll(`{{${k}}}`, v as string);
+    writeFileSync(join(wikiPath, f), body);
+  }
+  // state
+  let head = "";
+  try { head = execSync(`git -C ${JSON.stringify(projPath)} rev-parse HEAD 2>/dev/null`).toString().trim(); } catch {}
+  writeFileSync(join(wikiPath, ".wiki-llm", "state.json"), JSON.stringify({ last_head: head, last_check: nowISO() }, null, 2));
+  writeFileSync(join(wikiPath, ".wiki-llm", "queue.jsonl"), "");
+  writeFileSync(join(wikiPath, ".wiki-llm", "trash", "manifest.jsonl"), "");
+  writeFileSync(join(wikiPath, ".wiki-llm", "config.json"), JSON.stringify({
+    project: projPath, name, type, scope: a.scope || "all",
+    include: a.include_globs, exclude: a.exclude_globs,
+    auto_update: a.auto_update || "hook", backfill: a.backfill || "yes",
+  }, null, 2));
+  // register qmd collection (best-effort; non-fatal if qmd not installed)
+  try {
+    if (spawnSync("which", ["qmd"]).status === 0) {
+      spawnSync("qmd", ["collection", "add", wikiPath, "--name", slugify(name)], { stdio: "ignore" });
+      spawnSync("qmd", ["context", "add", `qmd://${slugify(name)}`, `${name} — wiki maintained by wiki-llm`], { stdio: "ignore" });
+    }
+  } catch {}
+  // register
+  const r = loadRegistry();
+  r.projects = r.projects.filter(p => resolve(p.path) !== projPath);
+  r.projects.push({
+    path: projPath, wiki: wikiPath, name, type, scope: a.scope || "all",
+    include: a.include_globs, exclude: a.exclude_globs, registered_at: nowISO(),
+  });
+  saveRegistry(r);
+  console.log(JSON.stringify({ ok: true, project: projPath, wiki: wikiPath }, null, 2));
+}
+
+// ----- status -----
+function cmdStatus() {
+  const r = loadRegistry();
+  if (r.projects.length === 0) { console.log("(no projects registered)"); return; }
+  for (const p of r.projects) {
+    const queue = join(p.wiki, ".wiki-llm", "queue.jsonl");
+    const pending = existsSync(queue) ? readFileSync(queue, "utf-8").split("\n").filter(l => l.trim()).length : 0;
+    const trash = join(p.wiki, ".wiki-llm", "trash", "manifest.jsonl");
+    const trashed = existsSync(trash) ? readFileSync(trash, "utf-8").split("\n").filter(l => l.trim()).length : 0;
+    console.log(`${p.name}\n  path:    ${p.path}\n  wiki:    ${p.wiki}\n  type:    ${p.type}\n  pending: ${pending}\n  trashed: ${trashed}`);
+  }
+}
+
+// ----- register / unregister -----
+function cmdRegister(args: string[]) {
+  const proj = resolve(args[0] || process.cwd());
+  if (!existsSync(join(proj, ".wiki-llm")) && !findProject(proj)) {
+    // attempt to find wiki via convention
+    const guess = join("/home/workspace/wiki", slugify(basename(proj)));
+    if (!existsSync(guess)) { console.error(`error: no wiki found for ${proj}. Run \`wiki init\` first.`); process.exit(1); }
+    const cfg = JSON.parse(readFileSync(join(guess, ".wiki-llm", "config.json"), "utf-8"));
+    const r = loadRegistry();
+    r.projects = r.projects.filter(p => resolve(p.path) !== proj);
+    r.projects.push({ path: proj, wiki: guess, name: cfg.name, type: cfg.type, scope: cfg.scope, include: cfg.include, exclude: cfg.exclude, registered_at: nowISO() });
+    saveRegistry(r);
+  }
+  console.log(`registered: ${proj}`);
+}
+function cmdUnregister(args: string[]) {
+  const proj = resolve(args[0] || process.cwd());
+  const r = loadRegistry();
+  const before = r.projects.length;
+  r.projects = r.projects.filter(p => resolve(p.path) !== proj);
+  saveRegistry(r);
+  console.log(`removed ${before - r.projects.length} entry(ies). Wiki files NOT deleted.`);
+}
+
+// ----- ingest -----
+function cmdIngest(args: string[]) {
+  const projFlag = args.indexOf("--project");
+  const projArg = projFlag >= 0 ? args[projFlag + 1] : undefined;
+  const file = args.find((a, i) => !a.startsWith("--") && (i === 0 || !args[i - 1].startsWith("--"))) || args[0];
+  if (!file) { console.error("usage: wiki ingest <file> [--project <path>]"); process.exit(1); }
+  const p = requireProject(projArg);
+  const fullPath = resolve(p.path, file);
+  if (!existsSync(fullPath)) { console.error(`error: ${fullPath} not found`); process.exit(1); }
+  const rel = relative(p.path, fullPath);
+  const content = readFileSync(fullPath, "utf-8");
+  const sourcePage = `pages/sources/${slugify(rel)}.md`;
+  const existing = existsSync(join(p.wiki, sourcePage)) ? readFileSync(join(p.wiki, sourcePage), "utf-8") : null;
+  // emit an instruction block for the agent
+  console.log(JSON.stringify({
+    action: "ingest",
+    project: p.name,
+    wiki: p.wiki,
+    source_relpath: rel,
+    source_abspath: fullPath,
+    target_page: sourcePage,
+    existing_page: existing,
+    content_bytes: content.length,
+    content,
+    instructions: [
+      `1. Read the source content above.`,
+      `2. Write or update ${join(p.wiki, sourcePage)} with frontmatter (kind: source, created/updated, sources: [${rel}]) and a concise summary of key facts, entities mentioned, and open questions.`,
+      `3. Identify entities/concepts. For each, create or update a page under ${join(p.wiki, "pages/entities")}/<slug>.md, adding ${rel} to its sources frontmatter.`,
+      `4. If this source changes any synthesis in pages/topics/, update those pages. Flag contradictions with > ⚠️ Contradicts: blockquotes.`,
+      `5. Add new pages to ${join(p.wiki, "index.md")} under the right section.`,
+      `6. Append a log entry to ${join(p.wiki, "log.md")}: \`## [${nowISO()}] ingest | ${rel}\`.`,
+    ],
+  }, null, 2));
+  // append to queue
+  appendFileSync(join(p.wiki, ".wiki-llm", "queue.jsonl"), JSON.stringify({ ts: nowISO(), action: "ingest", file: rel }) + "\n");
+}
+
+// ----- update (process queue + git diff) -----
+function cmdUpdate(args: string[]) {
+  const projFlag = args.indexOf("--project");
+  const p = requireProject(projFlag >= 0 ? args[projFlag + 1] : undefined);
+  const stateFile = join(p.wiki, ".wiki-llm", "state.json");
+  const state = existsSync(stateFile) ? JSON.parse(readFileSync(stateFile, "utf-8")) : { last_head: "" };
+  let curHead = "";
+  try { curHead = execSync(`git -C ${JSON.stringify(p.path)} rev-parse HEAD 2>/dev/null`).toString().trim(); } catch {}
+  let added: string[] = [], modified: string[] = [], deleted: string[] = [];
+  if (curHead && state.last_head && curHead !== state.last_head) {
+    try {
+      const diff = execSync(`git -C ${JSON.stringify(p.path)} diff --name-status ${state.last_head} ${curHead}`).toString();
+      for (const line of diff.split("\n")) {
+        const m = line.match(/^([AMDR])\s+(.+)$/);
+        if (!m) continue;
+        const [, kind, path] = m;
+        if (kind === "A") added.push(path);
+        else if (kind === "M") modified.push(path);
+        else if (kind === "D") deleted.push(path);
+        else if (kind === "R") { modified.push(path); }
+      }
+    } catch {}
+  }
+  // also unstaged changes
+  try {
+    const dirty = execSync(`git -C ${JSON.stringify(p.path)} status --porcelain`).toString();
+    for (const line of dirty.split("\n")) {
+      const m = line.match(/^(.{2})\s+(.+)$/);
+      if (!m) continue;
+      const [, flags, path] = m;
+      if (flags.includes("D") && !deleted.includes(path)) deleted.push(path);
+      else if (flags.includes("M") && !modified.includes(path)) modified.push(path);
+      else if ((flags.includes("A") || flags.includes("?")) && !added.includes(path)) added.push(path);
+    }
+  } catch {}
+  // also queue
+  const queueFile = join(p.wiki, ".wiki-llm", "queue.jsonl");
+  const queued = existsSync(queueFile) ? readFileSync(queueFile, "utf-8").split("\n").filter(l => l.trim()).map(l => JSON.parse(l)) : [];
+  // apply include/exclude filter from project config
+  added = filterChanges(p, added);
+  modified = filterChanges(p, modified);
+  deleted = filterChanges(p, deleted);
+  // archive deletions to trash
+  const trashed: string[] = [];
+  for (const d of deleted) {
+    const lastContent = recoverDeletedContent(p.path, d, state.last_head);
+    if (lastContent !== null) {
+      const stamp = nowFile();
+      const dest = join(p.wiki, ".wiki-llm", "trash", stamp, d);
+      mkdirSync(dirname(dest), { recursive: true });
+      writeFileSync(dest, lastContent);
+      appendFileSync(join(p.wiki, ".wiki-llm", "trash", "manifest.jsonl"),
+        JSON.stringify({ ts: nowISO(), stamp, relpath: d, dest, bytes: lastContent.length }) + "\n");
+      trashed.push(d);
+    }
+  }
+  console.log(JSON.stringify({
+    action: "update",
+    project: p.name,
+    wiki: p.wiki,
+    last_head: state.last_head, current_head: curHead,
+    added, modified, deleted, archived_to_trash: trashed, queued,
+    instructions: (added.length + modified.length + deleted.length + queued.length === 0)
+      ? ["Nothing to update."]
+      : [
+          `For each added/modified file: run \`wiki ingest <file>\` to get the source content + instruction block.`,
+          `For each deleted file: walk pages/sources/ and pages/entities/ that reference it, mark them with \`> ⚠️ Source deleted on ${nowISO()}\` and update synthesis accordingly. Don't delete the wiki pages — they're the historical record. The source has been archived to ${join(p.wiki, ".wiki-llm/trash")} and can be restored via \`wiki recover <relpath>\`.`,
+          `After processing, advance state: re-run \`wiki update --commit\` to mark this batch processed.`,
+        ],
+  }, null, 2));
+  if (args.includes("--commit")) {
+    writeFileSync(stateFile, JSON.stringify({ last_head: curHead, last_check: nowISO() }, null, 2));
+    writeFileSync(queueFile, "");
+    console.log(`state advanced to ${curHead || "(no git)"}`);
+  }
+}
+
+// ----- query -----
+function cmdQuery(args: string[]) {
+  const projFlag = args.indexOf("--project");
+  const p = requireProject(projFlag >= 0 ? args[projFlag + 1] : undefined);
+  const q = args.filter(a => !a.startsWith("--") && a !== (projFlag >= 0 ? args[projFlag + 1] : "")).join(" ");
+  if (!q.trim()) { console.error("usage: wiki query \"...\""); process.exit(1); }
+  // prefer qmd if installed
+  const qmd = spawnSync("which", ["qmd"]);
+  if (qmd.status === 0) {
+    const r = spawnSync("qmd", ["search", q, "-c", slugify(p.name), "-l", "10"], { encoding: "utf-8" });
+    console.log(r.stdout || r.stderr);
+    return;
+  }
+  // fallback to ripgrep over wiki
+  const r = spawnSync("rg", ["-l", "-i", "--max-count", "5", q, p.wiki], { encoding: "utf-8" });
+  console.log(JSON.stringify({
+    backend: "ripgrep-fallback",
+    note: "Install qmd for hybrid BM25+vector search: see `wiki install-qmd`",
+    matches: (r.stdout || "").split("\n").filter(Boolean),
+    instructions: ["Read each matched file, then synthesize an answer with citations as `[title](relpath.md)`."],
+  }, null, 2));
+}
+
+// ----- lint -----
+function cmdLint(args: string[]) {
+  const projFlag = args.indexOf("--project");
+  const p = requireProject(projFlag >= 0 ? args[projFlag + 1] : undefined);
+  const wikiPages = listMd(join(p.wiki, "pages"));
+  const indexBody = existsSync(join(p.wiki, "index.md")) ? readFileSync(join(p.wiki, "index.md"), "utf-8") : "";
+  const allBodies: Record<string, string> = {};
+  for (const f of wikiPages) allBodies[f] = readFileSync(f, "utf-8");
+  // orphans: pages not referenced from index or any other page
+  const orphans: string[] = [];
+  for (const f of wikiPages) {
+    const rel = relative(p.wiki, f);
+    const referenced = indexBody.includes(rel) || Object.entries(allBodies).some(([other, b]) => other !== f && (b.includes(rel) || b.includes(basename(f, ".md"))));
+    if (!referenced) orphans.push(rel);
+  }
+  // stale: page updated < a source it cites
+  const stale: { page: string; reason: string }[] = [];
+  for (const f of wikiPages) {
+    const body = allBodies[f];
+    const fm = body.match(/^---\n([\s\S]*?)\n---/);
+    if (!fm) continue;
+    const updMatch = fm[1].match(/updated:\s*(\S+)/);
+    const srcMatch = fm[1].match(/sources:\s*\[(.*?)\]/);
+    if (!updMatch || !srcMatch) continue;
+    const upd = new Date(updMatch[1]);
+    for (const s of srcMatch[1].split(",").map(x => x.trim().replace(/['"]/g, ""))) {
+      const sPath = resolve(p.path, s);
+      if (existsSync(sPath)) {
+        const mt = statSync(sPath).mtime;
+        if (mt > upd) stale.push({ page: relative(p.wiki, f), reason: `source ${s} modified ${mt.toISOString()} > page updated ${upd.toISOString()}` });
+      }
+    }
+  }
+  console.log(JSON.stringify({
+    action: "lint", project: p.name,
+    page_count: wikiPages.length,
+    orphans, stale,
+    instructions: [
+      `Resolve orphans by linking them from index.md or related pages, or delete if obsolete.`,
+      `Resolve stale pages by re-ingesting their source: \`wiki ingest <source>\`.`,
+    ],
+  }, null, 2));
+  appendFileSync(join(p.wiki, "log.md"), `\n## [${nowISO()}] lint | ${orphans.length} orphans, ${stale.length} stale\n`);
+}
+function listMd(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) out.push(...listMd(full));
+    else if (e.name.endsWith(".md")) out.push(full);
+  }
+  return out;
+}
+
+// ----- trash list / recover -----
+function cmdListDeleted(args: string[]) {
+  const projFlag = args.indexOf("--project");
+  const p = requireProject(projFlag >= 0 ? args[projFlag + 1] : undefined);
+  const m = join(p.wiki, ".wiki-llm", "trash", "manifest.jsonl");
+  if (!existsSync(m)) { console.log("(no trash)"); return; }
+  const entries = readFileSync(m, "utf-8").split("\n").filter(l => l.trim()).map(l => JSON.parse(l));
+  console.log(JSON.stringify({ project: p.name, count: entries.length, entries }, null, 2));
+}
+function cmdRecover(args: string[]) {
+  const projFlag = args.indexOf("--project");
+  const p = requireProject(projFlag >= 0 ? args[projFlag + 1] : undefined);
+  const rel = args.find((a, i) => !a.startsWith("--") && (i === 0 || !args[i - 1].startsWith("--")));
+  if (!rel) { console.error("usage: wiki recover <relpath> [--project <path>]"); process.exit(1); }
+  const m = join(p.wiki, ".wiki-llm", "trash", "manifest.jsonl");
+  if (!existsSync(m)) { console.error("error: no trash"); process.exit(1); }
+  const entries = readFileSync(m, "utf-8").split("\n").filter(l => l.trim()).map(l => JSON.parse(l)).filter((e: any) => e.relpath === rel);
+  if (entries.length === 0) { console.error(`error: no trash entry for ${rel}`); process.exit(1); }
+  const newest = entries[entries.length - 1];
+  const dest = resolve(p.path, rel);
+  mkdirSync(dirname(dest), { recursive: true });
+  copyFileSync(newest.dest, dest);
+  console.log(JSON.stringify({ ok: true, restored: dest, from: newest.dest, ts: newest.ts }, null, 2));
+}
+
+// ----- hook -----
+function cmdHook() {
+  // called by Claude Code Stop hook. Cheap, non-LLM. For each registered project,
+  // detect git changes, archive deletions to trash, append to queue.
+  const r = loadRegistry();
+  const summary: any[] = [];
+  for (const p of r.projects) {
+    if (!existsSync(p.path)) continue;
+    const stateFile = join(p.wiki, ".wiki-llm", "state.json");
+    if (!existsSync(stateFile)) continue;
+    const state = JSON.parse(readFileSync(stateFile, "utf-8"));
+    let curHead = "";
+    try { curHead = execSync(`git -C ${JSON.stringify(p.path)} rev-parse HEAD 2>/dev/null`).toString().trim(); } catch {}
+    let changes = { added: [] as string[], modified: [] as string[], deleted: [] as string[] };
+    if (curHead && state.last_head && curHead !== state.last_head) {
+      try {
+        const diff = execSync(`git -C ${JSON.stringify(p.path)} diff --name-status ${state.last_head} ${curHead}`).toString();
+        for (const line of diff.split("\n")) {
+          const m = line.match(/^([AMDR])\s+(.+)$/);
+          if (!m) continue;
+          if (m[1] === "A") changes.added.push(m[2]);
+          else if (m[1] === "M" || m[1] === "R") changes.modified.push(m[2]);
+          else if (m[1] === "D") changes.deleted.push(m[2]);
+        }
+      } catch {}
+    }
+    try {
+      const dirty = execSync(`git -C ${JSON.stringify(p.path)} status --porcelain`).toString();
+      for (const line of dirty.split("\n")) {
+        const m = line.match(/^(.{2})\s+(.+)$/);
+        if (!m) continue;
+        const [, flags, path] = m;
+        if (flags.includes("D") && !changes.deleted.includes(path)) changes.deleted.push(path);
+        else if (flags.includes("M") && !changes.modified.includes(path)) changes.modified.push(path);
+        else if ((flags.includes("A") || flags.includes("?")) && !changes.added.includes(path)) changes.added.push(path);
+      }
+    } catch {}
+    // apply include/exclude filter from project config
+    changes.added = filterChanges(p, changes.added);
+    changes.modified = filterChanges(p, changes.modified);
+    changes.deleted = filterChanges(p, changes.deleted);
+    // archive deletions
+    for (const d of changes.deleted) {
+      const lastContent = recoverDeletedContent(p.path, d, state.last_head);
+      if (lastContent !== null) {
+        const stamp = nowFile();
+        const dest = join(p.wiki, ".wiki-llm", "trash", stamp, d);
+        mkdirSync(dirname(dest), { recursive: true });
+        writeFileSync(dest, lastContent);
+        appendFileSync(join(p.wiki, ".wiki-llm", "trash", "manifest.jsonl"),
+          JSON.stringify({ ts: nowISO(), stamp, relpath: d, dest, bytes: lastContent.length, source: "stop-hook" }) + "\n");
+      }
+    }
+    // append to queue (one entry per change)
+    const queueFile = join(p.wiki, ".wiki-llm", "queue.jsonl");
+    for (const f of changes.added) appendFileSync(queueFile, JSON.stringify({ ts: nowISO(), action: "ingest", file: f, source: "hook" }) + "\n");
+    for (const f of changes.modified) appendFileSync(queueFile, JSON.stringify({ ts: nowISO(), action: "reingest", file: f, source: "hook" }) + "\n");
+    for (const f of changes.deleted) appendFileSync(queueFile, JSON.stringify({ ts: nowISO(), action: "deleted", file: f, source: "hook" }) + "\n");
+    if (changes.added.length + changes.modified.length + changes.deleted.length > 0) {
+      summary.push({ project: p.name, ...changes });
+    }
+  }
+  if (summary.length > 0) {
+    console.error(`[wiki-llm] pending updates: ${JSON.stringify(summary)}`);
+  }
+}
+
+// ----- install-hook -----
+function cmdInstallHook() {
+  const settingsPath = join(homedir(), ".claude", "settings.json");
+  const settings = existsSync(settingsPath) ? JSON.parse(readFileSync(settingsPath, "utf-8") || "{}") : {};
+  settings.hooks = settings.hooks || {};
+  settings.hooks.Stop = settings.hooks.Stop || [];
+  const wikiBin = resolve(import.meta.dir, "wiki");
+  const cmd = `${wikiBin} hook`;
+  // dedupe
+  const existing = settings.hooks.Stop.find((h: any) =>
+    (h.hooks || []).some((x: any) => x.command === cmd));
+  if (!existing) {
+    settings.hooks.Stop.push({ matcher: "", hooks: [{ type: "command", command: cmd }] });
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+    console.log(`installed Stop hook -> ${cmd}`);
+  } else {
+    console.log(`Stop hook already installed`);
+  }
+}
+function cmdUninstallHook() {
+  const settingsPath = join(homedir(), ".claude", "settings.json");
+  if (!existsSync(settingsPath)) return;
+  const settings = JSON.parse(readFileSync(settingsPath, "utf-8") || "{}");
+  const wikiBin = resolve(import.meta.dir, "wiki");
+  const cmd = `${wikiBin} hook`;
+  if (settings.hooks?.Stop) {
+    settings.hooks.Stop = settings.hooks.Stop
+      .map((h: any) => ({ ...h, hooks: (h.hooks || []).filter((x: any) => x.command !== cmd) }))
+      .filter((h: any) => (h.hooks || []).length > 0);
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+  }
+  console.log(`uninstalled Stop hook`);
+}
+
+// ----- install-qmd -----
+function cmdInstallQmd() {
+  if (spawnSync("which", ["qmd"]).status === 0) { console.log("qmd already installed"); return; }
+  const cargo = spawnSync("which", ["cargo"]);
+  if (cargo.status === 0) {
+    console.log("attempting `cargo install qmd`...");
+    const r = spawnSync("cargo", ["install", "qmd"], { stdio: "inherit" });
+    if (r.status === 0) return;
+  }
+  console.error("qmd install failed. Manual install: https://github.com/tobi/qmd. Skill will fall back to ripgrep search.");
+  process.exit(1);
+}
+
+// ----- dispatch -----
+const [, , cmd, ...rest] = process.argv;
+const cmds: Record<string, (a: string[]) => any> = {
+  init: cmdInit,
+  status: () => cmdStatus(),
+  register: cmdRegister,
+  unregister: cmdUnregister,
+  ingest: cmdIngest,
+  update: cmdUpdate,
+  query: cmdQuery,
+  lint: cmdLint,
+  "list-deleted": cmdListDeleted,
+  recover: cmdRecover,
+  hook: () => cmdHook(),
+  "install-hook": () => cmdInstallHook(),
+  "uninstall-hook": () => cmdUninstallHook(),
+  "install-qmd": () => cmdInstallQmd(),
+};
+if (!cmd || cmd === "--help" || cmd === "-h" || !cmds[cmd]) {
+  console.log(`wiki — LLM-maintained wiki for any project folder
+
+Usage: wiki <command> [args]
+
+Commands:
+  init [path]            Interactive setup (prints questions JSON; re-run with --json <answers> to scaffold)
+  status                 List registered projects + pending counts
+  register [path]        Add an existing wiki to the registry
+  unregister [path]      Remove from registry (wiki files preserved)
+  ingest <file>          Mark a source for ingestion; emits agent instruction block
+  update                 Diff vs last snapshot, archive deletions, list pending
+  query "..."            Search the wiki (qmd if installed, else ripgrep)
+  lint                   Health check: orphans, stale pages, etc.
+  list-deleted           Show files in wiki trash
+  recover <relpath>      Restore a deleted source from wiki trash
+  hook                   Stop-hook entrypoint (cheap, non-LLM, called by Claude Code)
+  install-hook           Add Stop hook to ~/.claude/settings.json
+  uninstall-hook         Remove Stop hook
+  install-qmd            Best-effort install of qmd search backend
+
+Common flags: --project <path>  --json <answers.json>  --commit
+`);
+  process.exit(cmd && !cmds[cmd] ? 1 : 0);
+}
+cmds[cmd](rest);

--- a/Community/wiki-llm/scripts/wiki
+++ b/Community/wiki-llm/scripts/wiki
@@ -1,18 +1,88 @@
 #!/usr/bin/env bun
 // wiki-llm CLI — see ../SKILL.md
-import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync, readdirSync, copyFileSync, rmSync, appendFileSync } from "node:fs";
-import { join, dirname, basename, resolve, relative } from "node:path";
-import { execSync, spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync, readdirSync, copyFileSync, rmSync, appendFileSync, renameSync, openSync, closeSync } from "node:fs";
+import { join, dirname, basename, resolve, relative, sep, isAbsolute } from "node:path";
+import { execSync, spawnSync, type SpawnSyncOptions } from "node:child_process";
 import { homedir } from "node:os";
 
 const REGISTRY = join(homedir(), ".wiki-llm", "registry.json");
 const TEMPLATE_DIR = resolve(import.meta.dir, "..", "assets", "wiki-template");
+const MAX_GIT_BUFFER = 50 * 1024 * 1024;   // 50 MB per `git show` / `git diff`
+const MAX_INGEST_BYTES = 5 * 1024 * 1024;  // 5 MB per ingested source
+const DEFAULT_TRASH_RETENTION_DAYS = 30;
+const GIT_REF_RE = /^[A-Za-z0-9._\/\-]{1,255}$/;
 
+// ---------- safety helpers ----------
+function gitSafeRef(ref: string | undefined | null): string | null {
+  if (!ref) return null;
+  return GIT_REF_RE.test(ref) ? ref : null;
+}
+/** Reject "..", absolute paths, or paths that escape `root` once resolved. */
+function safeRelpath(rel: string): string | null {
+  if (!rel || typeof rel !== "string") return null;
+  if (isAbsolute(rel)) return null;
+  const parts = rel.split(/[\\/]/);
+  if (parts.some(p => p === "..")) return null;
+  // strip leading "./" and any null bytes
+  if (rel.includes("\0")) return null;
+  return rel.replace(/^\.\//, "");
+}
+/** Ensure `child` resolves to a path under `root` (defence-in-depth around safeRelpath). */
+function isUnder(root: string, child: string): boolean {
+  const r = resolve(root) + sep;
+  const c = resolve(child);
+  return c === resolve(root) || c.startsWith(r);
+}
+function safeReadJSON<T>(path: string, fallback: T): T {
+  try {
+    if (!existsSync(path)) return fallback;
+    const raw = readFileSync(path, "utf-8");
+    if (!raw.trim()) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+function atomicWriteFile(path: string, data: string) {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp.${process.pid}.${Date.now()}`;
+  writeFileSync(tmp, data);
+  renameSync(tmp, path);
+}
+function runGit(cwd: string, args: string[], opts: SpawnSyncOptions = {}) {
+  return spawnSync("git", ["-C", cwd, ...args], {
+    encoding: "utf-8",
+    maxBuffer: MAX_GIT_BUFFER,
+    ...opts,
+  });
+}
+/** Single-process advisory lock via O_EXCL. Returns release(). */
+function acquireLock(lockPath: string, timeoutMs = 5000): (() => void) | null {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      mkdirSync(dirname(lockPath), { recursive: true });
+      const fd = openSync(lockPath, "wx");
+      writeFileSync(lockPath, String(process.pid));
+      return () => { try { closeSync(fd); } catch {}; try { rmSync(lockPath); } catch {} };
+    } catch {
+      // if lock is stale (>60s) reclaim it
+      try {
+        const st = statSync(lockPath);
+        if (Date.now() - st.mtimeMs > 60_000) rmSync(lockPath);
+      } catch {}
+      const wait = new Int32Array(new SharedArrayBuffer(4));
+      Atomics.wait(wait, 0, 0, 100);
+    }
+  }
+  return null;
+}
+
+// ---------- glob helpers ----------
 function globToRegex(g: string): RegExp {
   // minimal glob: **/ -> (?:.*/)?, ** -> .*, * -> [^/]*, {a,b} -> (a|b)
   let s = g.replace(/[.+^$()|\\]/g, "\\$&");
   s = s.replace(/\{([^}]+)\}/g, (_, alts) => "(" + alts.split(",").map((x: string) => x.trim()).join("|") + ")");
-  // **/ matches zero or more directory segments (so **/*.ts matches root-level too)
   s = s.replace(/\*\*\//g, "::DSSLASH::");
   s = s.replace(/\*\*/g, "::DOUBLESTAR::");
   s = s.replace(/\*/g, "[^/]*");
@@ -23,36 +93,39 @@ function globToRegex(g: string): RegExp {
 function matchesAny(path: string, globs: string[]): boolean {
   return globs.some(g => globToRegex(g).test(path) || globToRegex(g).test(path.replace(/\/$/, "")));
 }
-function recoverDeletedContent(projectPath: string, relpath: string, lastHead?: string): string | null {
-  // try HEAD first (file existed in latest commit, just deleted from worktree)
-  // then last_head, then the last commit that touched the path
-  const refs = ["HEAD", lastHead].filter((x): x is string => Boolean(x));
-  for (const ref of refs) {
-    try {
-      const out = execSync(`git -C ${JSON.stringify(projectPath)} show ${ref}:${JSON.stringify(relpath)} 2>/dev/null`).toString();
-      if (out.length > 0 || out === "") return out;
-    } catch {}
-  }
-  try {
-    const lastCommit = execSync(`git -C ${JSON.stringify(projectPath)} log -n 1 --pretty=format:%H -- ${JSON.stringify(relpath)} 2>/dev/null`).toString().trim();
-    if (lastCommit) {
-      const out = execSync(`git -C ${JSON.stringify(projectPath)} show ${lastCommit}:${JSON.stringify(relpath)} 2>/dev/null`).toString();
-      return out;
-    }
-  } catch {}
-  return null;
-}
-
 function filterChanges(p: Project, files: string[]): string[] {
-  // exclude wins; include must match if non-empty
   return files.filter(f => {
-    if (f.endsWith("/")) return false; // bare dir entries from porcelain
+    if (!f || f.endsWith("/")) return false;
     if (p.exclude?.length && matchesAny(f, p.exclude)) return false;
     if (p.include?.length && !matchesAny(f, p.include)) return false;
     return true;
   });
 }
 
+// ---------- git recovery (safe) ----------
+function recoverDeletedContent(projectPath: string, relpath: string, lastHead?: string): string | null {
+  const rel = safeRelpath(relpath);
+  if (!rel) return null;
+  const refs: string[] = [];
+  const head = gitSafeRef("HEAD")!;
+  refs.push(head);
+  const last = gitSafeRef(lastHead);
+  if (last) refs.push(last);
+  for (const ref of refs) {
+    const r = runGit(projectPath, ["show", `${ref}:${rel}`]);
+    if (r.status === 0 && r.stdout != null) return r.stdout;
+  }
+  // last-resort: find last commit that touched the path
+  const logR = runGit(projectPath, ["log", "-n", "1", "--pretty=format:%H", "--", rel]);
+  const lastCommit = gitSafeRef(logR.stdout?.trim());
+  if (lastCommit) {
+    const sh = runGit(projectPath, ["show", `${lastCommit}:${rel}`]);
+    if (sh.status === 0 && sh.stdout != null) return sh.stdout;
+  }
+  return null;
+}
+
+// ---------- types ----------
 type Project = {
   path: string;
   wiki: string;
@@ -62,6 +135,7 @@ type Project = {
   include: string[];
   exclude: string[];
   registered_at: string;
+  trash_retention_days?: number;
 };
 type Registry = { projects: Project[] };
 
@@ -70,20 +144,17 @@ function loadRegistry(): Registry {
     mkdirSync(dirname(REGISTRY), { recursive: true });
     return { projects: [] };
   }
-  return JSON.parse(readFileSync(REGISTRY, "utf-8"));
+  return safeReadJSON<Registry>(REGISTRY, { projects: [] });
 }
 function saveRegistry(r: Registry) {
-  mkdirSync(dirname(REGISTRY), { recursive: true });
-  writeFileSync(REGISTRY, JSON.stringify(r, null, 2));
+  atomicWriteFile(REGISTRY, JSON.stringify(r, null, 2));
 }
 function findProject(pathOrCwd?: string): Project | null {
   const r = loadRegistry();
   const target = resolve(pathOrCwd || process.cwd());
-  // exact match first
   let p = r.projects.find(p => resolve(p.path) === target);
   if (p) return p;
-  // ancestor match
-  p = r.projects.find(p => target.startsWith(resolve(p.path) + "/"));
+  p = r.projects.find(p => target.startsWith(resolve(p.path) + sep));
   return p || null;
 }
 function requireProject(flagPath?: string): Project {
@@ -107,7 +178,6 @@ function detectProjectType(path: string): { type: string; defaultInclude: string
   if (has("pyproject.toml") || has("requirements.txt") || has("setup.py")) return { type: "python-project", defaultInclude: ["**/*.{py,md,toml,yaml,yml}"], defaultExclude: exclude };
   if (has("Cargo.toml")) return { type: "rust-project", defaultInclude: ["**/*.{rs,toml,md}"], defaultExclude: exclude };
   if (has("go.mod")) return { type: "go-project", defaultInclude: ["**/*.{go,md,mod,sum}"], defaultExclude: exclude };
-  // data folder
   try {
     const files = readdirSync(path).slice(0, 50);
     const dataFiles = files.filter(f => /\.(csv|parquet|duckdb|sqlite|jsonl|tsv)$/.test(f));
@@ -118,16 +188,53 @@ function detectProjectType(path: string): { type: string; defaultInclude: string
   return { type: "generic-folder", defaultInclude: ["**/*"], defaultExclude: exclude };
 }
 
+// ---------- queue dedup ----------
+function queueAppend(queueFile: string, entry: any) {
+  const line = JSON.stringify(entry);
+  // Skip if the most recent entry for this file+action is already pending.
+  try {
+    if (existsSync(queueFile)) {
+      const lines = readFileSync(queueFile, "utf-8").split("\n").filter(Boolean);
+      for (let i = lines.length - 1; i >= 0 && i >= lines.length - 100; i--) {
+        try {
+          const prev = JSON.parse(lines[i]);
+          if (prev.file === entry.file && prev.action === entry.action) return;
+        } catch {}
+      }
+    }
+  } catch {}
+  appendFileSync(queueFile, line + "\n");
+}
+
+// ---------- trash retention ----------
+function pruneTrash(p: Project) {
+  const days = p.trash_retention_days ?? DEFAULT_TRASH_RETENTION_DAYS;
+  if (days <= 0) return; // 0 == never prune
+  const trashRoot = join(p.wiki, ".wiki-llm", "trash");
+  if (!existsSync(trashRoot)) return;
+  const cutoff = Date.now() - days * 86_400_000;
+  let pruned = 0;
+  for (const ent of readdirSync(trashRoot, { withFileTypes: true })) {
+    if (!ent.isDirectory()) continue;
+    const full = join(trashRoot, ent.name);
+    try {
+      const st = statSync(full);
+      if (st.mtimeMs < cutoff) { rmSync(full, { recursive: true, force: true }); pruned++; }
+    } catch {}
+  }
+  return pruned;
+}
+
 // ----- init -----
 async function cmdInit(args: string[]) {
   const jsonFlag = args.indexOf("--json");
   if (jsonFlag >= 0) {
     const answersPath = args[jsonFlag + 1];
     if (!answersPath || !existsSync(answersPath)) { console.error("error: --json requires a path to an existing answers file"); process.exit(1); }
-    const a = JSON.parse(readFileSync(answersPath, "utf-8"));
+    const a = safeReadJSON<any>(answersPath, null);
+    if (!a) { console.error("error: invalid JSON in answers file"); process.exit(1); }
     return doInit(a);
   }
-  // interactive
   const proj = resolve(args[0] || process.cwd());
   if (!existsSync(proj)) { console.error(`error: ${proj} does not exist`); process.exit(1); }
   const det = detectProjectType(proj);
@@ -145,9 +252,10 @@ async function cmdInit(args: string[]) {
       { id: "exclude_globs", default: det.defaultExclude },
       { id: "scope", help: "code/docs/runtime/ops/notes/data/all", default: det.type.includes("project") ? "code+ops" : "all" },
       { id: "auto_update", default: "hook" },
-      { id: "backfill", default: "yes" }
+      { id: "backfill", default: "yes" },
+      { id: "trash_retention_days", default: DEFAULT_TRASH_RETENTION_DAYS },
     ],
-    hint: "Run again with --json <answers.json> to actually scaffold."
+    hint: "Run again with --json <answers.json> to actually scaffold.",
   }, null, 2));
 }
 function doInit(a: any) {
@@ -159,7 +267,6 @@ function doInit(a: any) {
   mkdirSync(join(wikiPath, "pages", "entities"), { recursive: true });
   mkdirSync(join(wikiPath, "pages", "topics"), { recursive: true });
   mkdirSync(join(wikiPath, ".wiki-llm", "trash"), { recursive: true });
-  // copy template files with substitution
   const subs = {
     PROJECT_NAME: name,
     PROJECT_PATH: projPath,
@@ -173,30 +280,30 @@ function doInit(a: any) {
     for (const [k, v] of Object.entries(subs)) body = body.replaceAll(`{{${k}}}`, v as string);
     writeFileSync(join(wikiPath, f), body);
   }
-  // state
   let head = "";
-  try { head = execSync(`git -C ${JSON.stringify(projPath)} rev-parse HEAD 2>/dev/null`).toString().trim(); } catch {}
-  writeFileSync(join(wikiPath, ".wiki-llm", "state.json"), JSON.stringify({ last_head: head, last_check: nowISO() }, null, 2));
+  const headR = runGit(projPath, ["rev-parse", "HEAD"]);
+  if (headR.status === 0) head = (headR.stdout || "").trim();
+  atomicWriteFile(join(wikiPath, ".wiki-llm", "state.json"), JSON.stringify({ last_head: gitSafeRef(head) || "", last_check: nowISO() }, null, 2));
   writeFileSync(join(wikiPath, ".wiki-llm", "queue.jsonl"), "");
   writeFileSync(join(wikiPath, ".wiki-llm", "trash", "manifest.jsonl"), "");
-  writeFileSync(join(wikiPath, ".wiki-llm", "config.json"), JSON.stringify({
+  atomicWriteFile(join(wikiPath, ".wiki-llm", "config.json"), JSON.stringify({
     project: projPath, name, type, scope: a.scope || "all",
     include: a.include_globs, exclude: a.exclude_globs,
     auto_update: a.auto_update || "hook", backfill: a.backfill || "yes",
+    trash_retention_days: typeof a.trash_retention_days === "number" ? a.trash_retention_days : DEFAULT_TRASH_RETENTION_DAYS,
   }, null, 2));
-  // register qmd collection (best-effort; non-fatal if qmd not installed)
   try {
-    if (spawnSync("which", ["qmd"]).status === 0) {
+    if (which("qmd")) {
       spawnSync("qmd", ["collection", "add", wikiPath, "--name", slugify(name)], { stdio: "ignore" });
       spawnSync("qmd", ["context", "add", `qmd://${slugify(name)}`, `${name} — wiki maintained by wiki-llm`], { stdio: "ignore" });
     }
   } catch {}
-  // register
   const r = loadRegistry();
   r.projects = r.projects.filter(p => resolve(p.path) !== projPath);
   r.projects.push({
     path: projPath, wiki: wikiPath, name, type, scope: a.scope || "all",
     include: a.include_globs, exclude: a.exclude_globs, registered_at: nowISO(),
+    trash_retention_days: typeof a.trash_retention_days === "number" ? a.trash_retention_days : DEFAULT_TRASH_RETENTION_DAYS,
   });
   saveRegistry(r);
   console.log(JSON.stringify({ ok: true, project: projPath, wiki: wikiPath }, null, 2));
@@ -219,13 +326,13 @@ function cmdStatus() {
 function cmdRegister(args: string[]) {
   const proj = resolve(args[0] || process.cwd());
   if (!existsSync(join(proj, ".wiki-llm")) && !findProject(proj)) {
-    // attempt to find wiki via convention
     const guess = join("/home/workspace/wiki", slugify(basename(proj)));
     if (!existsSync(guess)) { console.error(`error: no wiki found for ${proj}. Run \`wiki init\` first.`); process.exit(1); }
-    const cfg = JSON.parse(readFileSync(join(guess, ".wiki-llm", "config.json"), "utf-8"));
+    const cfg = safeReadJSON<any>(join(guess, ".wiki-llm", "config.json"), null);
+    if (!cfg) { console.error(`error: corrupt config at ${guess}`); process.exit(1); }
     const r = loadRegistry();
     r.projects = r.projects.filter(p => resolve(p.path) !== proj);
-    r.projects.push({ path: proj, wiki: guess, name: cfg.name, type: cfg.type, scope: cfg.scope, include: cfg.include, exclude: cfg.exclude, registered_at: nowISO() });
+    r.projects.push({ path: proj, wiki: guess, name: cfg.name, type: cfg.type, scope: cfg.scope, include: cfg.include, exclude: cfg.exclude, registered_at: nowISO(), trash_retention_days: cfg.trash_retention_days });
     saveRegistry(r);
   }
   console.log(`registered: ${proj}`);
@@ -246,13 +353,20 @@ function cmdIngest(args: string[]) {
   const file = args.find((a, i) => !a.startsWith("--") && (i === 0 || !args[i - 1].startsWith("--"))) || args[0];
   if (!file) { console.error("usage: wiki ingest <file> [--project <path>]"); process.exit(1); }
   const p = requireProject(projArg);
-  const fullPath = resolve(p.path, file);
+  const safeRel = safeRelpath(file);
+  if (!safeRel && !isAbsolute(file)) { console.error(`error: invalid relative path: ${file}`); process.exit(1); }
+  const fullPath = isAbsolute(file) ? resolve(file) : resolve(p.path, safeRel!);
+  if (!isUnder(p.path, fullPath)) { console.error(`error: ${fullPath} escapes project root`); process.exit(1); }
   if (!existsSync(fullPath)) { console.error(`error: ${fullPath} not found`); process.exit(1); }
+  const st = statSync(fullPath);
+  if (st.size > MAX_INGEST_BYTES) {
+    console.error(`error: ${fullPath} is ${st.size} bytes; exceeds MAX_INGEST_BYTES=${MAX_INGEST_BYTES}. Split or chunk before ingesting.`);
+    process.exit(1);
+  }
   const rel = relative(p.path, fullPath);
   const content = readFileSync(fullPath, "utf-8");
   const sourcePage = `pages/sources/${slugify(rel)}.md`;
   const existing = existsSync(join(p.wiki, sourcePage)) ? readFileSync(join(p.wiki, sourcePage), "utf-8") : null;
-  // emit an instruction block for the agent
   console.log(JSON.stringify({
     action: "ingest",
     project: p.name,
@@ -272,37 +386,33 @@ function cmdIngest(args: string[]) {
       `6. Append a log entry to ${join(p.wiki, "log.md")}: \`## [${nowISO()}] ingest | ${rel}\`.`,
     ],
   }, null, 2));
-  // append to queue
-  appendFileSync(join(p.wiki, ".wiki-llm", "queue.jsonl"), JSON.stringify({ ts: nowISO(), action: "ingest", file: rel }) + "\n");
+  queueAppend(join(p.wiki, ".wiki-llm", "queue.jsonl"), { ts: nowISO(), action: "ingest", file: rel });
 }
 
-// ----- update (process queue + git diff) -----
-function cmdUpdate(args: string[]) {
-  const projFlag = args.indexOf("--project");
-  const p = requireProject(projFlag >= 0 ? args[projFlag + 1] : undefined);
-  const stateFile = join(p.wiki, ".wiki-llm", "state.json");
-  const state = existsSync(stateFile) ? JSON.parse(readFileSync(stateFile, "utf-8")) : { last_head: "" };
+// ----- update -----
+function collectChanges(p: Project, lastHead: string | undefined): { added: string[]; modified: string[]; deleted: string[]; curHead: string } {
   let curHead = "";
-  try { curHead = execSync(`git -C ${JSON.stringify(p.path)} rev-parse HEAD 2>/dev/null`).toString().trim(); } catch {}
+  const headR = runGit(p.path, ["rev-parse", "HEAD"]);
+  if (headR.status === 0) curHead = (headR.stdout || "").trim();
+  curHead = gitSafeRef(curHead) || "";
+  const safeLast = gitSafeRef(lastHead);
   let added: string[] = [], modified: string[] = [], deleted: string[] = [];
-  if (curHead && state.last_head && curHead !== state.last_head) {
-    try {
-      const diff = execSync(`git -C ${JSON.stringify(p.path)} diff --name-status ${state.last_head} ${curHead}`).toString();
-      for (const line of diff.split("\n")) {
+  if (curHead && safeLast && curHead !== safeLast) {
+    const diff = runGit(p.path, ["diff", "--name-status", safeLast, curHead]);
+    if (diff.status === 0) {
+      for (const line of (diff.stdout || "").split("\n")) {
         const m = line.match(/^([AMDR])\s+(.+)$/);
         if (!m) continue;
         const [, kind, path] = m;
         if (kind === "A") added.push(path);
-        else if (kind === "M") modified.push(path);
+        else if (kind === "M" || kind === "R") modified.push(path);
         else if (kind === "D") deleted.push(path);
-        else if (kind === "R") { modified.push(path); }
       }
-    } catch {}
+    }
   }
-  // also unstaged changes
-  try {
-    const dirty = execSync(`git -C ${JSON.stringify(p.path)} status --porcelain`).toString();
-    for (const line of dirty.split("\n")) {
+  const dirty = runGit(p.path, ["status", "--porcelain"]);
+  if (dirty.status === 0) {
+    for (const line of (dirty.stdout || "").split("\n")) {
       const m = line.match(/^(.{2})\s+(.+)$/);
       if (!m) continue;
       const [, flags, path] = m;
@@ -310,34 +420,46 @@ function cmdUpdate(args: string[]) {
       else if (flags.includes("M") && !modified.includes(path)) modified.push(path);
       else if ((flags.includes("A") || flags.includes("?")) && !added.includes(path)) added.push(path);
     }
-  } catch {}
-  // also queue
+  }
+  return { added, modified, deleted, curHead };
+}
+function cmdUpdate(args: string[]) {
+  const projFlag = args.indexOf("--project");
+  const p = requireProject(projFlag >= 0 ? args[projFlag + 1] : undefined);
+  const stateFile = join(p.wiki, ".wiki-llm", "state.json");
+  const state = safeReadJSON<{ last_head?: string }>(stateFile, { last_head: "" });
+  let { added, modified, deleted, curHead } = collectChanges(p, state.last_head);
   const queueFile = join(p.wiki, ".wiki-llm", "queue.jsonl");
-  const queued = existsSync(queueFile) ? readFileSync(queueFile, "utf-8").split("\n").filter(l => l.trim()).map(l => JSON.parse(l)) : [];
-  // apply include/exclude filter from project config
+  const queued = existsSync(queueFile)
+    ? readFileSync(queueFile, "utf-8").split("\n").filter(l => l.trim()).map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean)
+    : [];
   added = filterChanges(p, added);
   modified = filterChanges(p, modified);
   deleted = filterChanges(p, deleted);
-  // archive deletions to trash
+  // archive deletions
   const trashed: string[] = [];
   for (const d of deleted) {
-    const lastContent = recoverDeletedContent(p.path, d, state.last_head);
+    const safeD = safeRelpath(d);
+    if (!safeD) continue;
+    const lastContent = recoverDeletedContent(p.path, safeD, state.last_head);
     if (lastContent !== null) {
       const stamp = nowFile();
-      const dest = join(p.wiki, ".wiki-llm", "trash", stamp, d);
+      const dest = join(p.wiki, ".wiki-llm", "trash", stamp, safeD);
+      if (!isUnder(join(p.wiki, ".wiki-llm", "trash"), dest)) continue;
       mkdirSync(dirname(dest), { recursive: true });
       writeFileSync(dest, lastContent);
       appendFileSync(join(p.wiki, ".wiki-llm", "trash", "manifest.jsonl"),
-        JSON.stringify({ ts: nowISO(), stamp, relpath: d, dest, bytes: lastContent.length }) + "\n");
-      trashed.push(d);
+        JSON.stringify({ ts: nowISO(), stamp, relpath: safeD, dest, bytes: lastContent.length }) + "\n");
+      trashed.push(safeD);
     }
   }
+  const pruned = pruneTrash(p);
   console.log(JSON.stringify({
     action: "update",
     project: p.name,
     wiki: p.wiki,
     last_head: state.last_head, current_head: curHead,
-    added, modified, deleted, archived_to_trash: trashed, queued,
+    added, modified, deleted, archived_to_trash: trashed, trash_pruned: pruned, queued,
     instructions: (added.length + modified.length + deleted.length + queued.length === 0)
       ? ["Nothing to update."]
       : [
@@ -347,7 +469,7 @@ function cmdUpdate(args: string[]) {
         ],
   }, null, 2));
   if (args.includes("--commit")) {
-    writeFileSync(stateFile, JSON.stringify({ last_head: curHead, last_check: nowISO() }, null, 2));
+    atomicWriteFile(stateFile, JSON.stringify({ last_head: curHead, last_check: nowISO() }, null, 2));
     writeFileSync(queueFile, "");
     console.log(`state advanced to ${curHead || "(no git)"}`);
   }
@@ -359,14 +481,11 @@ function cmdQuery(args: string[]) {
   const p = requireProject(projFlag >= 0 ? args[projFlag + 1] : undefined);
   const q = args.filter(a => !a.startsWith("--") && a !== (projFlag >= 0 ? args[projFlag + 1] : "")).join(" ");
   if (!q.trim()) { console.error("usage: wiki query \"...\""); process.exit(1); }
-  // prefer qmd if installed
-  const qmd = spawnSync("which", ["qmd"]);
-  if (qmd.status === 0) {
+  if (which("qmd")) {
     const r = spawnSync("qmd", ["search", q, "-c", slugify(p.name), "-l", "10"], { encoding: "utf-8" });
     console.log(r.stdout || r.stderr);
     return;
   }
-  // fallback to ripgrep over wiki
   const r = spawnSync("rg", ["-l", "-i", "--max-count", "5", q, p.wiki], { encoding: "utf-8" });
   console.log(JSON.stringify({
     backend: "ripgrep-fallback",
@@ -382,31 +501,43 @@ function cmdLint(args: string[]) {
   const p = requireProject(projFlag >= 0 ? args[projFlag + 1] : undefined);
   const wikiPages = listMd(join(p.wiki, "pages"));
   const indexBody = existsSync(join(p.wiki, "index.md")) ? readFileSync(join(p.wiki, "index.md"), "utf-8") : "";
-  const allBodies: Record<string, string> = {};
-  for (const f of wikiPages) allBodies[f] = readFileSync(f, "utf-8");
-  // orphans: pages not referenced from index or any other page
+  // Build a single concatenated view of all bodies, avoiding O(N²) memory per-pair.
+  const refSet = new Set<string>();
+  for (const f of wikiPages) {
+    try {
+      const body = readFileSync(f, "utf-8");
+      for (const m of body.matchAll(/\]\(([^)]+\.md)\)/g)) refSet.add(m[1]);
+    } catch {}
+  }
   const orphans: string[] = [];
   for (const f of wikiPages) {
     const rel = relative(p.wiki, f);
-    const referenced = indexBody.includes(rel) || Object.entries(allBodies).some(([other, b]) => other !== f && (b.includes(rel) || b.includes(basename(f, ".md"))));
-    if (!referenced) orphans.push(rel);
+    const slug = basename(f, ".md");
+    if (indexBody.includes(rel) || refSet.has(rel) || refSet.has(slug)) continue;
+    orphans.push(rel);
   }
-  // stale: page updated < a source it cites
   const stale: { page: string; reason: string }[] = [];
   for (const f of wikiPages) {
-    const body = allBodies[f];
+    let body: string;
+    try { body = readFileSync(f, "utf-8"); } catch { continue; }
     const fm = body.match(/^---\n([\s\S]*?)\n---/);
     if (!fm) continue;
     const updMatch = fm[1].match(/updated:\s*(\S+)/);
     const srcMatch = fm[1].match(/sources:\s*\[(.*?)\]/);
     if (!updMatch || !srcMatch) continue;
     const upd = new Date(updMatch[1]);
+    if (isNaN(upd.getTime())) continue;
     for (const s of srcMatch[1].split(",").map(x => x.trim().replace(/['"]/g, ""))) {
-      const sPath = resolve(p.path, s);
-      if (existsSync(sPath)) {
-        const mt = statSync(sPath).mtime;
-        if (mt > upd) stale.push({ page: relative(p.wiki, f), reason: `source ${s} modified ${mt.toISOString()} > page updated ${upd.toISOString()}` });
-      }
+      const safe = safeRelpath(s);
+      if (!safe) continue;
+      const sPath = resolve(p.path, safe);
+      if (!isUnder(p.path, sPath)) continue;
+      try {
+        if (existsSync(sPath)) {
+          const mt = statSync(sPath).mtime;
+          if (mt > upd) stale.push({ page: relative(p.wiki, f), reason: `source ${safe} modified ${mt.toISOString()} > page updated ${upd.toISOString()}` });
+        }
+      } catch {}
     }
   }
   console.log(JSON.stringify({
@@ -437,7 +568,7 @@ function cmdListDeleted(args: string[]) {
   const p = requireProject(projFlag >= 0 ? args[projFlag + 1] : undefined);
   const m = join(p.wiki, ".wiki-llm", "trash", "manifest.jsonl");
   if (!existsSync(m)) { console.log("(no trash)"); return; }
-  const entries = readFileSync(m, "utf-8").split("\n").filter(l => l.trim()).map(l => JSON.parse(l));
+  const entries = readFileSync(m, "utf-8").split("\n").filter(l => l.trim()).map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
   console.log(JSON.stringify({ project: p.name, count: entries.length, entries }, null, 2));
 }
 function cmdRecover(args: string[]) {
@@ -445,12 +576,19 @@ function cmdRecover(args: string[]) {
   const p = requireProject(projFlag >= 0 ? args[projFlag + 1] : undefined);
   const rel = args.find((a, i) => !a.startsWith("--") && (i === 0 || !args[i - 1].startsWith("--")));
   if (!rel) { console.error("usage: wiki recover <relpath> [--project <path>]"); process.exit(1); }
+  const safe = safeRelpath(rel);
+  if (!safe) { console.error(`error: invalid relpath: ${rel}`); process.exit(1); }
   const m = join(p.wiki, ".wiki-llm", "trash", "manifest.jsonl");
   if (!existsSync(m)) { console.error("error: no trash"); process.exit(1); }
-  const entries = readFileSync(m, "utf-8").split("\n").filter(l => l.trim()).map(l => JSON.parse(l)).filter((e: any) => e.relpath === rel);
-  if (entries.length === 0) { console.error(`error: no trash entry for ${rel}`); process.exit(1); }
+  const entries = readFileSync(m, "utf-8").split("\n").filter(l => l.trim())
+    .map(l => { try { return JSON.parse(l); } catch { return null; } })
+    .filter((e: any) => e && e.relpath === safe);
+  if (entries.length === 0) { console.error(`error: no trash entry for ${safe}`); process.exit(1); }
   const newest = entries[entries.length - 1];
-  const dest = resolve(p.path, rel);
+  const dest = resolve(p.path, safe);
+  if (!isUnder(p.path, dest)) { console.error(`error: restore destination ${dest} escapes project root`); process.exit(1); }
+  // Source path must live under the wiki trash root (defence-in-depth against a tampered manifest).
+  if (!isUnder(join(p.wiki, ".wiki-llm", "trash"), newest.dest)) { console.error(`error: corrupt trash manifest`); process.exit(1); }
   mkdirSync(dirname(dest), { recursive: true });
   copyFileSync(newest.dest, dest);
   console.log(JSON.stringify({ ok: true, restored: dest, from: newest.dest, ts: newest.ts }, null, 2));
@@ -458,86 +596,62 @@ function cmdRecover(args: string[]) {
 
 // ----- hook -----
 function cmdHook() {
-  // called by Claude Code Stop hook. Cheap, non-LLM. For each registered project,
-  // detect git changes, archive deletions to trash, append to queue.
-  const r = loadRegistry();
-  const summary: any[] = [];
-  for (const p of r.projects) {
-    if (!existsSync(p.path)) continue;
-    const stateFile = join(p.wiki, ".wiki-llm", "state.json");
-    if (!existsSync(stateFile)) continue;
-    const state = JSON.parse(readFileSync(stateFile, "utf-8"));
-    let curHead = "";
-    try { curHead = execSync(`git -C ${JSON.stringify(p.path)} rev-parse HEAD 2>/dev/null`).toString().trim(); } catch {}
-    let changes = { added: [] as string[], modified: [] as string[], deleted: [] as string[] };
-    if (curHead && state.last_head && curHead !== state.last_head) {
-      try {
-        const diff = execSync(`git -C ${JSON.stringify(p.path)} diff --name-status ${state.last_head} ${curHead}`).toString();
-        for (const line of diff.split("\n")) {
-          const m = line.match(/^([AMDR])\s+(.+)$/);
-          if (!m) continue;
-          if (m[1] === "A") changes.added.push(m[2]);
-          else if (m[1] === "M" || m[1] === "R") changes.modified.push(m[2]);
-          else if (m[1] === "D") changes.deleted.push(m[2]);
+  // single-flight: avoid two concurrent Stop-hook fires corrupting the queue.
+  const lock = acquireLock(join(homedir(), ".wiki-llm", "hook.lock"), 2000);
+  if (!lock) return; // another hook is running; let it handle this turn
+  try {
+    const r = loadRegistry();
+    const summary: any[] = [];
+    for (const p of r.projects) {
+      if (!existsSync(p.path)) continue;
+      const stateFile = join(p.wiki, ".wiki-llm", "state.json");
+      if (!existsSync(stateFile)) continue;
+      const state = safeReadJSON<{ last_head?: string }>(stateFile, { last_head: "" });
+      let changes = collectChanges(p, state.last_head);
+      const filteredAdded = filterChanges(p, changes.added);
+      const filteredMod   = filterChanges(p, changes.modified);
+      const filteredDel   = filterChanges(p, changes.deleted);
+      for (const d of filteredDel) {
+        const safeD = safeRelpath(d);
+        if (!safeD) continue;
+        const lastContent = recoverDeletedContent(p.path, safeD, state.last_head);
+        if (lastContent !== null) {
+          const stamp = nowFile();
+          const dest = join(p.wiki, ".wiki-llm", "trash", stamp, safeD);
+          if (!isUnder(join(p.wiki, ".wiki-llm", "trash"), dest)) continue;
+          mkdirSync(dirname(dest), { recursive: true });
+          writeFileSync(dest, lastContent);
+          appendFileSync(join(p.wiki, ".wiki-llm", "trash", "manifest.jsonl"),
+            JSON.stringify({ ts: nowISO(), stamp, relpath: safeD, dest, bytes: lastContent.length, source: "stop-hook" }) + "\n");
         }
-      } catch {}
-    }
-    try {
-      const dirty = execSync(`git -C ${JSON.stringify(p.path)} status --porcelain`).toString();
-      for (const line of dirty.split("\n")) {
-        const m = line.match(/^(.{2})\s+(.+)$/);
-        if (!m) continue;
-        const [, flags, path] = m;
-        if (flags.includes("D") && !changes.deleted.includes(path)) changes.deleted.push(path);
-        else if (flags.includes("M") && !changes.modified.includes(path)) changes.modified.push(path);
-        else if ((flags.includes("A") || flags.includes("?")) && !changes.added.includes(path)) changes.added.push(path);
       }
-    } catch {}
-    // apply include/exclude filter from project config
-    changes.added = filterChanges(p, changes.added);
-    changes.modified = filterChanges(p, changes.modified);
-    changes.deleted = filterChanges(p, changes.deleted);
-    // archive deletions
-    for (const d of changes.deleted) {
-      const lastContent = recoverDeletedContent(p.path, d, state.last_head);
-      if (lastContent !== null) {
-        const stamp = nowFile();
-        const dest = join(p.wiki, ".wiki-llm", "trash", stamp, d);
-        mkdirSync(dirname(dest), { recursive: true });
-        writeFileSync(dest, lastContent);
-        appendFileSync(join(p.wiki, ".wiki-llm", "trash", "manifest.jsonl"),
-          JSON.stringify({ ts: nowISO(), stamp, relpath: d, dest, bytes: lastContent.length, source: "stop-hook" }) + "\n");
+      const queueFile = join(p.wiki, ".wiki-llm", "queue.jsonl");
+      for (const f of filteredAdded) queueAppend(queueFile, { ts: nowISO(), action: "ingest",   file: f, source: "hook" });
+      for (const f of filteredMod)   queueAppend(queueFile, { ts: nowISO(), action: "reingest", file: f, source: "hook" });
+      for (const f of filteredDel)   queueAppend(queueFile, { ts: nowISO(), action: "deleted",  file: f, source: "hook" });
+      if (filteredAdded.length + filteredMod.length + filteredDel.length > 0) {
+        summary.push({ project: p.name, added: filteredAdded, modified: filteredMod, deleted: filteredDel });
       }
     }
-    // append to queue (one entry per change)
-    const queueFile = join(p.wiki, ".wiki-llm", "queue.jsonl");
-    for (const f of changes.added) appendFileSync(queueFile, JSON.stringify({ ts: nowISO(), action: "ingest", file: f, source: "hook" }) + "\n");
-    for (const f of changes.modified) appendFileSync(queueFile, JSON.stringify({ ts: nowISO(), action: "reingest", file: f, source: "hook" }) + "\n");
-    for (const f of changes.deleted) appendFileSync(queueFile, JSON.stringify({ ts: nowISO(), action: "deleted", file: f, source: "hook" }) + "\n");
-    if (changes.added.length + changes.modified.length + changes.deleted.length > 0) {
-      summary.push({ project: p.name, ...changes });
-    }
-  }
-  if (summary.length > 0) {
-    console.error(`[wiki-llm] pending updates: ${JSON.stringify(summary)}`);
+    if (summary.length > 0) console.error(`[wiki-llm] pending updates: ${JSON.stringify(summary)}`);
+  } finally {
+    lock();
   }
 }
 
 // ----- install-hook -----
 function cmdInstallHook() {
   const settingsPath = join(homedir(), ".claude", "settings.json");
-  const settings = existsSync(settingsPath) ? JSON.parse(readFileSync(settingsPath, "utf-8") || "{}") : {};
+  const settings = safeReadJSON<any>(settingsPath, {});
   settings.hooks = settings.hooks || {};
   settings.hooks.Stop = settings.hooks.Stop || [];
   const wikiBin = resolve(import.meta.dir, "wiki");
   const cmd = `${wikiBin} hook`;
-  // dedupe
   const existing = settings.hooks.Stop.find((h: any) =>
     (h.hooks || []).some((x: any) => x.command === cmd));
   if (!existing) {
     settings.hooks.Stop.push({ matcher: "", hooks: [{ type: "command", command: cmd }] });
-    mkdirSync(dirname(settingsPath), { recursive: true });
-    writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+    atomicWriteFile(settingsPath, JSON.stringify(settings, null, 2));
     console.log(`installed Stop hook -> ${cmd}`);
   } else {
     console.log(`Stop hook already installed`);
@@ -546,61 +660,64 @@ function cmdInstallHook() {
 function cmdUninstallHook() {
   const settingsPath = join(homedir(), ".claude", "settings.json");
   if (!existsSync(settingsPath)) return;
-  const settings = JSON.parse(readFileSync(settingsPath, "utf-8") || "{}");
+  const settings = safeReadJSON<any>(settingsPath, {});
   const wikiBin = resolve(import.meta.dir, "wiki");
   const cmd = `${wikiBin} hook`;
   if (settings.hooks?.Stop) {
     settings.hooks.Stop = settings.hooks.Stop
       .map((h: any) => ({ ...h, hooks: (h.hooks || []).filter((x: any) => x.command !== cmd) }))
       .filter((h: any) => (h.hooks || []).length > 0);
-    writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+    atomicWriteFile(settingsPath, JSON.stringify(settings, null, 2));
   }
   console.log(`uninstalled Stop hook`);
 }
 
-// ----- install-qmd -----
+// ----- dep / install helpers -----
+const _whichCache = new Map<string, string | null>();
 function which(bin: string): string | null {
+  if (_whichCache.has(bin)) return _whichCache.get(bin)!;
   const r = spawnSync("which", [bin]);
   if (r.status === 0) {
     const out = r.stdout.toString().trim();
-    if (out) return out;
+    if (out) { _whichCache.set(bin, out); return out; }
   }
-  // Probe well-known install locations not always on PATH
   for (const dir of [join(homedir(), ".cargo", "bin"), join(homedir(), ".bun", "bin"), "/usr/local/bin"]) {
     const cand = join(dir, bin);
     if (existsSync(cand)) {
       if (!process.env.PATH?.split(":").includes(dir)) process.env.PATH = `${dir}:${process.env.PATH}`;
+      _whichCache.set(bin, cand);
       return cand;
     }
   }
+  _whichCache.set(bin, null);
   return null;
 }
+function clearWhich(bin: string) { _whichCache.delete(bin); }
 function tryInstallQmd(): boolean {
   if (which("qmd")) return true;
-  // Prefer npm/bun (qmd is published as @tobi/qmd; tobi/qmd also publishes prebuilt binaries)
   if (which("bun")) {
     console.log("→ trying `bun add -g qmd`...");
-    if (spawnSync("bun", ["add", "-g", "qmd"], { stdio: "inherit" }).status === 0 && which("qmd")) return true;
+    if (spawnSync("bun", ["add", "-g", "qmd"], { stdio: "inherit" }).status === 0) { clearWhich("qmd"); if (which("qmd")) return true; }
   }
   if (which("npm")) {
     console.log("→ trying `npm i -g qmd`...");
-    if (spawnSync("npm", ["i", "-g", "qmd"], { stdio: "inherit" }).status === 0 && which("qmd")) return true;
+    if (spawnSync("npm", ["i", "-g", "qmd"], { stdio: "inherit" }).status === 0) { clearWhich("qmd"); if (which("qmd")) return true; }
   }
-  // Cargo fallback (requires rustup/cargo on PATH)
   if (which("cargo")) {
     console.log("→ trying `cargo install qmd`...");
-    if (spawnSync("cargo", ["install", "qmd"], { stdio: "inherit" }).status === 0 && which("qmd")) return true;
+    if (spawnSync("cargo", ["install", "qmd"], { stdio: "inherit" }).status === 0) { clearWhich("qmd"); if (which("qmd")) return true; }
   }
   return false;
 }
 function tryInstallRustup(): boolean {
   if (which("rustup") && which("cargo")) return true;
   console.log("→ installing rustup (non-interactive, default profile)...");
+  // Use spawnSync directly with explicit args; no shell interpolation of user data.
   const r = spawnSync("bash", ["-lc", "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal"], { stdio: "inherit" });
   if (r.status !== 0) return false;
-  // Make cargo available in current process for downstream installs
   const cargoBin = join(homedir(), ".cargo", "bin");
   process.env.PATH = `${cargoBin}:${process.env.PATH}`;
+  clearWhich("cargo"); clearWhich("rustup");
   return Boolean(which("cargo"));
 }
 function aptInstall(pkg: string): boolean {
@@ -608,7 +725,7 @@ function aptInstall(pkg: string): boolean {
   if (which("apt-get") && process.getuid?.() === 0) {
     console.log(`→ apt-get install -y ${pkg}...`);
     spawnSync("apt-get", ["update", "-y"], { stdio: "ignore" });
-    if (spawnSync("apt-get", ["install", "-y", pkg], { stdio: "inherit" }).status === 0) return Boolean(which(pkg));
+    if (spawnSync("apt-get", ["install", "-y", pkg], { stdio: "inherit" }).status === 0) { clearWhich(pkg); return Boolean(which(pkg)); }
   }
   return false;
 }
@@ -616,7 +733,7 @@ type DepStatus = { name: string; ok: boolean; required: boolean; version?: strin
 function checkDeps(): DepStatus[] {
   const out: DepStatus[] = [];
   const ver = (bin: string, arg = "--version") => {
-    try { return execSync(`${bin} ${arg} 2>/dev/null`).toString().trim().split("\n")[0]; } catch { return undefined; }
+    try { return execSync(`${bin} ${arg} 2>/dev/null`, { maxBuffer: 1024 * 1024 }).toString().trim().split("\n")[0]; } catch { return undefined; }
   };
   out.push({ name: "bun",   required: true,  ok: !!which("bun"),   version: ver("bun") });
   out.push({ name: "git",   required: true,  ok: !!which("git"),   version: ver("git") });
@@ -636,7 +753,6 @@ function cmdDoctor(args: string[]) {
     if (!deps.find(d => d.name === "rg")?.ok)  aptInstall("ripgrep");
     if (!deps.find(d => d.name === "qmd")?.ok) {
       if (!tryInstallQmd()) {
-        // Last resort: install rustup so cargo path works
         if (tryInstallRustup()) tryInstallQmd();
       }
     }
@@ -660,7 +776,6 @@ function cmdDoctor(args: string[]) {
   }
 }
 function ensureDepsForFirstRun() {
-  // Auto-preflight on the first ever invocation in a fresh Zo instance: no registry yet.
   if (existsSync(REGISTRY)) return;
   const deps = checkDeps();
   const needFix = deps.some(d => !d.ok);
@@ -696,8 +811,6 @@ const cmds: Record<string, (a: string[]) => any> = {
   "install-qmd": () => cmdInstallQmd(),
   doctor: cmdDoctor,
 };
-// Preflight: on the first ever run (no registry), check + offer to install missing deps.
-// Skip for the doctor command itself (to avoid recursion) and the hook (cheap path).
 if (cmd && cmd !== "doctor" && cmd !== "hook" && cmds[cmd]) ensureDepsForFirstRun();
 if (!cmd || cmd === "--help" || cmd === "-h" || !cmds[cmd]) {
   console.log(`wiki — LLM-maintained wiki for any project folder


### PR DESCRIPTION
## Summary

Adds **wiki-llm** — a Community skill that maintains a persistent, incrementally-updated wiki for any project folder. Implements the [LLM-Wiki pattern by Andrej Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f): the agent builds and maintains a structured, interlinked markdown knowledge base that compounds over time, instead of re-deriving knowledge via RAG on every query.

### Why it matters — token / cost reduction

Without a wiki, every prompt that touches a project pays the same compounding tax:

1. **Re-scan**: the agent must `ls` / `grep` / `read_file` over the project to rediscover what's there.
2. **Re-derive**: it re-extracts the same architecture facts, entity definitions, ops history, conventions on every turn.
3. **Re-bloat context**: the discovered files get loaded into the prompt as raw text, even when only a few lines actually matter.

For a non-trivial repo (a few thousand source files), each session can easily burn 50k–200k input tokens *before* the agent does any real work. That cost is **paid every prompt**, multiplied across every model tier the request fans out to. The wiki replaces that with a tiny, structured, pre-synthesized layer:

- Each source is read **once**, summarized into a `pages/sources/<slug>.md`, and cross-linked to entity / topic pages — the agent reads ~10 KB of pre-condensed wiki instead of 2 MB of raw code.
- The `index.md` catalog acts as a O(1) routing table — the agent jumps straight to the relevant page rather than blind-grep.
- The `log.md` gives versioned history of ops + decisions, so prior fixes (e.g. an env-var bug from last month) don't need re-derivation.
- Stop-hook keeps the wiki **incrementally fresh** — only files actually changed since the last turn get reingested. No global rebuild, no re-summarize of unchanged code.
- Cross-session compounding: a fact learned in session N is *already* in the wiki by session N+1, so the cost of learning it is paid exactly once.

Net: bigger projects benefit more (sub-linear context growth vs. linear re-scan), and downstream model fan-out (T1 → T5 cascade in interview-portal, batched eval pipelines, etc.) multiplies the savings further because every tier reads the smaller wiki instead of the raw repo.

### Usage

All commands operate on a registered project — pass `--project <path>` or run from inside one. Every project lives in the central registry at `~/.wiki-llm/registry.json`; per-wiki internals live at `<wiki>/.wiki-llm/`.

| Command | Purpose | Example |
|---|---|---|
| `wiki init [path]` | Inspect folder, detect project type (`js-ts`, `python`, `rust`, `go`, `data-folder`, `notes-folder`, `generic`), emit questions JSON. Re-run with `--json <answers>` to scaffold. | `wiki init /home/workspace/my-app` then `wiki init --json /tmp/answers.json` |
| `wiki status` | List registered projects + pending update + trash counts. | `wiki status` |
| `wiki register [path]` | Add a project whose wiki already exists to the registry. | `wiki register /home/workspace/my-app` |
| `wiki unregister [path]` | Drop from registry; wiki files preserved. | `wiki unregister /home/workspace/my-app` |
| `wiki ingest <file>` | Mark a source file for ingestion; emits source content + agent instruction block (5 MB cap per file). | `wiki ingest src/server.ts --project /home/workspace/my-app` |
| `wiki update [--commit]` | Diff vs last-snapshot git head + dirty worktree, archive deletions to wiki trash, list pending. `--commit` advances state. | `wiki update --commit` |
| `wiki query "..."` | Hybrid BM25 + vector search via `qmd` if installed, else ripgrep fallback. | `wiki query "ZO_API_KEY auto-grader fallback"` |
| `wiki lint` | Health check: orphan pages (not referenced by index or any sibling), stale claims (sources newer than dependent page). | `wiki lint` |
| `wiki list-deleted` | Show files in wiki-native trash with timestamps. | `wiki list-deleted` |
| `wiki recover <relpath>` | Restore newest archived copy of a deleted source from wiki trash. | `wiki recover src/utils.ts` |
| `wiki hook` | Stop-hook entrypoint. Cheap and non-LLM: snapshots git diff for every registered project, archives deletions, queues changes. | `wiki hook` (invoked by Claude Code) |
| `wiki install-hook` | Register `wiki hook` in `~/.claude/settings.json` Stop hook array. Idempotent. | `wiki install-hook` |
| `wiki uninstall-hook` | Remove the Stop hook. | `wiki uninstall-hook` |
| `wiki install-qmd` | Best-effort install of qmd search backend (npm/bun → cargo → rustup+cargo). | `wiki install-qmd` |
| `wiki doctor [--fix]` | Check / install deps. Required: `bun`, `git`. Optional: `qmd`, `ripgrep`, `rustup`, `cargo`. | `wiki doctor --fix` |

## What's in it (technical)

### Architecture
- **Three layers per project** (per the LLM-Wiki pattern): raw sources (the project, read-only), the wiki (markdown the agent owns), the schema (`<wiki>/AGENTS.md` — co-evolved conventions).
- **Central registry** at `~/.wiki-llm/registry.json`; per-wiki state at `<wiki>/.wiki-llm/{config.json, state.json, queue.jsonl, trash/}`.
- **Wiki skeleton**: `index.md` (content catalog), `log.md` (chronological event log), `pages/sources/`, `pages/entities/`, `pages/topics/` — populated by the agent based on `AGENTS.md` conventions.

### Adaptive init
- Auto-detects project type from filesystem signals: `package.json` → js-ts; `pyproject.toml` / `requirements.txt` / `setup.py` → python; `Cargo.toml` → rust; `go.mod` → go; ≥2 `.csv`/`.parquet`/`.duckdb` files → data-folder; ≥2 `.md`/`.txt`/`.pdf` → notes-folder; else generic.
- Question set adapts to project type (different default include globs, scope choices: `code+ops` for code projects, `all` for notes/data) so the same skill scaffolds a code wiki and a research wiki differently.

### Stop-hook auto-update
- Hook runs after every Claude Code turn. For each registered project: `git rev-parse HEAD` + `git status --porcelain` + diff vs `<wiki>/.wiki-llm/state.json:last_head`.
- Apply project include/exclude globs (minimal `**`, `*`, `{a,b}` glob translator).
- Archive deletions to `<wiki>/.wiki-llm/trash/<ISO-stamp>/<relpath>` with a manifest line; queue add / modify / delete entries to `queue.jsonl`.
- **Zero LLM tokens spent in the hook** — content regeneration is deferred to an explicit `wiki update` so token cost stays predictable.

### Wiki-native trash + recovery
- Independent of git: even if the user `git reset --hard`'s away history, the trash still holds the deleted source.
- Multi-ref recovery: tries `HEAD` → `state.last_head` → last commit touching the path (`git log -n1 --pretty=%H -- <path>`).
- `wiki list-deleted` / `wiki recover <relpath>` work from the manifest, not git.
- Configurable retention: `trash_retention_days` (default 30) per project; pruning runs during `wiki update`.

### qmd integration
- Hybrid BM25 + vector search over the wiki (`qmd search`).
- Falls back to `ripgrep -l` with a heading-rank heuristic if qmd is missing.
- `wiki install-qmd` tries `bun add -g qmd` → `npm i -g qmd` → `cargo install qmd` → bootstrap rustup then cargo.

### First-run dependency preflight
- When `~/.wiki-llm/registry.json` doesn't exist (fresh Zo instance), the CLI auto-runs `doctor --fix` before any subcommand (except `doctor` and `hook` themselves to keep latency / recursion in check).

### Hardening (security / perf / memory)

This PR was reviewed end-to-end for security, vulnerability exposure, memory leaks, and performance — relevant fixes folded in:

- **Command-injection-safe git invocations**: all `git` calls go through `spawnSync` with explicit arg arrays — no shell interpolation of user-controlled data. Refs (`HEAD`, `state.last_head`, current head) are validated against `^[A-Za-z0-9._/-]{1,255}$` before any use, so a tampered `state.json` or a malicious branch name cannot break out of the argv boundary.
- **Path-traversal guards**: every relpath touching trash, recover, or ingest is rejected if it is absolute, contains `..` segments, or has null bytes. A defence-in-depth `isUnder(root, dest)` check then re-resolves the final write path and refuses anything that escapes the trash root, project root, or wiki root — so a corrupt manifest cannot get `wiki recover` to clobber `/etc/passwd`.
- **Memory caps**: `git show` / `git diff` are capped at 50 MB via `maxBuffer`; ingest refuses sources over 5 MB with a clear error rather than OOM-ing the process.
- **Crash-resistant JSON**: `safeReadJSON()` wraps every parse of registry / state / config / manifest / settings; a corrupt file falls back to defaults instead of throwing.
- **Atomic writes**: registry, state, config, and `~/.claude/settings.json` are written via `.tmp` + `rename`, so a crash mid-write can't leave them half-written.
- **Single-flight hook lock**: `wiki hook` acquires a `~/.wiki-llm/hook.lock` (O_EXCL with 60-s stale-lock reclaim), so two parallel Stop fires can't race-corrupt the queue.
- **Queue de-dup**: appending the same `file + action` within the last 100 entries is skipped — prevents queue growth on chatty turns.
- **Trash retention**: configurable per-project (default 30 days); pruning runs in-band during `wiki update`.
- **Lint perf**: replaced the O(N²) cross-page substring scan with a single O(N) markdown-link scan into a `Set<string>` — lint over hundreds of pages is now linear, not quadratic.
- **`which()` cache**: per-process memoization; binary detection no longer repeats `which` shell-outs across a single command's lifetime.

## Files

- `Community/wiki-llm/SKILL.md` — instructions for agents
- `Community/wiki-llm/DISPLAY.json` — catalog metadata (icon: `book-open`)
- `Community/wiki-llm/scripts/wiki` — the Bun CLI
- `Community/wiki-llm/assets/wiki-template/` — `AGENTS.md` + `index.md` + `log.md` skeleton seeded into every new wiki
- `Community/wiki-llm/references/CONCEPT.md` — the original LLM-Wiki concept doc

## Validation

`bun validate` passes clean for `Community/wiki-llm`. Smoke tested end-to-end on an `interview-portal` project: init → seed → register qmd collection → ingest → update → lint → list-deleted → recover → Stop hook trigger → path-traversal-rejection → corrupt-JSON survival → trash-retention prune.
