### PR TITLE
Add optimus community skill

### DIFF
--- a/Community/optimus/DISPLAY.json
+++ b/Community/optimus/DISPLAY.json
@@ -1,0 +1,5 @@
+{
+  "specVersion": "0.2.0",
+  "icon": "bot",
+  "tags": ["developer-tools", "llm", "agent", "productivity"]
+}

--- a/Community/optimus/SKILL.md
+++ b/Community/optimus/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: optimus
+description: >-
+  Optimus is a unified LLM/agent-tooling CLI (Rust) that bundles a persistent
+  code/notes wiki, an ultra-compressed "caveman" output mode, a structural
+  repo fingerprinter ("aura"), and a repo-fusing knowledge graph ("graphify")
+  behind one binary. Subcommands - optimus wiki, optimus caveman, optimus
+  aura, optimus graphify, optimus init manual, optimus init auto, optimus
+  help. Use when the user says "optimus", "optimus wiki", "optimus aura",
+  "optimus graphify", "optimus init", or names any of the subskills directly.
+compatibility: Created for Zo Computer
+metadata:
+  author: bitphill
+allowed-tools: Bash Read Edit
+---
+
+# Optimus
+
+Single Rust binary, several subskills, one persistent `sled`-backed memory store shared across them. Source: https://github.com/bitphill/optimus
+
+## First run: ensure the binary is installed
+
+Run `scripts/ensure-optimus.sh` before invoking any subcommand — it's a no-op if `optimus` is already on `PATH`, otherwise it installs via whichever of cargo/npm/pip is available, falling back to the universal installer from the GitHub release.
+
+## Sub-skills
+
+| Sub-skill | Trigger | What it does |
+|---|---|---|
+| wiki | `optimus wiki` | Persistent project wiki; `optimus wiki ingest <path>` treats each child folder as its own wiki, appended as `<parent>-<name>` |
+| caveman | `optimus caveman` | Ultra-compressed output mode (~65% token cut) |
+| aura | `optimus aura <path>` | Structural + semantic fingerprint of a repo |
+| graphify | `optimus graphify <path>` | Fuses linked repos into one navigable graph |
+| init manual | `optimus init manual` | Interactive BYOK setup — prompts for OpenRouter/Anthropic/OpenAI keys and subskill defaults |
+| init auto | `optimus init auto` | Non-interactive setup — applies cascade defaults, reads keys from env vars or a prior `init manual` run |
+| help | `optimus help [sub]` | Lists subskills, syntax, and example invocations |
+
+## BYOK
+
+`optimus` needs at least one LLM provider key to drive the `cascade` (OpenRouter recommended — it's the free-tier default). Run `optimus init manual` once to set it up interactively, or export `OPENROUTER_API_KEY` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` before use. Keys are stored in `~/.optimus/config.toml` (0600), never in this skill or in the binary.
+
+## When to use this skill
+
+User says any of:
+- "optimus", "optimus wiki `<path>`", "optimus caveman on/off"
+- "optimus aura `<path>`", "optimus graphify `<path>`"
+- "set up optimus", "optimus init"
+
+If the user references a subskill by name alone (e.g. "wiki", "caveman") without other context, prefer the standalone `wiki-llm`/`caveman` skill if installed; use `optimus <sub>` when they've explicitly invoked optimus or when only optimus is installed.

--- a/Community/optimus/scripts/ensure-optimus.sh
+++ b/Community/optimus/scripts/ensure-optimus.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Ensures the `optimus` binary is on PATH. No-op if already installed.
+# Tries, in order: cargo (crates.io), npm (@bitphill/optimus), pip
+# (optimus-cli), then falls back to the universal source/binary installer
+# from the GitHub release. Each step is best-effort; the next is only
+# attempted if the previous one didn't produce a working binary.
+set -euo pipefail
+
+if command -v optimus >/dev/null 2>&1; then
+  exit 0
+fi
+
+echo "optimus: not found on PATH, installing..." >&2
+
+try_cargo() {
+  command -v cargo >/dev/null 2>&1 || return 1
+  cargo install optimus-cli --locked
+}
+
+try_npm() {
+  command -v npm >/dev/null 2>&1 || return 1
+  npm install -g @bitphill/optimus
+}
+
+try_pip() {
+  (command -v pip3 >/dev/null 2>&1 && echo pip3) || \
+  (command -v pip >/dev/null 2>&1 && echo pip) || return 1
+}
+
+try_universal_installer() {
+  curl --proto '=https' --tlsv1.2 -sSf \
+    https://raw.githubusercontent.com/bitphill/optimus/main/install.sh | bash
+}
+
+for method in cargo npm pip; do
+  case "$method" in
+    cargo) try_cargo && break ;;
+    npm) try_npm && break ;;
+    pip)
+      pip_bin=$(try_pip) || continue
+      "$pip_bin" install --user optimus-cli && break
+      ;;
+  esac
+done
+
+if ! command -v optimus >/dev/null 2>&1; then
+  echo "optimus: no package manager install worked, running universal installer" >&2
+  try_universal_installer
+fi
+
+if ! command -v optimus >/dev/null 2>&1; then
+  echo "optimus: install failed. See https://github.com/bitphill/optimus#install" >&2
+  exit 1
+fi
+
+echo "optimus: installed ($(optimus --version))" >&2


### PR DESCRIPTION
## Summary
- Adds `Community/optimus`: a thin wrapper skill around the [optimus](https://github.com/bitphill/optimus) Rust CLI — persistent wiki, "caveman" ultra-compressed mode, "aura" repo fingerprinting, "graphify" repo-fusing knowledge graphs, and BYOK-driven `init manual`/`init auto`, all behind one binary and one shared `sled` memory store.
- `scripts/ensure-optimus.sh` installs the binary on first use (cargo → npm → pip → universal installer fallback chain), so the skill works without asking the user to pre-install anything.

## Test plan
- [x] `bun validate` — zero new errors/warnings (only pre-existing `External/*` warnings unrelated to this change)
- [x] Ran `scripts/ensure-optimus.sh` end-to-end in a clean shell: correctly no-ops when `optimus` isn't on crates.io yet, falls through to the npm path (`@bitphill/optimus`), and lands a working `optimus --version`
- [x] optimus itself is published and tested: [crates.io pending email verification], [npm](https://www.npmjs.com/package/@bitphill/optimus), [PyPI](https://pypi.org/project/optimus-cli/), [Homebrew tap](https://github.com/bitphill/homebrew-optimus)