### PR TITLE
Add oauth-mcp-connect skill

### DIFF
--- a/Community/oauth-mcp-connect/SKILL.md
+++ b/Community/oauth-mcp-connect/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: oauth-mcp-connect
+description: Generic connector for authorizing any remote MCP server that uses OAuth 2.1 (with dynamic client registration + PKCE) on Zo Computer. Use this whenever a new MCP server needs OAuth and there is no dedicated skill for it yet, instead of writing a bespoke auth script or a bespoke Zo Space callback route per provider.
+compatibility: Created for Zo Computer
+metadata:
+  author: YOUR_HANDLE.zo.computer
+---
+# OAuth MCP Connector
+
+Most remote MCP servers assume a local CLI or desktop client that can open a
+browser and receive a redirect on `http://127.0.0.1:<port>/callback`. That
+doesn't work inside Zo's sandbox: there's no browser here, and the sandbox has
+no public inbound port of its own for a random localhost redirect to land on.
+
+This skill solves that once, generically, by using a **shared Zo Space API
+route** (`https://<handle>.zo.space/api/oauth-mcp/callback`) as the
+`redirect_uri` for every OAuth MCP server. That route is already public,
+already deployed, and persists tokens straight into the workspace - so the
+provider's redirect actually lands somewhere real, regardless of which
+provider it is.
+
+Before this skill existed, each OAuth MCP integration (ChatPRD, TwinMind,
+Buildin, ByDesign, Slideshot, Magnific) needed its own bespoke auth script and
+often its own bespoke `/api/<provider>/callback` Space route, duplicating the
+PKCE + token-exchange logic every time. Use this skill instead of repeating
+that pattern for new providers.
+
+## When to use this vs. a dedicated skill
+
+- **New OAuth MCP server, no existing skill:** use this skill directly.
+- **Provider already has a dedicated skill with its own auth script**
+  (ChatPRD, TwinMind, Buildin, ByDesign, Slideshot, Magnific) — use that
+  skill's existing auth flow, don't duplicate it with this one. Those predate
+  this skill and are not required to migrate.
+- **Building a new dedicated skill for a provider going forward:** still use
+  this connector for the auth mechanics; the provider skill should only
+  document available tools and usage patterns, referencing this skill for
+  "how to connect." See `Skills/giststack/SKILL.md` for the pattern.
+
+## Prerequisites
+
+- The provider's MCP server must support OAuth 2.1 with:
+  - `/.well-known/oauth-authorization-server` (or `/.well-known/openid-configuration`) metadata discovery, AND
+  - Dynamic Client Registration (RFC 7591) at a `registration_endpoint`, OR a manually-issued `client_id`/`client_secret` you can pass via env vars.
+  - PKCE (`code_challenge_method=S256`) — nearly universal for MCP OAuth.
+- The one-time Zo Space callback route below must exist. Create it if it doesn't (see step 0).
+
+## Step 0: Create the shared callback route (one-time, skip if it already exists)
+
+Check first:
+```
+get_space_route("/api/oauth-mcp/callback")
+```
+
+If missing, create it with `write_space_route` using the exact code in
+`Skills/oauth-mcp-connect/references/callback-route.md`. Do not improvise a
+different implementation — this route's contract (pending-state file layout,
+token file layout) is what `scripts/oauth-mcp.ts` reads and writes.
+
+## Step 1: Connect a new provider
+
+```bash
+cd /home/workspace
+bun Skills/oauth-mcp-connect/scripts/oauth-mcp.ts connect <server-name> <mcp-url> [--scope "openid profile email offline_access"] [--handle your-zo-handle]
+```
+
+- `<server-name>`: short slug for the provider, e.g. `giststack`. Used for file/token naming.
+- `<mcp-url>`: the MCP server's endpoint, e.g. `https://app.giststack.com/api/mcp`. OAuth metadata is discovered from this URL's origin.
+- `--scope`: optional override. Defaults to the server's advertised `scopes_supported`, or `"openid profile email offline_access"` if none are advertised.
+- `--handle`: optional override for the Zo handle used in the redirect URI. Defaults to `$ZO_USER` / `$ZO_HOSTNAME`.
+
+This will:
+1. Discover the provider's OAuth metadata.
+2. Dynamically register an OAuth client (if the server supports RFC 7591), using the shared Space callback as `redirect_uri`.
+3. Generate a PKCE verifier/challenge and save pending state to `Data/oauth-mcp/pending/<state>.json` (15-minute TTL).
+4. Print an authorization URL.
+
+**If the server has no `registration_endpoint`:** the script prints an error and expects manually-issued credentials:
+```bash
+OAUTH_MCP_CLIENT_ID=xxx OAUTH_MCP_CLIENT_SECRET=yyy bun Skills/oauth-mcp-connect/scripts/oauth-mcp.ts connect <server-name> <mcp-url>
+```
+Direct the user to the provider's developer/settings page to obtain these, and to store them in [Settings > Advanced](/?t=settings&s=advanced) if they should persist across sessions (then export them before running connect).
+
+## Step 2: Get the user to approve
+
+Give the user the printed authorization URL to open in **their own browser**
+(desktop or phone — not Zo's sandbox browser, since the user needs to log
+into the third-party service themselves). Per the always-applied rule on
+external actions, do not click through or approve anything on the user's
+behalf — this is their login, their consent screen.
+
+After they approve, the shared callback route exchanges the code for tokens
+and writes `Data/oauth-mcp/tokens/<server-name>.json` automatically. No
+further action from you is needed until they confirm.
+
+## Step 3: Verify
+
+```bash
+bun Skills/oauth-mcp-connect/scripts/oauth-mcp.ts status <server-name>
+```
+
+Expect `"connected": true` with an `expires_at` timestamp. Per the
+always-applied verification rule, don't tell the user the connection
+succeeded until this returns `connected: true` — a printed auth URL is not
+evidence of a completed connection.
+
+## Step 4: Use it
+
+```bash
+bun Skills/oauth-mcp-connect/scripts/oauth-mcp.ts list-tools <server-name>
+bun Skills/oauth-mcp-connect/scripts/oauth-mcp.ts call <server-name> <tool-name> '<json-args>'
+```
+
+`call` auto-refreshes an expiring/expired access token (via the stored
+`refresh_token`) before calling, and retries once on a `401`. `refresh` and
+`revoke` are also available standalone.
+
+## Command reference
+
+```
+bun Skills/oauth-mcp-connect/scripts/oauth-mcp.ts connect <server-name> <mcp-url> [--scope "..."] [--handle ...]
+bun Skills/oauth-mcp-connect/scripts/oauth-mcp.ts status <server-name>
+bun Skills/oauth-mcp-connect/scripts/oauth-mcp.ts list-tools <server-name>
+bun Skills/oauth-mcp-connect/scripts/oauth-mcp.ts call <server-name> <tool-name> '<json-args>'
+bun Skills/oauth-mcp-connect/scripts/oauth-mcp.ts refresh <server-name>
+bun Skills/oauth-mcp-connect/scripts/oauth-mcp.ts revoke <server-name>
+```
+
+## File layout
+
+```
+Data/oauth-mcp/
+  servers/<name>.json     # { mcpUrl } - written at connect time, read by list-tools/call
+  pending/<state>.json    # in-flight PKCE state, deleted by the callback route on success, 15-min TTL
+  tokens/<name>.json      # { access_token, refresh_token, expires_at, client_id, client_secret,
+                           #   token_endpoint, redirect_uri, updated_at } - written by the callback route
+```
+
+`tokens/<name>.json` is the durable connection record. Treat it like any
+other credential file: don't print its contents, don't commit it anywhere
+public.
+
+## Troubleshooting
+
+- **"No matching request" on the callback page:** the 15-minute pending TTL
+  expired, or `connect` was run again (creating a new `state`) after the user
+  already had the URL open. Re-run `connect` and have the user open the fresh
+  URL promptly.
+- **"Could not discover OAuth metadata":** the provider doesn't expose
+  `.well-known/oauth-authorization-server` or `openid-configuration` at its
+  origin. Check the provider's docs for a different metadata URL or
+  hand-rolled OAuth details; this generic flow assumes standard discovery.
+- **Token exchange fails after approval:** check `Data/oauth-mcp/tokens/` — if
+  no file was written, read the HTML error the callback route returned (it
+  echoes the HTTP status and response body from the provider's token
+  endpoint) rather than guessing.
+- **401 on `call` even after connect:** run `status` to confirm `connected:
+  true` and check `expires_at`; if expired and no `refresh_token` was issued,
+  the user needs to re-run `connect` from scratch (some providers don't grant
+  `offline_access`/refresh tokens unless that scope was explicitly requested).

--- a/Community/oauth-mcp-connect/references/callback-route.md
+++ b/Community/oauth-mcp-connect/references/callback-route.md
@@ -1,0 +1,126 @@
+# Shared callback route: `/api/oauth-mcp/callback`
+
+This is the exact code deployed at `https://YOUR_HANDLE.zo.space/api/oauth-mcp/callback`.
+It is a **shared, provider-agnostic** OAuth redirect target — do not create a
+new per-provider callback route for servers connected via this skill;
+`scripts/oauth-mcp.ts` always points at this one path.
+
+If this route is ever missing (e.g. lost during a Space rebuild or export),
+recreate it with `write_space_route(path="/api/oauth-mcp/callback", route_type="api", public="true", code=<below>)`.
+It must stay public (API routes always are) since providers' OAuth redirects
+hit it unauthenticated.
+
+```typescript
+import type { Context } from "hono";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "fs";
+
+const DATA_DIR = "/home/workspace/Data/oauth-mcp";
+const PENDING_DIR = `${DATA_DIR}/pending`;
+const TOKENS_DIR = `${DATA_DIR}/tokens`;
+
+function htmlResponse(c: Context, title: string, message: string, ok: boolean) {
+  return c.html(
+    `<!doctype html><html><head><meta charset="utf-8" /><title>${title}</title>
+    <style>body{font-family:system-ui,sans-serif;max-width:560px;margin:60px auto;text-align:center;color:${ok ? "#1a1a1a" : "#7a1a1a"}}</style>
+    </head><body><h1>${title}</h1><p>${message}</p></body></html>`,
+    ok ? 200 : 400
+  );
+}
+
+export default async (c: Context) => {
+  const code = c.req.query("code");
+  const state = c.req.query("state");
+  const error = c.req.query("error");
+
+  if (error) {
+    return htmlResponse(c, "Authorization failed", c.req.query("error_description") || error, false);
+  }
+  if (!code || !state) {
+    return htmlResponse(c, "Missing parameters", "No authorization code or state received.", false);
+  }
+
+  const pendingPath = `${PENDING_DIR}/${state}.json`;
+  if (!existsSync(pendingPath)) {
+    return htmlResponse(
+      c,
+      "No matching request",
+      "No pending OAuth request matched this callback's state. It may have expired (15 min) - re-run the connect command and try again promptly.",
+      false
+    );
+  }
+
+  const pending = JSON.parse(readFileSync(pendingPath, "utf8"));
+
+  try {
+    const body = new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: pending.redirectUri,
+      client_id: pending.clientId,
+      code_verifier: pending.codeVerifier,
+    });
+    if (pending.clientSecret) body.set("client_secret", pending.clientSecret);
+
+    const tokenRes = await fetch(pending.tokenEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+      body,
+    });
+    const text = await tokenRes.text();
+    if (!tokenRes.ok) {
+      return htmlResponse(c, "Token exchange failed", `HTTP ${tokenRes.status}: ${text.slice(0, 500)}`, false);
+    }
+    const tokenData = JSON.parse(text);
+
+    mkdirSync(TOKENS_DIR, { recursive: true });
+    writeFileSync(
+      `${TOKENS_DIR}/${pending.serverName}.json`,
+      JSON.stringify(
+        {
+          access_token: tokenData.access_token,
+          refresh_token: tokenData.refresh_token,
+          token_type: tokenData.token_type,
+          expires_at: tokenData.expires_in ? Date.now() + tokenData.expires_in * 1000 : null,
+          client_id: pending.clientId,
+          client_secret: pending.clientSecret,
+          token_endpoint: pending.tokenEndpoint,
+          redirect_uri: pending.redirectUri,
+          updated_at: new Date().toISOString(),
+        },
+        null,
+        2
+      ),
+      { mode: 0o600 }
+    );
+
+    unlinkSync(pendingPath);
+
+    return htmlResponse(
+      c,
+      `${pending.serverName} connected`,
+      "Authorization successful. You can close this tab and return to Zo.",
+      true
+    );
+  } catch (err: any) {
+    return htmlResponse(c, "Callback error", err?.message || String(err), false);
+  }
+};
+```
+
+## Contract this route depends on
+
+- Reads `Data/oauth-mcp/pending/<state>.json` written by `scripts/oauth-mcp.ts connect`:
+  ```json
+  {
+    "serverName": "string",
+    "tokenEndpoint": "string (URL)",
+    "clientId": "string",
+    "clientSecret": "string | undefined",
+    "codeVerifier": "string",
+    "redirectUri": "string (URL, must equal https://<handle>.zo.space/api/oauth-mcp/callback)",
+    "mcpUrl": "string (URL)",
+    "createdAt": "ISO timestamp"
+  }
+  ```
+- Writes `Data/oauth-mcp/tokens/<serverName>.json`, read by `scripts/oauth-mcp.ts status/list-tools/call/refresh`.
+- Deletes the pending file on success (one-shot; a re-approved stale link will hit "No matching request").

--- a/Community/oauth-mcp-connect/scripts/oauth-mcp.ts
+++ b/Community/oauth-mcp-connect/scripts/oauth-mcp.ts
@@ -1,0 +1,453 @@
+#!/usr/bin/env bun
+/**
+ * Generic OAuth 2.1 connector for remote MCP servers on Zo Computer.
+ *
+ * Zo's sandbox has no public inbound port of its own, so a normal
+ * "open localhost:PORT and wait for the redirect" OAuth flow (what most
+ * MCP clients assume) never completes here. This script instead uses a
+ * Zo Space API route (https://<handle>.zo.space/api/oauth-mcp/callback)
+ * as the redirect_uri. That route is already public, already deployed,
+ * and persists tokens straight to the workspace - so the browser-side
+ * redirect actually lands somewhere real.
+ *
+ * Flow:
+ *   1. Discover OAuth metadata (.well-known/oauth-authorization-server,
+ *      falling back to /.well-known/openid-configuration).
+ *   2. Dynamically register an OAuth client (RFC 7591) if the server
+ *      supports it, using our fixed Space callback as redirect_uri.
+ *   3. Generate PKCE verifier/challenge, save a "pending" record keyed
+ *      by `state` to /home/workspace/Data/oauth-mcp/pending/<state>.json.
+ *   4. Print the authorization URL for the user to open in their own
+ *      browser (desktop app or phone - NOT this sandbox).
+ *   5. The Space route /api/oauth-mcp/callback receives the redirect,
+ *      matches the state, exchanges the code for tokens, and writes
+ *      /home/workspace/Data/oauth-mcp/tokens/<server>.json.
+ *   6. `status`/`call` here read that token file directly (with
+ *      refresh-token rotation support).
+ *
+ * Usage:
+ *   bun oauth-mcp.ts connect <server-name> <mcp-url> [--scope "..."]
+ *   bun oauth-mcp.ts status <server-name>
+ *   bun oauth-mcp.ts list-tools <server-name>
+ *   bun oauth-mcp.ts call <server-name> <tool-name> '<json-args>'
+ *   bun oauth-mcp.ts refresh <server-name>
+ *   bun oauth-mcp.ts revoke <server-name>
+ */
+
+import { mkdirSync, readFileSync, writeFileSync, existsSync, unlinkSync } from "fs";
+import { randomBytes, createHash, randomUUID } from "crypto";
+
+const DATA_DIR = "/home/workspace/Data/oauth-mcp";
+const PENDING_DIR = `${DATA_DIR}/pending`;
+const TOKENS_DIR = `${DATA_DIR}/tokens`;
+const CALLBACK_PATH = "/api/oauth-mcp/callback";
+const PENDING_TTL_MS = 15 * 60 * 1000;
+
+function zoHandle(): string {
+  const fromEnv = process.env.ZO_HOSTNAME || process.env.ZO_USER;
+  if (fromEnv) return fromEnv.replace(/\.zo\.(space|computer)$/, "");
+  throw new Error(
+    "Could not determine Zo handle. Pass --handle <your-zo-handle> or set ZO_USER."
+  );
+}
+
+function redirectUri(handleOverride?: string): string {
+  const handle = handleOverride || zoHandle();
+  return `https://${handle}.zo.space${CALLBACK_PATH}`;
+}
+
+function b64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function pkce() {
+  const verifier = b64url(randomBytes(32));
+  const challenge = b64url(createHash("sha256").update(verifier).digest());
+  return { verifier, challenge };
+}
+
+async function discoverMetadata(mcpUrl: string) {
+  const origin = new URL(mcpUrl).origin;
+  const candidates = [
+    `${origin}/.well-known/oauth-authorization-server`,
+    `${origin}/.well-known/openid-configuration`,
+  ];
+  for (const url of candidates) {
+    try {
+      const res = await fetch(url, { headers: { Accept: "application/json" } });
+      if (!res.ok) continue;
+      const ct = res.headers.get("content-type") || "";
+      if (!ct.includes("json")) continue;
+      const meta = await res.json();
+      if (meta.authorization_endpoint && meta.token_endpoint) {
+        return meta as {
+          authorization_endpoint: string;
+          token_endpoint: string;
+          registration_endpoint?: string;
+          scopes_supported?: string[];
+        };
+      }
+    } catch {
+      // try next candidate
+    }
+  }
+  throw new Error(
+    `Could not discover OAuth metadata for ${origin}. Tried: ${candidates.join(", ")}. ` +
+      `The server may need manual client_id/client_secret - check its docs.`
+  );
+}
+
+async function registerClient(
+  registrationEndpoint: string,
+  redirect: string,
+  serverName: string
+): Promise<{ client_id: string; client_secret?: string }> {
+  const res = await fetch(registrationEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify({
+      client_name: `zo-computer-${serverName}`,
+      redirect_uris: [redirect],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    }),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`Dynamic client registration failed (${res.status}): ${text.slice(0, 500)}`);
+  return JSON.parse(text);
+}
+
+function cleanupExpiredPending() {
+  if (!existsSync(PENDING_DIR)) return;
+  const fs = require("fs");
+  for (const f of fs.readdirSync(PENDING_DIR)) {
+    const p = `${PENDING_DIR}/${f}`;
+    try {
+      const stat = fs.statSync(p);
+      if (Date.now() - stat.mtimeMs > PENDING_TTL_MS) fs.unlinkSync(p);
+    } catch {}
+  }
+}
+
+async function cmdConnect(args: string[]) {
+  const serverName = args[0];
+  const mcpUrl = args[1];
+  if (!serverName || !mcpUrl) {
+    console.error("Usage: oauth-mcp.ts connect <server-name> <mcp-url> [--scope \"a b c\"] [--handle your-zo-handle]");
+    process.exit(1);
+  }
+  const scopeIdx = args.indexOf("--scope");
+  const scopeOverride = scopeIdx >= 0 ? args[scopeIdx + 1] : undefined;
+  const handleIdx = args.indexOf("--handle");
+  const handleOverride = handleIdx >= 0 ? args[handleIdx + 1] : undefined;
+
+  mkdirSync(PENDING_DIR, { recursive: true });
+  cleanupExpiredPending();
+
+  const redirect = redirectUri(handleOverride);
+  console.log(`Discovering OAuth metadata for ${mcpUrl} ...`);
+  const meta = await discoverMetadata(mcpUrl);
+  console.log(`  authorization_endpoint: ${meta.authorization_endpoint}`);
+  console.log(`  token_endpoint: ${meta.token_endpoint}`);
+
+  let clientId: string;
+  let clientSecret: string | undefined;
+  if (meta.registration_endpoint) {
+    console.log(`Registering OAuth client (redirect_uri=${redirect}) ...`);
+    const client = await registerClient(meta.registration_endpoint, redirect, serverName);
+    clientId = client.client_id;
+    clientSecret = client.client_secret;
+    console.log(`  client_id: ${clientId}`);
+  } else {
+    console.error(
+      `No registration_endpoint advertised. This server needs a manually-issued client_id ` +
+        `(and possibly client_secret). Re-run with:\n` +
+        `  OAUTH_MCP_CLIENT_ID=xxx OAUTH_MCP_CLIENT_SECRET=yyy bun oauth-mcp.ts connect ${serverName} ${mcpUrl}`
+    );
+    clientId = process.env.OAUTH_MCP_CLIENT_ID || "";
+    clientSecret = process.env.OAUTH_MCP_CLIENT_SECRET;
+    if (!clientId) process.exit(1);
+  }
+
+  const state = randomUUID();
+  const { verifier, challenge } = pkce();
+  const scope = scopeOverride || (meta.scopes_supported || ["openid", "profile", "email", "offline_access"]).join(" ");
+
+  writeFileSync(
+    `${PENDING_DIR}/${state}.json`,
+    JSON.stringify(
+      {
+        serverName,
+        tokenEndpoint: meta.token_endpoint,
+        clientId,
+        clientSecret,
+        codeVerifier: verifier,
+        redirectUri: redirect,
+        mcpUrl,
+        createdAt: new Date().toISOString(),
+      },
+      null,
+      2
+    ),
+    { mode: 0o600 }
+  );
+
+  const authUrl = new URL(meta.authorization_endpoint);
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("client_id", clientId);
+  authUrl.searchParams.set("redirect_uri", redirect);
+  authUrl.searchParams.set("scope", scope);
+  authUrl.searchParams.set("state", state);
+  authUrl.searchParams.set("code_challenge", challenge);
+  authUrl.searchParams.set("code_challenge_method", "S256");
+  authUrl.searchParams.set("resource", mcpUrl);
+
+  console.log("\n" + "=".repeat(70));
+  console.log(`Open this URL in a browser to authorize ${serverName}:`);
+  console.log("=".repeat(70));
+  console.log(`\n${authUrl.toString()}\n`);
+  console.log(
+    `After you approve, the Zo Space callback route will exchange the code\n` +
+      `and save tokens to ${TOKENS_DIR}/${serverName}.json automatically.\n` +
+      `Run "bun oauth-mcp.ts status ${serverName}" after approving to confirm.`
+  );
+}
+
+type TokenFile = {
+  access_token: string;
+  refresh_token?: string;
+  token_type?: string;
+  expires_at?: number | null;
+  client_id: string;
+  client_secret?: string;
+  token_endpoint: string;
+  redirect_uri: string;
+  updated_at: string;
+};
+
+function tokenPath(serverName: string) {
+  return `${TOKENS_DIR}/${serverName}.json`;
+}
+
+function loadToken(serverName: string): TokenFile {
+  const p = tokenPath(serverName);
+  if (!existsSync(p)) {
+    throw new Error(
+      `No token file at ${p}. Run "bun oauth-mcp.ts connect ${serverName} <mcp-url>" first, then approve in a browser.`
+    );
+  }
+  return JSON.parse(readFileSync(p, "utf8"));
+}
+
+async function refreshTokenFile(serverName: string): Promise<TokenFile> {
+  const token = loadToken(serverName);
+  if (!token.refresh_token) throw new Error(`No refresh_token stored for ${serverName}; re-run connect.`);
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: token.refresh_token,
+    client_id: token.client_id,
+  });
+  if (token.client_secret) body.set("client_secret", token.client_secret);
+
+  const res = await fetch(token.token_endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+    body,
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`Refresh failed (${res.status}): ${text.slice(0, 500)}`);
+  const data = JSON.parse(text);
+
+  const updated: TokenFile = {
+    ...token,
+    access_token: data.access_token,
+    refresh_token: data.refresh_token || token.refresh_token,
+    expires_at: data.expires_in ? Date.now() + data.expires_in * 1000 : null,
+    updated_at: new Date().toISOString(),
+  };
+  writeFileSync(tokenPath(serverName), JSON.stringify(updated, null, 2), { mode: 0o600 });
+  return updated;
+}
+
+async function ensureValidToken(serverName: string): Promise<string> {
+  let token = loadToken(serverName);
+  const expiringSoon = token.expires_at && token.expires_at - Date.now() < 60_000;
+  if (expiringSoon && token.refresh_token) {
+    token = await refreshTokenFile(serverName);
+  }
+  return token.access_token;
+}
+
+async function mcpCall(serverName: string, mcpUrl: string, method: string, params: Record<string, unknown> = {}) {
+  const accessToken = await ensureValidToken(serverName);
+  const doCall = async (bearer: string) =>
+    fetch(mcpUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: `Bearer ${bearer}`,
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    });
+
+  let res = await doCall(accessToken);
+  if (res.status === 401) {
+    const refreshed = await refreshTokenFile(serverName);
+    res = await doCall(refreshed.access_token);
+  }
+
+  const text = await res.text();
+  if (!res.ok) throw new Error(`MCP HTTP ${res.status}: ${text.slice(0, 1000)}`);
+
+  const dataLine = text
+    .split(/\r?\n/)
+    .filter((l) => l.startsWith("data: "))
+    .map((l) => l.slice(6))
+    .pop();
+  const payload = dataLine ? JSON.parse(dataLine) : JSON.parse(text);
+  if (payload.error) throw new Error(`MCP error: ${JSON.stringify(payload.error)}`);
+  return payload.result;
+}
+
+async function cmdStatus(args: string[]) {
+  const serverName = args[0];
+  if (!serverName) {
+    console.error("Usage: oauth-mcp.ts status <server-name>");
+    process.exit(1);
+  }
+  const p = tokenPath(serverName);
+  if (!existsSync(p)) {
+    console.log(JSON.stringify({ connected: false, server: serverName }, null, 2));
+    return;
+  }
+  const token = loadToken(serverName);
+  console.log(
+    JSON.stringify(
+      {
+        connected: true,
+        server: serverName,
+        has_refresh_token: Boolean(token.refresh_token),
+        expires_at: token.expires_at ? new Date(token.expires_at).toISOString() : null,
+        updated_at: token.updated_at,
+      },
+      null,
+      2
+    )
+  );
+}
+
+async function cmdListTools(args: string[]) {
+  const serverName = args[0];
+  if (!serverName) {
+    console.error("Usage: oauth-mcp.ts list-tools <server-name>");
+    process.exit(1);
+  }
+  const token = loadToken(serverName);
+  const result = await mcpCall(serverName, mcpUrlFor(serverName, token), "tools/list");
+  console.log(JSON.stringify(result, null, 2));
+}
+
+function mcpUrlFor(serverName: string, _token?: TokenFile): string {
+  const p = `${PENDING_DIR}`;
+  // mcpUrl is not persisted in the token file by default; store it alongside on connect.
+  const cfgPath = `${DATA_DIR}/servers/${serverName}.json`;
+  if (existsSync(cfgPath)) {
+    return JSON.parse(readFileSync(cfgPath, "utf8")).mcpUrl;
+  }
+  throw new Error(
+    `Unknown MCP URL for ${serverName}. Re-run: bun oauth-mcp.ts connect ${serverName} <mcp-url>`
+  );
+}
+
+async function cmdCall(args: string[]) {
+  const serverName = args[0];
+  const toolName = args[1];
+  const rawArgs = args[2] || "{}";
+  if (!serverName || !toolName) {
+    console.error("Usage: oauth-mcp.ts call <server-name> <tool-name> '<json-args>'");
+    process.exit(1);
+  }
+  const toolArgs = JSON.parse(rawArgs);
+  const mcpUrl = mcpUrlFor(serverName);
+  const result = await mcpCall(serverName, mcpUrl, "tools/call", { name: toolName, arguments: toolArgs });
+  if (result?.content) {
+    for (const item of result.content) {
+      if (item.type === "text") console.log(item.text);
+      else console.log(JSON.stringify(item, null, 2));
+    }
+  } else {
+    console.log(JSON.stringify(result, null, 2));
+  }
+}
+
+async function cmdRefresh(args: string[]) {
+  const serverName = args[0];
+  if (!serverName) {
+    console.error("Usage: oauth-mcp.ts refresh <server-name>");
+    process.exit(1);
+  }
+  const updated = await refreshTokenFile(serverName);
+  console.log(JSON.stringify({ refreshed: true, expires_at: updated.expires_at ? new Date(updated.expires_at).toISOString() : null }, null, 2));
+}
+
+async function cmdRevoke(args: string[]) {
+  const serverName = args[0];
+  if (!serverName) {
+    console.error("Usage: oauth-mcp.ts revoke <server-name>");
+    process.exit(1);
+  }
+  const p = tokenPath(serverName);
+  if (existsSync(p)) unlinkSync(p);
+  console.log(`Removed local token for ${serverName}. Note: this does not revoke server-side authorization - do that in the provider's settings.`);
+}
+
+async function main() {
+  const [command, ...rest] = process.argv.slice(2);
+  // Persist mcpUrl alongside connect so later calls don't need it repeated.
+  if (command === "connect") {
+    mkdirSync(`${DATA_DIR}/servers`, { recursive: true });
+    const serverName = rest[0];
+    const mcpUrl = rest[1];
+    if (serverName && mcpUrl) {
+      writeFileSync(`${DATA_DIR}/servers/${serverName}.json`, JSON.stringify({ mcpUrl }, null, 2));
+    }
+    await cmdConnect(rest);
+    return;
+  }
+  switch (command) {
+    case "status":
+      await cmdStatus(rest);
+      break;
+    case "list-tools":
+      await cmdListTools(rest);
+      break;
+    case "call":
+      await cmdCall(rest);
+      break;
+    case "refresh":
+      await cmdRefresh(rest);
+      break;
+    case "revoke":
+      await cmdRevoke(rest);
+      break;
+    default:
+      console.log(`oauth-mcp.ts - generic OAuth connector for remote MCP servers on Zo Computer
+
+Usage:
+  bun oauth-mcp.ts connect <server-name> <mcp-url> [--scope "..."] [--handle your-zo-handle]
+  bun oauth-mcp.ts status <server-name>
+  bun oauth-mcp.ts list-tools <server-name>
+  bun oauth-mcp.ts call <server-name> <tool-name> '<json-args>'
+  bun oauth-mcp.ts refresh <server-name>
+  bun oauth-mcp.ts revoke <server-name>
+`);
+      process.exit(command ? 1 : 0);
+  }
+}
+
+main().catch((err) => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Description

Generic OAuth 2.1 connector for authorizing any remote MCP server that requires OAuth on Zo Computer, using dynamic client registration (RFC 7591) and PKCE.

Zo's sandbox has no public inbound port of its own, so the "open localhost:PORT and wait for the redirect" OAuth flow most MCP clients assume never lands anywhere. This skill solves it once, generically, with a shared Zo Space API route (`https://<handle>.zo.space/api/oauth-mcp/callback`) as the `redirect_uri` for every OAuth MCP server — the route is public, already deployed on any Zo Space, and persists tokens straight to the workspace.

## Features

- Discovers OAuth metadata via `.well-known/oauth-authorization-server` (falling back to `openid-configuration`)
- Dynamic client registration (RFC 7591), with a manual `client_id`/`client_secret` escape hatch for servers that don't support it
- PKCE (S256) authorization code flow
- Reference implementation for the one-time shared Zo Space callback route (`references/callback-route.md`) that exchanges the code for tokens and writes them to the workspace
- Token status/refresh/revoke, and a generic `list-tools`/`call` MCP JSON-RPC client with automatic refresh-and-retry on 401
- `<server-name>`-scoped file layout so multiple providers can be connected side by side without collisions

## Testing

Used to connect a live third-party MCP server end to end on Zo Computer: discovered metadata, registered a client, completed the browser approval against the shared callback route, and verified `status` returned `connected: true` with a refresh token, then ran `list-tools` and a real tool call (`get_sources`) successfully.

## Checklist

- [x] SKILL.md has required frontmatter (name, description, metadata.author)
- [x] Skill directory name matches `name` in frontmatter
- [x] Description clearly explains when to use the skill
- [x] No sensitive data (API keys, tokens) included — sanitized author handle and doc references to `YOUR_HANDLE.zo.computer`
- [x] `bun validate` passes (0 issues introduced; pre-existing warnings are unrelated to this skill)