### PR TITLE
Community: add bangers

### DIFF
--- a/Community/bangers/DISPLAY.json
+++ b/Community/bangers/DISPLAY.json
@@ -1,0 +1,9 @@
+{
+  "specVersion": "0.2.0",
+  "icon": "megaphone",
+  "tags": [
+    "content",
+    "marketing",
+    "research"
+  ]
+}

--- a/Community/bangers/SKILL.md
+++ b/Community/bangers/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: bangers
+description: >
+  Social-media content system. Use whenever the request is about making content: what to post,
+  content ideas, hooks, titles, thumbnails, YouTube or short-form video scripts, X/Bluesky threads,
+  LinkedIn or Substack or newsletter posts, Facebook Group posts, Instagram or LinkedIn carousels,
+  technical explainers and tutorials, video edit plans and captions, repurposing one source across
+  platforms, or checking whether a draft reads as AI-written and how to disclose AI use. Studies
+  public creator and platform mechanics and adapts them to the author's own audience and voice.
+homepage: https://github.com/Jeff-Kazzee/bangers
+license: MIT
+metadata:
+  author: Jeff Kazzee
+  generated: scripts/build-zo-skill.mjs
+  source: https://github.com/Jeff-Kazzee/bangers
+  suite: bangers
+  version: "1.1.0"
+---
+
+# BANGERS
+
+A research-backed social-media content system. It studies public creator and
+platform behavior, extracts reusable mechanics, and turns real source material
+into native assets without copying anyone's voice.
+
+This is the Zo Computer build. Zo has no plugin system, so the twelve
+procedures live under `references/procedures/` instead of as separate skills.
+Load one procedure at a time. Do not read them all.
+
+## Router
+
+Pick one procedure, read it completely, then load only the references it names.
+
+| Request | Procedure |
+| --- | --- |
+| Research a creator, platform, format, or writing pattern | `references/procedures/banger-research.md` |
+| Ideas, angles, or a content calendar | `references/procedures/banger-ideas.md` |
+| Hooks, titles, thumbnails, or packaging | `references/procedures/banger-hooks.md` |
+| Technical explainer, tutorial, build log, or how-it-works teaching content | `references/procedures/banger-explainer.md` |
+| YouTube or long-form video script | `references/procedures/banger-script-longform.md` |
+| Short vertical script | `references/procedures/banger-script-shorts.md` |
+| X, Twitter, or Bluesky post or thread | `references/procedures/banger-threads.md` |
+| LinkedIn, Substack, newsletter, or Facebook Group post | `references/procedures/banger-longform-written.md` |
+| Instagram or LinkedIn carousel | `references/procedures/banger-carousels.md` |
+| Cut sheet, captions, markers, reframe, or recording plan | `references/procedures/banger-edit.md` |
+| One source adapted to several platforms | `references/procedures/banger-repurpose.md` |
+| AI detector check, authenticity verification, or AI-use disclosure | `references/procedures/banger-detector.md` |
+
+## Before drafting anything
+
+1. Start from a real source, observation, result, or a clearly named audience
+   question. Never invent proof, experience, metrics, quotes, or current
+   platform facts.
+2. Read `references/frameworks/voice-and-audience.md` to fix who is speaking
+   and who they are speaking to, then
+   `references/frameworks/writing-quality.md` for the failure list.
+3. When the piece teaches a mechanism the reader must repeat, also read
+   `references/frameworks/technical-clarity.md` and apply the frame/payload
+   split: the author's voice carries the hook, story, and judgment, while the
+   explanation takes one name per concept, one idea per sentence, and active
+   voice.
+
+## Suite rules
+
+1. Research updates need dated sources, observed examples, a confidence label,
+   and a reusable mechanic. One viral post does not establish a law. Treat any
+   platform claim without a current entry in
+   `references/research/source-ledger.md` as unverified and research it first.
+2. Borrow mechanics, not phrasing, identity, signature jokes, or an imitation
+   voice.
+3. Adapt every output to its native platform. Never paste identical copy
+   everywhere.
+4. Detector results are weak adversarial evidence. Never damage a true, clear
+   passage to move a score, and never claim output passes AI detection. Route
+   detector and disclosure work through
+   `references/procedures/banger-detector.md`.
+5. Keep private client, identity, health, financial, and unpublished business
+   context out of anything reusable.
+
+## Checking a draft
+
+The deterministic writing checker runs in the Zo terminal. It reads UTF-8 files
+and can enforce an author's em-dash ban:
+
+```
+node scripts/check-writing.mjs --no-em-dash draft.md
+```
+
+It prompts human review. It does not prove authorship or quality.
+
+## Output
+
+Lead with the strongest ready-to-use asset. Then give only the source
+assumptions, platform notes, and the approval needed next. Drafting is free.
+Publishing, scheduling, and outreach need the author's explicit per-item
+approval.
+
+## Credit
+
+Creator playbooks study public work by Fireship, Matt Pocock, Theo, and
+ThePrimeagen. The technical-clarity standard is adapted from ASD-STE100
+Simplified Technical English and Orwell's six rules, and reached this project
+through @geogristle, @Voxyz_ai, and @mikehostetler on X. Full credit in
+`references/frameworks/technical-clarity.md`.
+
+MIT licensed. Source and updates: https://github.com/Jeff-Kazzee/bangers

--- a/Community/bangers/references/creators/_synthesis.md
+++ b/Community/bangers/references/creators/_synthesis.md
@@ -1,0 +1,32 @@
+# THE SYNTHESIS — What All Four Creators Share (the meta-playbook)
+The four reference creators look different but run the SAME underlying machine. When you produce anything in this suite, these are the shared laws. Pair with `voice-and-audience.md` to retarget them at YOUR audience.
+
+## 1. THE FIRST 3 SECONDS ARE THE WHOLE GAME
+All four kill the intro. Fireship: first word is the topic. Theo/Prime: open on the stakes/the spicy take. Pocock: the hook line IS a curiosity gap. No "hey guys," no throat-clearing, no channel bumper. **Lead with the payoff or the promise.** On every short-form platform the first 1–3 seconds decide distribution (swipe-away kills reach); on long-form the first 30 seconds decide retention.
+
+## 2. RIDE SOMETHING THAT'S ALREADY MOVING
+None of them start from a blank page every time. Fireship trend-jacks the week's news. Theo reacts to what happened. Prime reacts to a submitted article. Pocock answers real questions people are asking. **Borrow a skeleton with existing heat** (a trending AI tool, a viral demo, a question everyone has) and add your layer on top. The internet supplies infinite raw material; your reaction/teaching is the only original part.
+
+## 3. ONE THING, DENSELY
+Fireship = one idea per sentence, no filler. Pocock = one concept per post. Both refuse to waste the viewer's time. **Every sentence must add information OR a laugh — cut everything else.** For beginners, "dense" means no wasted words, not more concepts.
+
+## 4. A REAL OPINION / VERDICT (the value-add)
+Theo and Prime never just report — they tell you what to think and back it with lived experience, then leave you with a verdict ("here's what I'd actually do"). Pure reaction with no take is the failure mode. **Have a spine.** Be the trusted filter.
+
+## 5. SHOW, DON'T TELL
+Pocock reveals the invisible on screen (the type, the error, the result). Fireship shows real code being typed. Prime pulls the artifact up live. **Put the actual thing on screen** — the prompt and its output, the before/after, the real result — not a description of it.
+
+## 6. MANUFACTURE ENERGY / PERSONALITY
+Prime swings volume and engineers spikes. Theo brings "chat" energy. Fireship uses deadpan comedy. Pocock uses warm enthusiasm. The topic rotates; **YOU are the format.** Personality is what makes it un-clonable.
+
+## 7. BE CORRECTABLE + AUTHENTIC
+Theo publicly says "I was wrong." Prime self-deprecates ("I broke prod"). Pocock punctures his own guru status. **Confidence + humility = trust.** Anti-corporate, anti-gatekeeping, real.
+
+## 8. VOLUME VIA THE FUNNEL, NOT VIA MORE WORK
+Prime and Theo go long once, then shred one session into a video + many clips. Pocock and Fireship keep a fixed template so only the topic research is new. **Produce one rich source asset, then atomize it** (see the repurposing waterfall). Don't make ten things from scratch — make one thing and cut it ten ways.
+
+## 9. PACKAGING > EVERYTHING
+Theo: "obsess over whether the packaging makes it worth clicking." Fireship's titles/thumbnails are engineered. **The title + thumbnail (or first line + first frame) is a separate craft from the content** — and often decides whether the content is ever seen. Plan it before you make the thing.
+
+## 10. CLARITY IS THE MOAT
+"What sets them apart isn't editing skills — it's their writing and unique perspective." The tools are commodities; **the clear explanation and the real point of view are the product.**

--- a/Community/bangers/references/creators/fireship.md
+++ b/Community/bangers/references/creators/fireship.md
@@ -1,0 +1,36 @@
+# FIRESHIP — Maximum-Density + Deadpan-Comedy Playbook
+
+> Jeff Delaney (Fireship). Thesis: **max information density + deadpan self-aware comedy + zero dead air + cheap-but-precise visuals**, riding whatever's hot this week. The video is "already sped up — you have to slow it down to keep up." **Adapt it:** keep the density, pacing, humor, and visual discipline — but calibrate concept count to YOUR audience. Density = "no wasted words," NOT "more concepts." If your audience is less expert than his (developers who already code), cut concept count, keep the tightness, and don't skip fundamentals; if your audience is expert, you can compress harder.
+
+## Two engines
+Evergreen "**X in 100 Seconds**" (timeless intros) + trend-jacking "**The Code Report**" ("CNN for software" — breaking news framing). Blend timeless + reactive for compounding growth. The TEMPLATE never changes, only the topic — that's what enables rapid cadence.
+
+## The hook (first word is the topic — NEVER a greeting)
+No "hey guys," no face-cam, no bumper, no "in this video," no "so." The clock starts on information at word one.
+- **Definition-first:** "[Topic] — a [category] for [doing X], built by [who], released in [year]." ("React — a JavaScript library for building user interfaces, developed at Facebook and released in 2013.")
+- **Problem-provocation:** name the pain as a jab, then present the fix.
+- **Spicy claim (news):** open on the most dramatic-but-true framing, deadpan.
+Copy templates: "[X] — the [tool] that finally [solves annoying problem]." / "Yesterday, [company] did something that [breaks/ends] [thing everyone assumed]." / "There are [N] ways to [do X]. Most are wrong. Here's the one that isn't." / "You've been [doing thing] wrong your entire life. In [N] seconds I'll fix that."
+
+## Density: the no-filler law (the core mechanic)
+Physically produced by: **voiceover recorded sentence-by-sentence**, then razored together so every pause/um/gap is cut → wall-to-wall narration, zero dead air. **Every on-screen asset lives 1–5 seconds** then cuts. One new idea per sentence, chained not nested, never re-explained. Compress with "just / basically / literally" ("it's just a function") then move on.
+DENSITY CHECKLIST: first word = topic; zero dead air; no sentence survives that doesn't add info OR a laugh; visual changes every 1–5s; one new idea per sentence; audio quality non-negotiable ("low quality audio is the quickest way to drop a viewer"); one-line sign-off, no begging outro.
+
+## Script skeletons
+**"X in 100 Seconds"** (~100–140s, 250–350 words): (1) definition hook → (2) the problem it solves + jab → (3) origin (optional) → (4) core mechanism / "it's just a ___" + smallest real example → (5) hands-on micro-demo → (6) the catch / why you'd actually use it → (7) one-line sign-off. Arc: concrete → deeper → caveat → out.
+**"The Code Report" / news:** (1) title card + date, black bg, breaking-news framing → (2) spiciest lede → (3) 2–3 compressed context sentences → (4) rapid takes + roast → (5) one genuinely useful technical payload → (6) deadpan anticlimactic verdict → (7) sign-off.
+
+## Humor & voice
+Deadpan, dry, ironic, self-aware; never laughs at its own jokes; jokes buried inside informative sentences so they reward attention. Devices: self-deprecation ("the personality of a carrot"), roasting industry churn ("every week there's a new JavaScript framework"), rename bits ("they call it a [X], but it's really just a [blunt name]"), meme cutaways timed to the punch word (no face → the meme carries the joke), deadpan over/understatement ("developers are not okay"), meta fourth-wall breaks, ironic flat subscribe ask. Put the joke ON the informative sentence, not in a separate bit.
+
+## Visuals & editing (cheap but precise)
+Minimalist black background, code/subject front-and-center, dense text overlays, emojis/memes timed to the syllable, punchy SFX on cuts. Signature tricks: the **reverse-delete reveal** (write finished code, delete in reverse while recording undo so it re-inserts line-by-line synced to narration — adapt it: the same trick works for revealing any text/UI step-by-step, whatever your subject), emoji/arrow/freeze-frame pointers on the exact line being discussed (a paused viewer always knows the context), jump-cut everything, motion-graphic transitions between beats. Tools: Premiere (edit + VO assembly), After Effects (animation), Figma (graphics), Videohive (transitions), Unsplash/Pexels (stock), Giphy (memes), sub-$100 USB condenser mic. **The polish is writing + editing discipline, not gear.**
+
+## Titles & thumbnails
+"[Topic] in 100 Seconds" (ownable, searchable, promises brevity). "I tried [N] [things]" / "[N] things in [N] minutes" (finite promise). Hot-take titles with the exact buzzword people are searching. Rules: put the searched term in the title; make a concrete finite promise (number/time/verdict); bait mild curiosity, never "Let's learn X." Thumbnail: high-contrast, dark bg, big logo(s), short punchy label, occasional emoji reaction, reads instantly at small size, one clear idea.
+
+## Topic selection (ride the hype cycle)
+Two-track: evergreen (long-tail search) + reactive (news spikes). Surf the peak FAST — biggest wins come from moving immediately at max interest (ChatGPT launch coverage ≈16.9M views). Pick what the audience already argues about. Own a narrow lane. Format reusable, topic fresh.
+
+## THE 10 RULES OF FIRESHIP DNA
+1. First word is the topic — no greeting ever. 2. Zero dead air. 3. Skip everything your audience doesn't need — but if you teach beginners, don't skip fundamentals. 4. One new idea per sentence; delete repeats. 5. Trivialize with "just," then move on. 6. Deadpan, never laugh at your own joke. 7. Roast the industry/yourself, don't hype earnestly. 8. Visual change every 1–5s; reveal step-by-step; pointer on the live line. 9. Cheap assets + precise timing = "expensive" feel. 10. Ride the week's hottest topic through an unchanging template; one flat sign-off.

--- a/Community/bangers/references/creators/matt-pocock.md
+++ b/Community/bangers/references/creators/matt-pocock.md
@@ -1,0 +1,47 @@
+# MATT POCOCK — Teach-One-Thing / Show-Don't-Tell Playbook
+
+> Matt Pocock (@mattpocockuk, Total TypeScript). Ex-singing teacher → "the TypeScript guy." His edge is PEDAGOGY, not genius: "I could explain things a lot better." Grew via VOLUME of tiny high-frequency free content, not one viral hit. **Adapt it:** swap "advanced TypeScript" for YOUR topic (e.g. AI tools for beginners, fitness, personal finance) — the one-concept-per-post, make-the-invisible-visible teaching method works in any niche.
+
+## Signature format: ONE concept, shown not told
+Atomic unit = a single insight, demonstrated visually, that makes people go 🤯. Skeleton of a tip post:
+1. **Hook line** — a curiosity gap or promise.
+2. **The demo** — a screenshot/clip showing the problem or setup.
+3. **The reveal** — the ONE trick, shown happening (not described).
+4. **One-line "why this matters"** — the payoff sentence.
+5. (Optional) CTA/bridge.
+
+## The one-concept discipline
+Each post solves EXACTLY one problem. **Example-first, not concept-first** — show the situation before naming the abstraction; the learner feels the problem, then gets the tool. The insight must feel like a GIFT, not a lecture ("here's a thing that'll make your life better"). **Isolation test:** if you can't state the takeaway in one sentence, it's not one concept — split it. Titles are tightly scoped, complete, actionable verb-phrases.
+
+## Hook patterns (curiosity gap + specificity + a number)
+- `There are [N] ways to [do thing]. I bet you don't know [2 or 3] of them.`
+- `Here are [N] [things] you HAVE to know about.`
+- `This [thing] will wreck your [outcome].`
+- `The [feature] they didn't tell you about.`
+- `Don't use [popular thing]. Here's what to do instead.`
+- `What does this do? 🤔` (quiz — reveal answer below)
+- `I guarantee if you [do X], you'll [aspirational result].`
+Rules: put a NUMBER in it when you can. Name the reader's pain/aspiration in the first 7 words. Create a gap the demo closes — never give the answer in the hook. Mild stakes ("will wreck," "you HAVE to") but the payoff must always deliver — no clickbait debt.
+
+## Visual style: make the invisible visible
+The killer move — surface what's normally hidden right in the shot (adapt it to your subject: show the actual output, the input→result, the before/after, the setting most people never find). Every screenshot should contain a REVEAL — the thing you can't see in plain text. Short, no-cut screen recordings (<2 min, one take, real screen) were his growth engine. The mistake/error IS the drama: show the broken version, then the fix. The "aha" must be locatable in one glance (arrow/highlight the one thing).
+
+## Growth tactics (his own words)
+Volume + consistency of tiny content. Follow the response signal — watch which posts pop, make more of those. **Reply, reply, reply** — "if you reply, they just ask you more"; replies are the flywheel. Teach-by-answering — answer real questions = endless post ideas + authority. Own a niche until you ARE the niche. Free beginner content as the funnel. Repurpose one insight across X → thread → 2-min video → article → LinkedIn. Build EVERGREEN assets (a running "Ultimate ___ Thread" you keep adding to) that compound.
+
+## Voice/tone: warm, low-ego, "let me show you"
+"Hey, I'm Matt!" energy. Collaborative "let me show you," not "let me explain." Self-deprecating, punctures own guru status. Encouraging + aspirational — cast the reader as a future expert ("turn you into a wizard"). Plain language over jargon; earn advanced terms by grounding in an example first. Real, visible enthusiasm. Phrasings: "This one blew my mind." / "Don't worry if it looks scary — it's simpler than it looks." / "You're going to love this."
+
+## Translating hard → beginner (the scaffolding recipe)
+Concrete broken example → let them feel the pain → reveal the one fix → show the proof it works → name the concept LAST → one-sentence "now you can use this for ___." Also: problem→solve→solution loops; radical scoping (one concept, one sentence); "skim, don't study" permission to lower intimidation; the aspirational "wizard" frame that pulls beginners toward difficulty instead of away.
+
+## THE RULES CHECKLIST
+- [ ] One concept only (state takeaway in one sentence, or split).
+- [ ] Example first — show real/broken situation before the abstraction.
+- [ ] Hook has a curiosity gap; first 7 words name a pain/promise; answer NOT given away; number if possible.
+- [ ] The visual REVEALS the invisible; the "aha" is locatable in one glance.
+- [ ] Payoff delivers on the hook — no clickbait debt.
+- [ ] Reader cast as capable; tone warm + low-ego.
+- [ ] One-sentence "why this matters" closes it.
+- [ ] Repurposable (thread entry / 2-min video / article / LinkedIn) and cheap to produce.
+- [ ] Feeds an evergreen hub; you're ready to reply to every question it generates.

--- a/Community/bangers/references/creators/primeagen.md
+++ b/Community/bangers/references/creators/primeagen.md
@@ -1,0 +1,42 @@
+# THE PRIMEAGEN — React-and-Read / Manufactured-Energy Playbook
+
+> Michael Paulson ("ThePrimeagen"/"ThePrimeTime"). Ex-Netflix engineer, ADHD, streams every ~2 days, shreds VODs into YouTube + shorts. **Adapt it:** react to the news/demos/threads YOUR audience cares about. Keep the energy engine; drop the crude gremlin humor and the dev in-jokes (skill issue, YavaScript) unless they fit your brand. The ENERGY techniques transfer; the specific bits are optional seasoning.
+
+## The core engine
+Someone else's content (article, tweet, demo, video) = the SKELETON. Your live reaction = the MEAT. The emotional spikes = the CLIPS. The clips = the funnel. **You almost never start from a blank page** — borrow a stranger's structure and headline, add your opinion + energy on top. The internet supplies infinite raw material; your reaction is the only original part. Funnel order: **go long & raw → cut the reaction into a video → cut the spike into a short.** One long session = many assets (a single session can yield several videos + 10+ shorts).
+
+## The react-and-read rhythm ("read a beat, then riff")
+Read 1–2 sentences of the source verbatim (audience reads WITH you) → **hard STOP** (the pause IS the content) → riff: agree loudly, disagree loudly, add a war story, make a joke, give a verdict → resume. Repeat. Why it works: zero prep + infinite supply; the source is the straight man, you're the comedian; parasocial co-reading = "watching a smart friend react," not a lecture.
+
+## Manufacturing the energy (the product IS the energy)
+- **Dynamic range** — whisper-to-YELL swings. Never monotone. Quiet "okay so…" then sudden "**THIS IS INSANE**." Boredom is the only real failure.
+- **Speed bursts** — chase a tangent, catch yourself, snap back. (ADHD pacing as a feature.)
+- **Physicality on cam** — lean in, recoil, hands up, the reaction face. The face sells the take.
+- **Repetition for emphasis** — "No. No. No no no."
+- **Self-deprecation as pressure valve** — earn strong opinions by trashing yourself first ("I broke prod four times, what do I know"). Confidence + self-roast = likable not arrogant.
+Energy scaffold for a segment: OPEN QUIET → BUILD (read/react, volume climbing) → PEAK (the yell / hot take) → UNDERCUT (self-deprecating aside) → RESET ("okay, moving on").
+
+## Clip-ability — engineer the spike
+Every 5–10 minutes, deliberately manufacture ONE clippable spike (a yell, a hot take, a bit, a validation). A great clip = a single emotion, 30–90s, clean in/out, no setup needed, one quotable line, a visible face reaction, contained conflict (you vs. the bad take). You're farming clips in real time.
+
+## Credible hot takes
+Strong claim + lived experience that earns it, delivered at hot-take VOLUME even when the actual position is nuanced. Attack platitudes and hyped ideas, never beginners — roast the take, welcome the person. Unfiltered = trustworthy. Vulnerability (ADHD, failures) makes the loud confident takes land as honest. Template: "Hot take: [provocative claim]. And before you @ me — [credential/experience]. [The nuanced position, said at max volume]. [self-aware undercut]."
+
+## Titles & thumbnails
+Master pattern: **source's own headline + a reaction tag** (`[Headline] | Prime Reacts`) — ride someone else's curiosity, stamp your reaction on it. Other patterns: `[Thing] is [Dead/a Scam/Ridiculous]` · `Why [trendy thing]??` · `Dear [group], You Are Wrong` · `This is [Insane/Genius]` · `why i quit [thing]` (lowercase, confessional) · `The TRUTH about [hyped topic]` · `I read [X] so you don't have to`. Thumbnail = your face doing the emotion + the source screenshot + one punchy word (WRONG / INSANE / DEAD). Every thumbnail poses an implicit conflict: praise or destroy? Click to find out.
+
+## Topic selection
+Ride what's already moving: trending articles, community drama, fan submissions, perennial holy wars, big personal/spicy meta takes. **Selection filter:** does it already have heat AND do I have a genuine strong reaction? Both yes → react. Trending but you feel nothing → skip; the reaction has to be real.
+
+## RULES CHECKLIST
+- [ ] Start from someone else's content, not a blank page.
+- [ ] Read a beat, then STOP and react — never a whole paragraph unbroken.
+- [ ] Swing the volume; manufacture one clippable spike every 5–10 min.
+- [ ] Anchor hot takes to lived credibility, then undercut with self-deprecation.
+- [ ] Attack platitudes/hype, never beginners.
+- [ ] Title = source headline + reaction tag, or outrage/curiosity frame.
+- [ ] Thumbnail = your face doing the emotion + source screenshot + one word.
+- [ ] Make the audience a character; stay authentic over corporate.
+- [ ] Pick topics with existing heat AND a genuine reaction — no fake outrage.
+- [ ] Go long, then shred one session into many videos + shorts.
+- [ ] The reaction is the product; the information is the excuse.

--- a/Community/bangers/references/creators/theo.md
+++ b/Community/bangers/references/creators/theo.md
@@ -1,0 +1,52 @@
+# THEO (t3.gg) — Reaction & Hot-Take Commentary Playbook
+
+> Theo Browne. YouTube "Theo - t3.gg", Twitch streamer, founder. His model: an experienced insider reacts to today's news, has a strong defensible opinion, and explains WHY. **Adapt it:** swap "senior engineers arguing about frameworks" for whatever YOUR audience is confused/excited about (e.g. beginners navigating AI tools) — same reaction energy, stakes pitched to their level.
+
+## Core thesis
+Not a tutorial channel — a **current-events commentary channel**. Three pillars: (1) Recency — cover what happened this week (new AI model, feature, viral demo). (2) Authority + Opinion — tell people what to think and defend it with hands-on experience ("I've been using X for a while..."). (3) Personality — fast, casual, opinionated; YOU are the format, the topic rotates.
+
+## Reaction format (the value formula)
+`Source material + (insider context OR hands-on experience OR historical pattern) + explicit verdict = a video.`
+Pure reaction with no added layer is the failure mode. Structure: (A) The trigger — something external happened, pull it ON SCREEN. (B) Frame it — "let's talk about X and why it matters right now." (C) React + narrate — read source aloud, interject. (D) THE VALUE-ADD — add context the source lacks, your hands-on take, historical framing, a verdict on what you'd actually do. (E) Tangent-and-return — wander for personality, then explicitly snap back ("anyway—").
+
+## Hot takes: "controversial but defensible"
+- Opinion first, receipts ready. Bold claim, sober defense.
+- Attack ideas/decisions, rarely people. Keeps it debate, not a feud.
+- Steelman the other side before dismantling it — makes the take feel earned.
+- Show the walk-back — publicly say "I was wrong" when a take ages badly. Being correctable = credibility (and a follow-up video).
+- **Defensibility test:** Could a smart person agree after hearing your reasoning? Yes → publish. Only works on people who don't know the topic → it's ragebait, cut it.
+- Ride disagreements the audience ALREADY has; don't invent outrage.
+
+## Titles — "clickbait-but-honest" (over-promise curiosity, then DELIVER)
+Packaging matters more than almost anything. Short, emotional, curiosity-gap or bold-claim. Real patterns:
+1. Rhetorical question — "Why Can't We Commit .env Files?" / "Are we in an AI Bubble?"
+2. Emotive reaction + parenthetical reveal — "Oh no (the new Grok model is good)"
+3. Personal hands-on — "So I've been using gpt-5.6 for a while..."
+4. Contrarian declaration — "Your Product Could Be A Markdown File"
+5. Imperative — "Stop Being Scared of Deleting Code"
+6. Betrayal/debunk — "You were lied to about ___"
+7. Rant flag — "I need to rant about ___"
+8. End-of-era — "The unexpected death of ___" / "The ___ wars are over"
+9. Vague suspense/FOMO — "It's FINALLY here!!!" / "I'm about to make a lot of people angry..."
+10. Definitive verdict — "GPT-5.6: The Review"
+11. Taxonomy framing — "The Eras of AI Agents"
+
+## Thumbnails (his own rules)
+Face + strong reaction ("YouTube face"). 1–3 words MAX, big. Red arrows work. **Thumbnail must NOT repeat the title** — it adds a SECOND hook. Plan thumbnail BEFORE filming so you shoot the promised moment.
+
+## Stream → clip → shorts funnel (how volume happens)
+Stream long (raw material + R&D lab) → test topics live, chat is the instant focus group → editors mine VODs into standalone videos + shorts → package title/thumbnail after the fact to fit the strongest moment. Clip = one self-contained take + reasoning, a genuine reaction beat, a question→payoff arc that stands alone, tied to a current topic.
+
+## Voice/tone
+Fast, casual, high-energy, unscripted — like a Discord call with friends, not a lecture. Emotionally reactive vocab: "oh no," "this is actually insane," "wait, what?", "here's the thing," "I need to rant about...". Opinionated and direct: "this is bad," "this is genuinely great," "stop doing X." Self-aware and correctable. Transparent — share your process and numbers.
+
+## Topic selection test
+Is it (a) recent, (b) something you have a real opinion + experience on, (c) something your audience is already talking about? Two of three minimum; all three = a banger.
+
+## COPY THESE — templates
+**Hot-take frame:** "Everyone says [accepted belief]. Having [your real experience], I actually think [contrarian claim] — here's why: [2–3 concrete checkable reasons]. The case FOR the mainstream view is [fair steelman] — but [why it still doesn't hold]. Bottom line: [what I'd actually do]."
+**Reaction opening:** "So [thing] just happened. [Pull it up.] And honestly? [emotional reaction]. Here's what's actually going on, because [coverage] is missing [key context] — and I've [actually used it]. Let's get into it."
+
+## DO / DON'T
+DO: cover this-week news; lead with opinion then back it; put the artifact on screen; steelman + be correctable; plan title+thumbnail before filming; open on stakes; talk TO viewers; ~1 CTA per piece.
+DON'T: react with no added layer; manufacture outrage or attack people; make thumbnail repeat title; script the personality out; obsess over vanity metrics; let tangents kill the spine.

--- a/Community/bangers/references/frameworks/hooks-bank.md
+++ b/Community/bangers/references/frameworks/hooks-bank.md
@@ -1,0 +1,56 @@
+# THE HOOK BANK — Swipe File for Openers, Titles & Thumbnails
+A hook's only job: buy the next 3 seconds. Every platform decides distribution on the opening (first 1–3s short-form, first 30s long-form, first ~150 chars on text). Match the hook to the audience (see `voice-and-audience.md`) — fill every pattern with YOUR audience's topics, vocabulary, and sophistication level. Never write clickbait you don't pay off — the payoff must always deliver, or reach dies on the mismatch check.
+
+## THE 7 HOOK ENGINES (pick one, then fill it)
+1. **Curiosity gap** — open a loop the content closes. "There's one ChatGPT setting that changes everything. Almost nobody turns it on."
+2. **Specific promise** — a number + a concrete outcome. "5 AI tools that write your emails in 10 seconds."
+3. **Contrarian / pattern-break** — challenge what they assume. "You're using ChatGPT wrong. Here's the fix."
+4. **Stakes / warning** — name what they'll lose. "If you're still doing [tedious task] by hand in 2026, you're wasting 5 hours a week."
+5. **Reaction / news** — ride what just happened. "A new AI thing dropped today. Do you actually need it? Honest take."
+6. **Relatable pain** — say the thing they feel. "AI feels overwhelming and everyone acts like you should already get it. Let's fix that in 60 seconds."
+7. **Result-first / proof** — show the outcome, then how. "I made this whole [thing] in 4 minutes with AI. Here's exactly how."
+
+## FILL-IN-THE-BLANK OPENERS (short-form / video)
+- "The one [tool] trick that [surprising outcome]."
+- "You've been [common task] wrong your whole life. Here's the 30-second fix."
+- "[N] AI tools that do [annoying task] while you sleep."
+- "Stop paying for [thing]. This free AI does it in seconds."
+- "I tried [tool] so you don't have to. The verdict:"
+- "Everyone's talking about [new AI thing]. Here's what it actually means for you."
+- "Watch me [do real task] with AI in real time."
+- "If [relatable situation], you need to see this."
+
+## TITLE PATTERNS (YouTube — combine SEO term + a finite promise or emotion)
+- "[Thing] in 100 Seconds" (ownable, searchable, promises brevity)
+- "I tried [N] AI [tools] so you don't have to"
+- "[N] AI tools that feel illegal to know"
+- "The truth about [hyped AI thing]"
+- "Is [new tool] actually worth it? (honest review)"
+- "You don't need [expensive thing] anymore. Here's why."
+- "How I [real outcome] using only free AI"
+- Reaction: "[Source headline] — my honest reaction"
+Rules: put the exact term people search in the title; make ONE concrete promise (number, time box, or verdict); bait mild curiosity, never "Let's learn about AI." ~70 chars, front-load the payoff.
+
+## THUMBNAIL RULES (from Theo + Fireship + Prime)
+- **1–3 words MAX**, big and high-contrast. Red arrows/circles work.
+- **The thumbnail must NOT repeat the title** — it adds a SECOND hook.
+- If your face is on it: do the emotion (surprise/skepticism/delight) — the face tells the take before they click.
+- Every thumbnail should pose an implicit question: is this good or bad? Worth it or not? Click to find out.
+- Keep key elements in the center (survives cropping across surfaces). Reads instantly at small size.
+- **Plan the thumbnail BEFORE you make the content** so you actually deliver the promised moment.
+
+## TEXT-POST HOOKS (X / LinkedIn / Substack Notes — first line is everything)
+- Number + bet: "There are 7 ways to use AI for [task]. I bet you're only using 1."
+- "You HAVE to know about [thing]." / "The [tool] feature they didn't tell you about."
+- Contrarian: "Don't use [popular thing] for [task]. Do this instead."
+- Result: "I automated [task] with one prompt. Here it is 👇"
+- Question: "What if you never had to write [tedious thing] again?"
+- Story cold-open: "Last week I watched someone spend 3 hours on something AI does in 30 seconds."
+Rules: front-load the value in the first ~150 chars (that's all that shows before "see more"). One idea. No link in the first post/body (put it in a reply/comment — but note LinkedIn now penalizes link-in-first-comment too; add it after traction).
+
+## THE HOOK CHECKLIST
+- [ ] Does it work in the first 3 seconds / first line alone?
+- [ ] Is there ONE clear reason to keep going (a gap, a promise, a stake, a reaction)?
+- [ ] Is it specific (a number, a named tool, a concrete outcome) — not vague?
+- [ ] Does the content actually PAY OFF the hook? (No clickbait debt.)
+- [ ] Would YOUR audience feel invited, not intimidated (or, for experts: intrigued, not patronized)?

--- a/Community/bangers/references/frameworks/technical-clarity.md
+++ b/Community/bangers/references/frameworks/technical-clarity.md
@@ -1,0 +1,171 @@
+# Technical clarity: the frame and payload split
+
+Read this when the content teaches how something works. It sits between
+`voice-and-audience.md` (who is speaking) and `writing-quality.md` (what fails).
+
+## Where this came from
+
+This file is downstream of a public conversation on X in 2026, and the people
+who started it deserve the credit:
+
+- **[@geogristle](https://x.com/geogristle/status/2078492579511906771)** made
+  the original point: you can get LLMs to write technical documentation that
+  does not sound like AI by requiring them to follow ASD-STE100 Simplified
+  Technical English. Earliest of the three posts below.
+- **[@Voxyz_ai](https://x.com/Voxyz_ai/status/2078857039116156978)** made the
+  argument that matters most here: stop banning words one at a time, because
+  you never gave the model a writing system. Orwell's six rules from 1946 are
+  the base block.
+- **[@mikehostetler](https://x.com/mikehostetler/status/2079245119455150418)**
+  carried the STE answer further.
+- **[woosal1337](https://github.com/woosal1337/blog/tree/main/videos/ep01-the-cure-for-ai-slop)**
+  ran the cross-model experiment and published a linter and results, showing a
+  banned-word list barely moves the needle while a full writing system cuts
+  measured violations sharply.
+- **[danyuchn/asd-ste100-skill](https://github.com/danyuchn/asd-ste100-skill)**
+  published an ASD-STE100 Claude Code skill. This file is not the first of its
+  kind.
+
+What this file adds is the frame/payload split below, which is the part none of
+the sources address: what happens when you apply a controlled-language standard
+to writing that also has to carry a voice.
+
+Most technical content fails by applying one register to the whole piece. All
+voice and the explanation goes hand-wavy: the reader enjoys it and cannot
+repeat it. All specification and the piece reads like a manual: correct,
+unshareable, unfinished. Teaching content needs both registers, assigned
+deliberately.
+
+## The split
+
+**Frame = the author's voice.** Hook, stance, the story of what happened, the
+cost of getting it wrong, transitions, the judgment, the call to action. This
+is where the reader decides whether to keep going and whether to trust the
+person talking. Personality lives here. Apply the creator profile, not the
+clarity rules below.
+
+**Payload = technical clarity.** The passages where the reader must understand
+a mechanism: definitions, steps, what the system does, why the failure
+happens. This is where the reader is working, and where vague writing costs
+them the most. Apply the discipline below.
+
+A starting ratio for a teaching post: frame carries the first and last fifth,
+payload carries the middle. Adjust to the piece.
+
+## Payload discipline
+
+Adapted from ASD-STE100 Simplified Technical English, a controlled-language
+standard for aircraft maintenance documentation. It exists because airlines
+asked for it: roughly 80% of them are not native English speakers, and per the
+standard's own documentation, complex technical instructions can be
+misunderstood, and misunderstandings can lead to accidents. Working group
+formed 1983, first released 1986 as the AECMA document, still maintained. The
+full standard is free at https://www.asd-ste100.org/.
+
+1. **One name per thing.** Choose the term on first use and never rotate it.
+   If it is a "context file" in paragraph two, it is not a "memory doc" in
+   paragraph five. Synonym rotation is the fastest way to lose a reader who is
+   tracking a mechanism.
+2. **One idea per sentence.** Around 25 words in payload prose, closer to 20
+   for steps and instructions.
+3. **Active voice with a named actor.** "The parser reads the file", not "the
+   file is read". The reader is building a model of who does what.
+4. **Verbs, not nominalized verbs.** Analyze, not "perform an analysis of".
+   Help, not "provide assistance".
+5. **Cut hedge stacks.** "This may potentially help improve" says nothing. It
+   either does the thing or it does not. Real uncertainty stated plainly
+   ("I have not tested this at scale") is honesty, not hedging. Keep that.
+6. **Show quality, never claim it.** No seamless, robust, powerful, blazing,
+   effortless. Give the number, the before and after, or the failure it
+   prevents.
+7. **No semicolons in payload prose.** Use a period.
+8. **Concrete over abstract.** The exact command, the exact error text, the
+   exact file. Screenshots and code blocks beat description.
+
+## What survives the discipline
+
+Do not sand these off in the name of clarity:
+
+- Contractions, if the author uses them.
+- The aside that names the annoying part.
+- The judgment call. A specification has no opinions. The author does, and the
+  opinion is often why the piece is worth reading.
+- Humor and intensity where the author has earned them.
+
+Orwell's sixth rule governs the whole document: break any of these rules
+before you write something barbarous. Clarity is the goal. Compliance is not.
+
+## Orwell's six rules
+
+From "Politics and the English Language" (1946), paraphrased:
+
+1. Never use a figure of speech you are used to seeing in print.
+2. Never use a long word where a short one works.
+3. If you can cut a word, cut it.
+4. Never use the passive where the active works.
+5. Never use jargon when everyday English works.
+6. Break any of these rules before writing something barbarous.
+
+## Kill-list: applies to the WHOLE document, frame included
+
+The payload discipline above governs only the payload. This kill-list governs
+everything, voice sections included. Do not skip it on the frame because the
+frame is "yours". The frame is exactly where these creep back in, because it is
+the part no length rule is watching.
+
+### Frame-specific tells
+
+These are the ones that survive a clean payload and still make a piece read as
+machine-written:
+
+- **Closer cadence.** Every section ending on a short, quotable, self-satisfied
+  line. One or two landings in a piece is voice. Landing every single section is
+  the single loudest tell there is, and it is the one writers miss, because each
+  line looks good alone. Check the last sentence of every section in a column.
+  If they all punch, flatten most of them. Let sections end mid-thought, on a
+  qualifier, or on an ordinary sentence.
+- **Significance flagging.** "That is the whole trap", "this is the part I would
+  keep", "if you take one thing from this", "that is the whole trick". Telling
+  the reader what matters instead of letting the writing carry it. Cut every
+  instance.
+- **Manufactured symmetry.** "I did not have an X problem. I had a Y problem."
+  Reads clever, teaches nothing the plain sentence would not.
+- **Too clean an arc.** Real accounts have loose ends. If nothing in the piece is
+  unresolved, uncertain, or admitted-to-be-still-wrong, it was probably smoothed
+  by a model. Put the loose end back.
+- **Uniform paragraph length.** Three to four lines each, all the way down. Vary
+  it for real, driven by how much the thought needs.
+
+### General tells
+
+These hit hardest in teaching content, because the reader is already working:
+
+- Significance inflation: "plays a pivotal role", "underscores the
+  importance", "a testament to", "the evolving landscape of".
+- Copula avoidance: "serves as" and "boasts" where "is" and "has" work.
+- Negative parallelism: "it's not just a cache, it's a paradigm shift".
+- Rule-of-three triples that sound complete and teach nothing.
+- Vague attribution: "experts argue", "industry reports suggest". Name the
+  source or cut the claim.
+- Filler vocabulary: delve, intricate, interplay, meticulous, leverage,
+  facilitate, showcase, foster, robust, seamless.
+- Formatting tells: bold on every other phrase, Title Case Headings, and a
+  closing paragraph that restates the piece.
+
+## Check before delivering
+
+- Can a reader follow the mechanism and repeat it with the post closed?
+- Is every concept called exactly one name?
+- Did any sentence claim quality instead of showing it?
+- Does the frame still sound like the author, or did the discipline flatten
+  the piece?
+- Would deleting any sentence lose information? If not, delete it.
+- **Read the last sentence of every section, in order, on their own.** If they
+  all land like punchlines, the piece reads as machine-written no matter how
+  good the payload is. Flatten most of them.
+- Is anything in the piece left genuinely unresolved? If not, you smoothed
+  something you should not have.
+
+A mechanical check catches the countable defects and nothing else. It will
+pass a clean, confident, hollow paragraph. It cannot tell you whether you had
+anything to say.

--- a/Community/bangers/references/frameworks/voice-and-audience.md
+++ b/Community/bangers/references/frameworks/voice-and-audience.md
@@ -1,0 +1,72 @@
+# THE VOICE & AUDIENCE PROFILE — Define who you're talking to, then adapt the mechanics
+Read this FIRST whenever producing content. The four reference creators (Fireship, Matt Pocock, Theo, Primeagen) all serve TECHNICAL/dev audiences. The creator you're helping almost certainly serves someone else. The creators' MECHANICS are the gold; their jargon, examples, and in-group signaling are fuel for THEIR audience only. This file is how you keep the engine and swap the fuel — for any niche.
+
+## STEP 1: BUILD THE AUDIENCE PROFILE (do this before writing anything)
+If you don't already know who this creator serves, **ask them once at the start of the session**, store the answers, and apply them to everything you produce. Five questions:
+
+1. **Who are they?** (role, life stage, identity — "new parents," "junior devs," "small-business owners," "home cooks who hate meal planning")
+2. **What do they want?** (the outcome they'd pay for — save time, make money, get fit, ship code, feel less overwhelmed)
+3. **What do they fear or struggle with?** (the thing that keeps them stuck — feeling behind, wasting money, looking dumb, information overload, past failures)
+4. **How sophisticated are they?** (total beginner ↔ practitioner ↔ expert — this drives every vocabulary decision below)
+5. **What do they respond to?** (proof? humor? authority? relatability? "you can do this" warmth? spicy takes?)
+
+If the creator cannot answer crisply, help them describe one real person who follows them. A vivid single person beats a vague demographic. If answers are unavailable, state the assumption and proceed. Never silently guess.
+
+## Step 2: Record hard creator constraints
+
+Store these beside the audience profile so every writing route can enforce them:
+
+```yaml
+creator_name: ""
+recent_approved_samples: []
+punctuation_bans: []
+prohibited_phrases: []
+required_tone: []
+forbidden_tone: []
+detector_mode: "off" # off | requested | panel
+private_overlay_path: ""
+```
+
+`punctuation_bans` and `prohibited_phrases` are automatic failures. `detector_mode: panel` requires the detector workflow in `writing-quality.md` when accessible. Keep private values in a local overlay rather than this public template.
+
+## THE PRIME DIRECTIVE
+**Match vocabulary to the audience's ACTUAL sophistication — it cuts both ways.**
+- **Non-expert audience:** no unexplained jargon. When a technical term is unavoidable, define it in the same breath with a plain analogy. Assume zero prior knowledge; never make them feel stupid for lacking it.
+- **Expert audience:** use insider shorthand freely — over-explaining basics signals you're not one of them and burns their time. Skip the 101; get to the insight.
+- The test: **would one real member of this audience understand every sentence WITHOUT feeling either lost or patronized?** If not, rewrite.
+
+## HOW TO TRANSLATE EACH CREATOR'S MECHANIC (keep the move, change the target)
+
+**Fireship → density + humor, calibrated to the audience.** Keep: zero filler, fast pace, one punchy idea after another, deadpan jokes, "X in 100 seconds" compression. Change: density means VALUE-PER-SECOND for THIS audience, not information overload. For beginners (in any niche), density = "no wasted words" — cut the concept count, keep the pace. For experts, density = more real substance per minute. Examples: "5 stretches in 100 seconds" (fitness), "Index funds explained in 100 seconds" (finance), "Your CRM's hidden feature in 60 seconds" (B2B software).
+
+**Matt Pocock → one concept, shown not told.** Usually the single most portable mechanic. Keep: teach exactly ONE thing per piece, example-first, make-the-invisible-visible (show the actual input and the actual result on screen), warm low-ego "let me show you," cast the viewer as capable. Point it at one concept in YOUR niche: one knife technique (cooking), one form fix (fitness), one budgeting move (finance), one prompt trick (AI for beginners), one settings toggle (B2B software). The screenshot reveal = show the real before/after — the messy dashboard vs. the clean one, the burnt pan vs. the seared steak.
+
+**Theo → react to what's happening now, with an opinion.** Keep: cover this-week news in your niche (a new product, a study, a viral claim, a rule change), have a real take, "here's what this actually means for YOU." Change the target of the take to your audience's decision: "is this new supplement worth it?" (fitness), "does this rate change affect your mortgage?" (finance), "is this viral kitchen gadget hype?" (cooking), "should your team switch tools?" (B2B), "is this parenting trend evidence-based?" (parenting). You become the trusted filter who tells overwhelmed people what deserves their attention. Steelman the other side + be correctable stays, in every niche.
+
+**Primeagen → react-and-read energy + the funnel, tuned to your audience's culture.** Keep: borrow someone else's content as the skeleton (react to an article/post/demo/video so you never face a blank page), manufacture energy with genuine reactions and volume swings, engineer clippable spikes, go-long-then-shred one session into many pieces, credential-anchored takes undercut with humility. Change: swap HIS in-group humor ("skill issue," dev in-jokes) for YOUR audience's shared language and running gags — every niche has them. If your audience is beginners, your authenticity marker is "I was confused by this too, here's what finally clicked." If experts, it's battle scars: "I've done this 200 times; here's where it breaks."
+
+## VOICE (derive the creator's own blend)
+Don't clone any of the four — **blend them in the creator's own proportions.** The four dials:
+- **Energy** (Prime/Theo): alive, opinionated, reactive. How loud is this creator, honestly?
+- **Pedagogy** (Pocock): patient, one-thing-at-a-time, "you've got this." How much is this creator a teacher?
+- **Tightness** (Fireship): no filler, respect the viewer's time. Non-negotiable at some level for everyone.
+- **Humor**: deadpan (Fireship), chaotic (Prime), dry (Theo), warm (Pocock) — or the creator's own. Never forced.
+
+Ask the creator (or infer from their existing content): which two dials are naturally highest? Write to those. Then anchor the voice with a **recurring promise** — the one sentence their audience should associate with them (e.g., "You don't need to be technical, you just need the exact steps" / "Evidence, not bro-science" / "Restaurant results with grocery-store ingredients"). Use it as a consistency check on every piece.
+
+## VOICE DO / DON'T
+DO: use "you," short sentences, concrete examples with real numbers/outcomes, before/after, "here's exactly what to do/type/click," name the audience's fear and dissolve it ("this feels overwhelming — it's actually three steps"). Show the real screen/pan/spreadsheet/rep. Give one win they can get today.
+DON'T: mismatch vocabulary to sophistication (jargon at beginners, baby-talk at experts), hype without proof, talk down, hedge everything, bury the useful part, borrow another niche's in-jokes, be a hype-man with no substance.
+
+## THE SUBSTANCE BAR (Theo's + Prime's rule, applied)
+Every piece must pass: **would this audience walk away able to actually DO one new thing, or UNDERSTAND one thing they were confused about?** Entertainment without a takeaway is empty; a takeaway without energy is boring. Bangers have both.
+
+## FORMATS THAT FIT (fill in [your topic])
+- "I tried [tool/product/method] so you don't have to — here's the verdict."
+- "The one [technique/setting/move] that [does a useful real-life thing]."
+- "You're doing [common task] wrong. Here's the fix." (Pocock's before/after)
+- "New [thing in your niche] dropped. Do you actually need it? (honest take)" (Theo react)
+- "[N] [tools/tricks/foods/exercises] that do [boring or hard task] in [tiny time]." (Fireship density)
+- "Watch me [do a real thing in your niche] in real time." (Prime react-and-do)
+- "[Big claim going around]. Let's test it." (react + verdict, any niche)
+Adapt the noun, keep the shape. The shapes are audience-agnostic; only the fill changes.

--- a/Community/bangers/references/frameworks/writing-quality.md
+++ b/Community/bangers/references/frameworks/writing-quality.md
@@ -1,0 +1,51 @@
+# Living writing-quality gate
+
+This gate catches generic, over-smoothed, or untrustworthy prose before publication. It does not define one universal voice. The creator profile owns voice-specific rules.
+
+## Before drafting
+
+- Name the author, audience, platform, purpose, and source of truth.
+- Pull two or three recent approved samples from the actual author when available.
+- Decide what the reader should understand, feel, or do after one pass.
+
+## Human writing test
+
+1. Truth: every claim, story, number, and result is sourced or clearly qualified.
+2. Specificity: replace abstract praise with a concrete detail, choice, cost, or consequence.
+3. Point of view: the piece makes a real judgment instead of balancing every side into mush.
+4. Rhythm: sentence and paragraph lengths vary naturally. The prose survives reading aloud.
+5. Friction: remove canned setup, fake suspense, empty transitions, summary repetition, and ornamental conclusions.
+6. Voice: the author could plausibly say every line. Preserve their vocabulary, contractions, humor, intensity, and restraint.
+7. Platform: the hook, container, pacing, and call to action belong on the target surface.
+8. Restraint: do not use decorative headings, forced three-part lists, needless bolding, or audience flattery as a substitute for substance.
+9. Attribution: borrowed ideas are credited, and creator mechanics do not become creator imitation.
+
+## Common synthetic tells
+
+Treat these as prompts to inspect, not forbidden strings:
+
+- generic openings such as "in today's fast-paced world";
+- repeated "not just X, but Y" constructions;
+- vague authority claims such as "experts agree";
+- excessive symmetry, stacked triads, and identical paragraph lengths;
+- fake quotations, invented personal experience, and unsupported numbers;
+- transition words carrying the argument instead of evidence;
+- an inspirational ending that merely repeats the introduction;
+- constant hedging or breathless certainty;
+- vocabulary the named author never uses.
+
+## Detector panel
+
+Read `detector_mode` from the creator profile.
+
+- `off`: do not run a detector.
+- `requested`: run the panel only when the author asks.
+- `panel`: run the panel for outward-facing prose whenever detector access exists. If access does not exist, mark it `not run` instead of pretending.
+
+Use two independent, currently accessible detector services when practical. Record the service name, URL or version, date, input identifier or hash, score or label, and highlighted passages in `references/research/detector-runs.md` or a private equivalent. Do not commit private draft text to a public ledger.
+
+A score alone never triggers a rewrite. Map each highlight to a real defect in the human writing test, revise only those defects, rerun once, and stop after at most two detector-led passes. Truth, clarity, rhythm, and authentic voice outrank every score.
+
+## Creator-specific rules
+
+Load the creator profile for hard constraints. A profile may ban punctuation, phrases, tones, or formatting. These rules override generic stylistic advice.

--- a/Community/bangers/references/platforms/platform-playbook.md
+++ b/Community/bangers/references/platforms/platform-playbook.md
@@ -1,0 +1,113 @@
+# PLATFORM PLAYBOOK
+
+> Freshness status, 2026-07-25: legacy claims are unaudited. Treat every numeric benchmark, algorithm assertion, feature-availability claim, and policy statement below as a research lead, not current truth, until `references/research/source-ledger.md` contains a non-expired supporting entry. Official technical specifications should also be reverified when the platform may have changed.
+
+This file collects candidate platform mechanics for the BANGERS suite. Read the relevant section before platform-specific work, but use only currently supported claims in outward-facing advice.
+
+## TABLE OF CONTENTS
+1. YouTube long-form · 2. YouTube Shorts · 3. TikTok · 4. Instagram (Reels + Carousels) · 5. X/Twitter · 6. LinkedIn · 7. Substack · 8. Bluesky · 9. Facebook Groups · 10. Cross-platform repurposing waterfall
+
+---
+
+## 1. YOUTUBE LONG-FORM
+**SPECS:** 16:9. 1080p min (upload 1440p/4K for crisper thumbnails). 24–60fps. H.264/MP4, AAC 48kHz. Thumbnail 1280×720, <2MB. Title ~70 chars, front-load the payoff. Chapters need ≥3 timestamps, first at 00:00, each ≥10s.
+**RULES:**
+- Optimize for **session contribution + satisfaction**, not raw watch time. YouTube now weights whether you keep the viewer on YouTube afterward, and discounts watch time by satisfaction signals (surveys, "not interested"). Satisfaction now sits ABOVE raw watch time.
+- **Win the first 30 seconds** — lead with the title's payoff, cut intros/preamble. Leading with the key insight raised past-30s retention 15–20pts in a cited case.
+- Retention benchmarks (avg % viewed): <5min → 50–70%; 5–15 → 40–55%; 15–30 → 30–45%; 30+ → 25–35%.
+- CTR: aim >4% overall; smaller channels run higher. Do NOT pair high CTR with a fast drop-off — YouTube checks first-30s retention against the click and demotes clickbait mismatch.
+- **Comments > likes** for ranking. Prompt discussion. Build SERIES, not one-offs (repeat viewing within a topic gets boosted).
+- Cadence: ~1/week minimum for algo trust; 2/week grows ~3× faster at equal quality. SEO: keyword in title + first 1–2 description lines + spoken audio (transcript is indexed). Tags are low-weight now.
+- Reach-killers: channel-intro cold opens, thumbnail/title mismatch, topic-hopping (breaks niche clustering), <1/week, mass-produced/reused content (demonetization risk). **Label AI content** (mandatory disclosure; unlabeled = reduced distribution).
+
+## 2. YOUTUBE SHORTS
+**SPECS:** 9:16, 1080×1920. Max 180s; ideal 15–45s (13s and 60s test well). 30fps, H.264. **Safe zones:** keep text/faces out of top 288px, bottom 672px, left 48px, right 192px — effective safe area ≈ centered 840×960.
+**RULES:**
+- A "view" now counts on every start/replay (since Mar 2025). Optimize for **"Engaged views"** (Analytics → Advanced) — monetization runs on engaged views, not the vanity count.
+- **Win seconds 1–3 or die** (explore/exploit: a seed audience decides expansion). Watch "Viewed vs. Swiped Away." **Engineer the loop** — seamless start/end so it replays.
+- Shorts are **decoupled from long-form** (late 2025) — each Short stands alone; subs/long-form history don't guarantee reach. Caption everything (watched muted); say the topic aloud early.
+- Cadence 3+/week (daily works). #shorts + 1–3 tags; trending audio helps.
+- Reach-killers: letterboxed/horizontal footage, text under the button rails, teaser clips that only make sense with the long video, no hook.
+
+## 3. TIKTOK
+**SPECS:** 9:16, 1080×1920, 30fps, MP4/H.264. Ideal 21–34s (go 1–3min only if completion holds). Photo Mode: 9:16 images, 5–7 slides. **Safe zones:** top ~90px, bottom ~330px (caption/audio), left/right ~65px.
+**RULES:**
+- Algorithm rewards **rewatches/completion far above likes**; diversifies the feed; pushes longer content when completion holds.
+- **Search is a primary surface** — TikTok SEO is real (+20–40% visibility): put your keyword in three places — spoken in the first line (speech-to-text), bold on-screen text in first 2–3s (OCR), and caption first 100–150 chars.
+- **Photo Mode is the sleeper format** (~5× views, ~80% completion) — test it for how-to/list content.
+- Hook in first 3s; add captions (30%+ watch muted); use a trending sound (+52% views avg). 3–5 hashtags max (broad + niche). Cadence ~1×/day (min 3×/week).
+- Reach-killers: watermarked/reused imports, keyword-stuffing, 15+ hashtags, low-quality filler, driving users off-platform in-video.
+
+## 4. INSTAGRAM (REELS + CAROUSELS)
+**SPECS — Reels:** 9:16, 1080×1920, 30fps, H.264. Ideal <90s (15–90s sweet spot). Cover: design at 1080×1920 but keep key elements in center 1080×1080 (grid crop). Safe zones: clear top ~220px, bottom ~450px, ~35px sides.
+**SPECS — Carousels:** up to 20 slides, 8–10 optimal (under 5 underperforms). 4:5 (1080×1350) for max feed real estate, or 1:1. Can mix images + 1–2 video slides.
+**RULES:**
+- Top signals: **sends/DM shares (≈3–5× a like) and saves**, then watch time, then comments/likes. Explicitly ask "send this to someone who…" / "save for later."
+- **No blanket format preference** — IG shows Reels to video-watchers, carousels to photo-engagers. Reels = top-of-funnel reach & new audience; carousels = saves, depth, and mature/large accounts (carousels get a re-serve second impression using different cover slides — make slide 1 AND slide 2 strong).
+- Hashtags don't drive reach anymore — **keyword SEO** in caption/on-screen text/profile is the lever; 3–5 tags (search-only).
+- **Trial Reels** (1K+ followers): publish to non-followers only, get metrics in 24–72h, then share to followers — a low-risk A/B surface.
+- Original content gets 40–60% more distribution; 10+ reposts/month risks recommendation exclusion. Never post TikTok-watermarked files. Cadence 4–5/week; space posts out (dumping several triggers balancing).
+
+## 5. X / TWITTER
+**SPECS:** 280 chars free / 25,000 Premium (only first ~280 render before "Show more" — front-load the hook). Native video ≤2:20 free; 9:16 favored for the Video Tab, 1080×1920, MP4/H.264, ≤512MB, captions. Threads = chained 280-char posts.
+**RULES:**
+- Engagement weights (open-source-derived): **Reply ≈ 13.5–27× a Like, Repost ≈ 20×, Bookmark ≈ 10–12×, Quote ≈ 10×**, Like 1×. Negative: Report −369×, Block −74×, Mute −31×, **external link ≈ −8× / 50–90% reach cut**.
+- **Keep links OUT of the main post** — put the URL in a reply. Lead with a scroll-stopping first line. Prioritize replies/reposts; reply to your own comments in the first 15–30 min. First **15 minutes** decide virality (10+ early engagements amplifies; <3 kills it); visibility halves ~every 6h.
+- Post 3–5×/day, spaced. 0–1 hashtag (3+ trips spam filters; Grok reads the text now). Premium ≈ 2–4× reach.
+- Don't: engagement pods/bought engagement, delete-and-repost, AI-slop replies (downvotable as spam since Mar 2026).
+
+## 6. LINKEDIN
+**SPECS:** text ≤3,000 chars, sweet spot **800–1,600**; "see more" cutoff ≈ first ~150 chars mobile — put the hook there. **Document/PDF carousel (highest reach):** 5–10 slides, 1080×1080 or 1080×1350, one takeaway/slide, strong slide 1. Native video: **30–90s**, 1:1 or 9:16, captions mandatory. Newsletters bypass the feed (notify + email all subs, Google-indexed).
+**RULES:**
+- 360Brew (2026) distributes on an **interest graph**, not your social graph — a niche post from a small account can outreach a generic post from a big one. Keep a consistent narrow topic so it locks your "topic DNA."
+- Signals: **dwell time, saves, shares, comment-thread depth**. Dwell curve: 0–3s ≈1.2% eng → 31–60s = max distribution → 61+s ≈15.6% (a ~13× gap). Engineer dwell: question in first line (+32% comments), 3–4-line paragraphs, white space.
+- **Golden hour** (first 30–60 min) decides trajectory; reply to every comment within 60–120 min. Comments ≈ 2× likes.
+- **Links out of the post body** (~60% reach cut) — AND the link-in-first-comment workaround is now also penalized (early 2026); add the link after traction or in a follow-up.
+- Post 3–5×/week. Don't: engagement bait ("Agree? 👇"), polls (~0.07% eng, dead), pods/automation, editing after posting, "bro-etry," AI-slop.
+
+## 7. SUBSTACK
+**SPECS:** title/subject ≤100 chars, subtitle ≤250, body unlimited. Cover 1200×630 (also the OG/email-preview image). Video posts ≤1080p/4GB. Notes = short-form; best Notes are 1–3 punchy sentences.
+**RULES:**
+- Distribution now driven by **Notes + Recommendations network**, not just email. **Restacks are one of the single most important signals** — write Notes designed to be restacked (a strong standalone idea/mini-story/hot take), not bare links. Notes reach = audience overlap (shown to non-subscribers who overlap with you + adjacent pubs); restacks/replies/quotes >> likes.
+- Turn on **Recommendations** and recommend overlapping publications (reciprocity fuels growth — historically ~40% of subs came through the network). Grow the free list first; convert later (don't hard-paywall early).
+- "10-minute restack system": restack yesterday's post AM, a strong old Note midday, 1–2 niche writers PM. Substack pushes video/Live (auto-clips → YouTube Shorts). Post consistently.
+
+## 8. BLUESKY
+**SPECS:** post ≤300 chars (hard). Up to 4 images (4:5/16:9/1:1), use alt text. Video MP4/MOV, ≤~60s, <100MB. No native scheduling, **no editing after posting**. 2–3 hashtags.
+**RULES:**
+- No single central algo — users pin their own feeds. **Following feed = strictly chronological** (timing matters). **Discover feed** surfaces conversation momentum (recent replies, quotes, network proximity, recency) — posts that spark back-and-forth rise; passive likes don't.
+- Replies are distribution. Get into/create **Starter Packs** (up to ~150 accounts, network-proximity boost) and niche **custom feeds** (hashtags route posts there). Pin your best EVERGREEN post, not your newest.
+- Post 1–3×/day (<10k followers). Don't verbatim-cross-post from X/LinkedIn — it performs poorly. Mix ~60% educational/entertaining, 30% conversational, 10% promo.
+
+## 9. FACEBOOK GROUPS
+**SPECS:** ideal text post ≤20 words (question-led). Native video square 1:1, captions required, 3-sec hook. Facebook Live = highest-reach format. Polls punch above weight.
+**RULES:**
+- Groups reach **20–40% of members** (vs ~1.6–5.9% for Pages) — the highest-ROI free surface on FB. Members get direct notifications (~4× feed open rate).
+- **Engagement velocity is the top signal** — comments in the first 30–60 min multiply distribution; comments > reactions; shares-with-commentary rank highest. Engineer early comments with a direct pain-point question.
+- Content ranking: native/Live video > photos > links > text-only. Never post a bare YouTube link (links rank lowest) — upload native. Target engaged niche groups (~4.5k–18k members, ~42% higher engagement) over giant link-dump groups. Drip posts over the day; don't bulk-dump.
+- Don't: engagement bait ("Like if you agree"), duplicate/repetitive content, breaking group rules, late-night posting.
+
+---
+
+## 10. CROSS-PLATFORM REPURPOSING WATERFALL
+**Principle: stop cross-posting, start repurposing. "Film once, cut everywhere."** Identical files everywhere trip duplicate-detection (up to ~42% Reels reach cut for detected duplicates, ~72% if a TikTok watermark is visible). Deriving platform-native variants from one source does NOT.
+
+**Source-capture specs (shoot once, derive everything):** 4K (3840×2160) so you can crop 16:9 → 9:16 / 1:1 / 4:5 with room. 24/30fps (60 for slow-mo). Film 16:9 horizontal as master. **Center-safe composition:** frame subject + any text within the center ~80% (title-safe); keep top 10–15%, bottom 15–25%, right 10% clear for platform UI. Record a clean verbal hook in the first 3s; plan to swap in each platform's native trending audio.
+
+**The waterfall (one shoot → many assets):**
+1. YouTube long-form (16:9, 8–20min) — the anchor.
+2. Mid-form cutdowns (2–4) from distinct chapters → standalone YouTube/LinkedIn-native videos.
+3. Short-form clips (10–30) from best 15–60s moments → 9:16, burned-in captions, hook-first → Shorts/Reels/TikTok, each with a DIFFERENT intro frame + native audio + caption style + pacing.
+4. Carousel (1–3) from a framework/list → 4:5 or 1:1 → Instagram + LinkedIn.
+5. X thread from transcript hooks; attach a clip to the top post.
+6. LinkedIn post (one story/lesson), professional reframe.
+7. Substack/newsletter — chapter summaries + embeds (owned-audience layer).
+8. Bluesky/Threads — atomized one-liners.
+9. Facebook Group — a discussion-starter question + native clip.
+
+**RULES:**
+- Export a **clean master with NO watermark** before it ever touches TikTok; distribute that master downstream.
+- Give each short-form clip a unique first frame + native trending audio + caption styling — don't ship the same MP4 to all three (duplicate detection weights the first ~0.5s heavily).
+- Adapt the text container per platform: X = strong first line then media; LinkedIn = short-line mini-essay; IG caption front-loaded (truncates fast).
+- Upload native files per platform (scheduler or native app — both fine; schedulers do NOT penalize reach). **Stagger publishing 24–72h** and hit each platform's best time.
+- Tooling: Opus Clip (long→short at scale), Descript (transcript-based editing), CapCut (per-platform finishing), Repurpose.io (hands-off distribution), Metricool/Buffer/Later (native scheduling + trending-audio discovery).

--- a/Community/bangers/references/procedures/banger-carousels.md
+++ b/Community/bangers/references/procedures/banger-carousels.md
@@ -1,0 +1,34 @@
+# Banger Carousels — swipeable slide content that gets saved
+
+Carousels are the highest engagement-by-reach format on Instagram and a top-reach format on LinkedIn, and they earn SAVES (a heavily weighted signal). The craft: one idea per slide, a slide 1 that stops the scroll, and a last slide that earns the save/share.
+
+## Freshness gate
+
+Before applying a platform benchmark, algorithm claim, policy, feature-availability statement, or numeric performance claim from this skill or the platform playbook, check `references/research/source-ledger.md` for non-expired support. If support is missing or past its review date, run `references/procedures/banger-research.md`, qualify the claim as unverified, or omit it. Never present a legacy value as current truth.
+## Load first
+- `references/frameworks/writing-quality.md` for the living human-writing test and creator-specific constraints. Treat detector results as weak evidence.
+- `references/frameworks/voice-and-audience.md` (the creator's own defined audience — ask once if it isn't set) + `references/creators/matt-pocock.md` (one concept, example-first, make-the-invisible-visible).
+- `references/platforms/platform-playbook.md` §4 (Instagram carousels — 8–10 slides, 4:5 1080×1350, strong slide 1 AND 2 for the re-serve) and §6 (LinkedIn document carousels — 5–10 slides, PDF, 1080×1080 or 1080×1350).
+
+## Structure (the swipe arc)
+1. **Slide 1 — the hook.** A bold promise, curiosity gap, or contrarian line + minimal visual. This is the whole ballgame; it decides the swipe. (On Instagram, make slide 2 strong too — IG re-serves the carousel using different cover slides.)
+2. **Slides 2–(N-1) — one idea each.** One takeaway per slide, big readable text, an example or the actual thing shown (a screenshot of the real result, a before/after, a diagram). Keep momentum — each slide should pull to the next ("but here's the catch →").
+3. **Final slide — the payoff + CTA.** Recap the value in one line and explicitly ask for the save/share ("Save this for the next time you…", "Send to someone who needs it"). Optionally a soft follow CTA.
+
+## Design rules
+- **One idea per slide.** If a slide has two points, split it. 8–10 slides for IG, 5–10 for LinkedIn (engagement drops after ~10).
+- **Readable at a glance** — large type, high contrast, generous margins, consistent template. Keep key text centered/safe.
+- **Format:** Instagram 4:5 (1080×1350) images; LinkedIn export as a **PDF** document (1080×1080 or 1080×1350).
+- **Keyword-rich caption** (IG search is keyword-driven now, not hashtags) + 3–5 tags.
+
+## Building the file
+This skill produces the slide CONTENT and layout. To generate an actual deliverable:
+- For a polished slide deck / PDF carousel, use the **pptx** skill (read its SKILL.md) to build the slides, then export to PDF for LinkedIn. For visual theming/colors/fonts, the **theme-factory** skill can style it.
+- For image carousels, you can also produce a clean single-file HTML layout (one slide per section, correct aspect ratio) the user can screenshot/export, or hand a spec to their design tool (Canva/Figma).
+Always research/confirm the content FIRST, then read the format skill's SKILL.md before building (never anchor on document mechanics before the content is right).
+
+## Output format
+Deliver a **slide-by-slide script**: for each slide give the **headline text**, any **body/subtext**, and a **[visual: ...]** note (what to show/screenshot). Call out slide 1 (and IG slide 2) as the hook slides and the final slide as the save-CTA. Provide the post **caption** (keyword-front-loaded) + hashtags. Then, if the user wants the actual file, build it via the pptx skill and deliver with SendUserFile.
+
+## Quality bar
+Confirm slide 1 stops the scroll on its own, every slide holds exactly one idea, the deck is readable at thumbnail size, and the last slide gives a concrete reason to save/share.

--- a/Community/bangers/references/procedures/banger-detector.md
+++ b/Community/bangers/references/procedures/banger-detector.md
@@ -1,0 +1,167 @@
+# Banger Detector — authenticity verification and honest disclosure
+
+Read this whole section before running anything. Most requests that arrive
+here ask for the wrong outcome, and delivering it would make the writing
+worse.
+
+## What a detector score is, and is not
+
+AI text detectors mostly measure two statistical properties: **perplexity**
+(how predictable each next word is) and **burstiness** (how much sentence
+length and structure vary). Low perplexity and low burstiness read as machine
+generated.
+
+That is a proxy for a style, not evidence of authorship. The consequences are
+measured and severe:
+
+- Liang et al. (2023, *Patterns*) found detectors falsely flagged **61.3% of
+  essays by non-native English writers**, while classifying native-speaker
+  essays nearly perfectly. **97.8% of TOEFL essays** were flagged by at least
+  one detector.
+- In the same work, rewriting non-native essays with more elaborate
+  vocabulary dropped the false positive rate from 61.22% to 11.77%. The
+  detector was measuring vocabulary range, not authorship.
+- Technical, legal, and scientific writing is flagged for the same reason. A
+  field's papers reuse terminology and structure by necessity. Detectors read
+  that necessary uniformity as machine output.
+- Recent formal work argues the false positive problem is **structural**: any
+  text-only detector with real detection power must produce false accusations
+  against some human populations. Better engineering does not remove this.
+
+A detector cannot prove a human wrote something, and it cannot prove a machine
+did. Treat every score as weak adversarial evidence.
+
+## The trap specific to this suite
+
+`technical-clarity.md` deliberately produces short sentences, one name per
+concept, consistent structure, and plain vocabulary. That is **low perplexity
+and low burstiness by design**. Applying it correctly will often *raise* a
+draft's AI score while *improving* the writing.
+
+Never resolve that conflict by damaging clarity. If a piece is clear, sourced,
+and genuinely the author's, a high detector score is the detector being wrong.
+Record it and move on.
+
+## Step 1: verify authenticity, which is not a score
+
+These checks decide whether a draft is genuinely the author's. Run them first,
+and run them even when no detector is available.
+
+1. **Provenance.** Every number, quote, story, date, result, and named
+   specific traces to a real artifact: a file, commit, screenshot, measurement,
+   published post, or something the author said. Anything unsourceable gets
+   cut, not softened. This is the check that actually matters.
+2. **Judgment.** The piece makes a call that only this author would make, from
+   their own experience. Balanced summary with no position is the real tell.
+3. **Earned texture.** The concrete detail that could not be generated: the
+   exact error string, what it cost, the part that went wrong, the thing they
+   changed their mind about.
+4. **Real variation.** Sentence rhythm varies because the thinking varies, not
+   because variation was manufactured. Read it aloud.
+5. **Constraint compliance.** The creator profile's banned punctuation,
+   phrases, and tone rules are satisfied.
+6. **Say-it-out-loud.** Would the author speak this line to a peer? Rewrite
+   any line they would not.
+
+A draft that passes all six is authentic regardless of what any detector says.
+
+## Step 2: decide whether to run a detector at all
+
+Read `detector_mode` from the creator profile.
+
+- `off` — do not run one.
+- `requested` — run only when the author asks.
+- `panel` — run for outward-facing prose when detector access exists. If
+  access does not exist, record `not run`. Never imply a run happened.
+
+Skip detectors entirely for private drafts, internal docs, and anything the
+author is not publishing under their name.
+
+## Step 3: run the panel
+
+- Use at least two independent, currently accessible services. One score is
+  noise.
+- Never paste private, unpublished, or client-confidential drafts into a
+  third-party detector. That is a disclosure of the author's material to an
+  outside service. Ask first, every time.
+- Record each run in `references/research/detector-runs.md`: date, input
+  identifier or hash, service and version, result, highlighted passage
+  locator, the mapped writing defect, the revision, and the rerun result.
+- Use only scrubbed samples in a public ledger. Private drafts go in a private
+  overlay.
+
+## Step 4: map highlights to real defects, or stop
+
+A score never triggers a rewrite. For each highlighted passage, ask whether it
+maps to a genuine defect from `writing-quality.md`:
+
+- generic opening, empty transition, or ornamental conclusion,
+- unsourced claim or vague authority,
+- stacked triads, symmetric paragraphs, or forced parallelism,
+- hedging or breathless certainty,
+- vocabulary the author never uses.
+
+Revise only those. Rerun once. **Stop after two detector-led passes**, whatever
+the score says. Truth, clarity, rhythm, and authentic voice outrank every
+score.
+
+## Forbidden moves
+
+These damage the work and the author's credibility:
+
+- Inserting typos, grammatical errors, or awkward phrasing to look human.
+- Running the draft through a "humanizer" tool.
+- Padding with filler or synonym rotation to raise perplexity. That
+  reintroduces exactly what the suite removes.
+- Altering a true, clear, author-authentic passage only to move a number.
+- Presenting a detector score as proof of authorship, in either direction.
+- Publishing a claim that content "passes AI detection" as a feature. It is
+  unverifiable, it varies by service and by week, and it invites an easy
+  public rebuttal.
+
+## Step 5: disclosure
+
+Being open about AI assistance is a stronger position than any score, and it
+is the only one that survives scrutiny.
+
+**The principle:** disclose the process honestly, and be specific about what
+the tool did and what the human did. Readers do not object to tool use. They
+object to being misled about whose thinking they are reading.
+
+**What an honest disclosure covers:**
+
+- The opinions, judgments, and conclusions are the author's.
+- Every factual specific was verified by the author against a real artifact.
+- The author takes responsibility for errors.
+- Where the tool genuinely helped: drafting, structuring, editing, research
+  assistance, checking prose against a written standard.
+
+**What to avoid:**
+
+- Claiming "100% human written" when a tool was used. One screenshot ends
+  that.
+- A blanket AI disclaimer stapled to everything, which reads as legal cover
+  rather than honesty.
+- Overclaiming the reverse, implying the tool did the thinking when the author
+  did.
+- Making the disclosure the subject of the piece when it is a footnote.
+
+**Placement:** one plain line, where a reader would want it. In a byline, an
+author's note, a repository README, or an about page. Not in every paragraph.
+
+Draft the disclosure in the author's voice, offer it, and let the author
+choose the wording. Never publish a disclosure the author has not approved.
+
+## Output format
+
+Report, in this order:
+
+1. The six authenticity checks, pass or fail, with the failures named.
+2. Detector runs: service, date, result, or `not run` with the reason.
+3. Highlighted passages that mapped to a real defect, and the revision made.
+4. Highlighted passages dismissed, and why.
+5. The proposed disclosure line, if the piece needs one.
+6. What still needs the author's approval.
+
+Never report a score without the authenticity result beside it. The score is
+the weaker signal and must never be presented as the headline.

--- a/Community/bangers/references/procedures/banger-edit.md
+++ b/Community/bangers/references/procedures/banger-edit.md
@@ -1,0 +1,39 @@
+# Banger Edit — edit sheets, captions & markers for any editor (+ OBS recording)
+
+This skill turns a script or a raw recording into the assets an editor actually needs: a cut plan, caption files, markers, and overlay cues — usable in **DaVinci Resolve, Adobe Premiere, CapCut, or Descript**, with **OBS** for recording. It produces text/files the user imports; it doesn't run the NLE. Ask (or infer from context) which editor the user works in, and tailor the import notes to it.
+
+## Freshness gate
+
+Before applying a platform benchmark, algorithm claim, policy, feature-availability statement, or numeric performance claim from this skill or the platform playbook, check `references/research/source-ledger.md` for non-expired support. If support is missing or past its review date, run `references/procedures/banger-research.md`, qualify the claim as unverified, or omit it. Never present a legacy value as current truth.
+## Load first
+- `references/frameworks/writing-quality.md` for captions, overlays, title cards, and any corrected transcript text.
+
+- `references/creators/fireship.md` (the editing DNA: zero dead air, visual change every 1–5s, reveal step-by-step, pointer on the live element, cheap assets + precise timing) + `references/creators/primeagen.md` (clip the emotional spikes).
+- `references/platforms/platform-playbook.md` (specs + safe zones for the target platform; §10 for the film-once-cut-everywhere reframe rules).
+
+## What this skill can produce
+1. **Cut sheet / Edit Decision List (human-readable).** A timestamped table: `In–Out · what happens · cut type (jump cut / J-cut) · [B-roll or screen-capture] · [on-screen text] · [SFX/zoom/punch-in] · note`. Works in any editor — the user executes it on their timeline. Enforce Fireship discipline: razor out every pause/um (zero dead air), a visual change every 1–5s, jump-cut the talking head, an arrow/pointer on whatever is being discussed. (Descript users can execute much of the cut by deleting the same lines in the transcript — note the transcript lines to delete alongside the timecodes.)
+2. **Caption assets.** Either a **burned-in caption script** (line-by-line on-screen text with timings, for short-form watched muted) or a proper **.srt subtitle file**. Import steps per tool:
+   - **Resolve:** Timeline → Import Subtitle, drop onto a subtitle track.
+   - **Premiere:** File → Import the .srt, drag to the Captions track (or Text panel → Captions → import).
+   - **CapCut / Descript:** auto-caption first, then correct the text against the provided caption script (their auto-captions are the fast path; your script is the accuracy pass).
+   - **YouTube:** upload the .srt directly in Studio for closed captions.
+   Keep caption text inside the platform safe zone.
+3. **Marker / chapter CSV.** A CSV of timeline markers (name, timecode, color, note) to drop chapter points, clip-worthy moments, and B-roll spots — also usable to plan Shorts cutdowns. Resolve imports marker CSVs directly (use its expected columns); Premiere users can add the markers from the sheet manually or via extensions; CapCut/Descript users treat it as a working checklist while cutting. Always usable as YouTube chapter text for the description.
+4. **Vertical reframe plan.** For repurposing 16:9 → 9:16: which subject/region to keep centered per shot, where captions/CTA sit clear of platform UI, and where the editor's reframe/tracking should follow (Resolve: reframe/tracking; Premiere: Auto Reframe; CapCut: aspect ratio + auto-reframe; Descript: layout templates). Reference the safe-zone px in the platform playbook.
+5. **OBS recording setup.** Scene list (talking-head, screen-capture, overlay), source layout, canvas/output resolution + fps for the target platform (e.g. 1920×1080/30 for long-form, or a 1080×1920 vertical canvas), a mic/levels reminder ("low quality audio is the fastest way to drop a viewer"), and a pre-record checklist (framing in the center-safe zone, hook ready, hotkeys for scene switches).
+
+## Producing files
+When the user wants an actual file, write it to disk and deliver with SendUserFile (and, if they want it on their machine, commit it to their connected folder):
+- **.srt** — standard SubRip blocks (index, `HH:MM:SS,mmm --> HH:MM:SS,mmm`, text). Imports into Resolve, Premiere, CapCut, and Descript, and uploads to YouTube.
+- **Marker .csv** — include a header row and clear timecodes; use Resolve's expected columns if the user is in Resolve, otherwise a clean generic `name,timecode,color,note` layout (or an EDL-style list).
+Ask for the frame rate if timecodes matter and it wasn't given (24/30/60), since marker/subtitle timing depends on it.
+
+## Method
+1. Get the input: a script (plan the edit forward) or a transcript/raw recording description (plan the cut backward). Ask for length, target platform(s), which editor they use, and fps if needed.
+2. Choose the deliverable(s) from the list above based on the ask.
+3. Apply the density/energy rules; mark the clippable spikes for Shorts.
+4. Output the sheet(s) + any files; note exactly how to import each into the user's editor and OBS.
+
+## Quality bar
+Confirm: no dead air survives, a visual beat lands every 1–5s, captions stay inside the safe zone, marker/subtitle timecodes match the stated fps, the import steps match the user's actual editor, and the clip-worthy moments are flagged for repurposing.

--- a/Community/bangers/references/procedures/banger-explainer.md
+++ b/Community/bangers/references/procedures/banger-explainer.md
@@ -1,0 +1,120 @@
+# Banger Explainer — teaching content that survives being shared
+
+Teaching content fails in two directions. Too much voice and the reader
+enjoys it but cannot repeat it. Too much specification and it reads like
+documentation nobody shares. This procedure assigns each register to the part
+of the piece it is actually good at.
+
+## Load first
+
+- `references/frameworks/voice-and-audience.md` — the
+  audience profile and the creator's hard constraints.
+- `references/frameworks/technical-clarity.md` — the
+  frame/payload split and the payload discipline. Core reference here.
+- `references/frameworks/writing-quality.md` — the
+  living gate, run before delivery.
+- The target platform section of
+  `references/platforms/platform-playbook.md`.
+
+## Freshness gate
+
+Before using any platform benchmark, algorithm claim, or numeric performance
+claim from this skill or the playbook, check
+`references/research/source-ledger.md` for non-expired support. If support is
+missing or past review, run `references/procedures/banger-research.md`, label the claim unverified, or
+omit it.
+
+## Step 1: name the mechanism
+
+Write one sentence, for yourself, not the reader: **what does the reader
+understand after this that they did not before?** One mechanism per piece. If
+it takes two sentences, it is two pieces.
+
+Then name the wrong model the reader probably holds right now. Strong
+technical content replaces a wrong model rather than filling an empty one.
+That wrong model is usually the hook.
+
+## Step 2: check the proof
+
+Before drafting, name:
+
+- the artifact (repository, file, commit, screenshot, error text, benchmark),
+- what actually happened, including the part that failed,
+- what has not been tested, stated plainly.
+
+If there is no artifact, this is an opinion piece, not an explainer. Route to
+`references/procedures/banger-threads.md` or `references/procedures/banger-longform-written.md` and say so.
+
+## Step 3: set the explanation depth
+
+Use the audience profile from `voice-and-audience.md`. The prime directive
+governs: match vocabulary to the audience's actual sophistication.
+
+- **Non-expert audience** — define every primitive in the same breath, with a
+  plain analogy. Show the exact screen, prompt, and result. Payload gets
+  longer, steps get smaller. Never talk down.
+- **Practitioner audience** — insider shorthand is free, and over-explaining
+  burns their time. Spend the space on tradeoffs, failure modes, and what you
+  would do differently.
+
+## Step 4: draft with the split
+
+**Frame (author voice, not the clarity rules):**
+
+- A hook that names the specific wrong model or the specific pain, not the
+  category.
+- The story: what you were doing, what broke, what it cost.
+- The judgment: what you now think, and how confident you are.
+- The call to action native to the platform.
+
+**Payload (technical clarity):**
+
+- One name per concept, held for the whole piece.
+- One idea per sentence, roughly 25 words, steps closer to 20.
+- Active voice with a named actor: "the parser reads the file".
+- Verbs, not nominalizations. Numbers shown, not quality claimed.
+- Concrete artifacts: real commands, real errors, real paths.
+
+Keep contractions, asides, humor, and opinion inside the payload where they
+carry weight. Discipline is not the same as flattening.
+
+## Step 5: platform shape
+
+- **X or Bluesky thread** — one mechanism step per post. Frame is post one and
+  the last post. Payload posts carry a code block or screenshot where
+  possible. Never longer than the mechanism requires.
+- **LinkedIn** — hook in the first 150 characters, wrong-model framing, then
+  three or four payload beats in short paragraphs. End on the judgment plus a
+  question. No links in the body.
+- **Newsletter or Substack** — a header per mechanism step, a diagram or code
+  block per step, pull-quote the judgment. Provide standalone Notes drawn from
+  the payload, not the frame.
+- **Video description or docs-style post** — payload dominates, frame shrinks
+  to two lines.
+- **Facebook group** — do not use this procedure. Route to
+  `references/procedures/banger-longform-written.md`, question-led and short.
+
+## Step 6: verify before delivering
+
+Run the `writing-quality.md` gate, then these:
+
+1. Could a reader repeat the mechanism with the post closed?
+2. Is every concept called exactly one name?
+3. Did anything claim quality instead of showing it?
+4. Does the frame still sound like the author said it out loud?
+5. Is every number, quote, and result traceable to a real artifact?
+6. Are the creator's hard constraints (banned punctuation, phrases, tone)
+   satisfied?
+
+## Output format
+
+Lead with the finished asset, ready to paste, formatted for the platform.
+Then:
+
+- the mechanism sentence and the wrong model it replaces,
+- the artifact each claim traces to,
+- anything labeled unverified,
+- the approval needed next.
+
+Drafting is free. Publishing, scheduling, and outreach need the creator's
+explicit per-item approval.

--- a/Community/bangers/references/procedures/banger-hooks.md
+++ b/Community/bangers/references/procedures/banger-hooks.md
@@ -1,0 +1,35 @@
+# Banger Hooks — packaging that earns the click and the first 3 seconds
+
+Packaging is a separate craft from the content, and it usually decides whether the content is seen at all (Theo: "obsess over whether the packaging makes it worth clicking"). A hook's only job is to buy the next 3 seconds. A title/thumbnail's only job is to earn the click — honestly.
+
+## Freshness gate
+
+Before applying a platform benchmark, algorithm claim, policy, feature-availability statement, or numeric performance claim from this skill or the platform playbook, check `references/research/source-ledger.md` for non-expired support. If support is missing or past its review date, run `references/procedures/banger-research.md`, qualify the claim as unverified, or omit it. Never present a legacy value as current truth.
+## Load the swipe file first
+Read `references/frameworks/hooks-bank.md` (the hook engines, fill-in templates, title patterns, thumbnail rules) and `references/frameworks/voice-and-audience.md` (the creator's own defined audience and voice — ask once if it isn't set — so hooks invite that audience instead of intimidating them). For platform-specific opening rules (what "the first 3 seconds" means per surface), see `references/platforms/platform-playbook.md`.
+
+## Method
+1. **Know the payoff first.** You can't hook honestly without knowing what the content delivers. If the user hasn't told you, ask what the one takeaway is.
+2. **Pick a hook engine** (curiosity gap / specific promise / contrarian / stakes / reaction / relatable pain / result-first). Choose the one the content can actually pay off.
+3. **Make it specific.** Swap vague nouns for a named tool, a number, a concrete outcome — whatever your niche's version is. "This can help you" → "This free tool writes a week of emails in 90 seconds" / "This one stretch fixes desk-job back pain in 5 minutes a day."
+4. **Generate options, not one.** Give 5–10 hook variants so the user can pick the voice that fits. Vary the engine across them.
+5. **Never write clickbait you can't pay off.** The payoff must deliver — reach dies on the hook/retention mismatch check (YouTube, TikTok, IG all penalize it).
+
+## Titles (for YouTube / long-form)
+Combine the exact searched term + a finite promise or emotion (number, time box, or verdict). Front-load the payoff; ~70 chars. Offer 5–8 title options ranging from safe to spicy. Patterns and rules are in the hook bank ("[Thing] in 100 Seconds", "I tried N... so you don't have to", "The truth about ___", reaction titles, etc.).
+
+## Thumbnails
+Describe a concept the user can actually make in whatever design tool they use (Canva, Figma, Photoshop, their video editor's title tool). Rules that matter most:
+- 1–3 words MAX, big, high-contrast; the thumbnail must NOT repeat the title (it's a SECOND hook).
+- If a face is used, describe the emotion to perform. Every thumbnail poses an implicit question (good/bad? worth it?).
+- Keep key elements centered (survives cropping). Plan the thumbnail BEFORE the content is finalized so the promised moment actually exists.
+Give 2–3 distinct thumbnail directions with the exact words + the visual + why it works.
+
+## Output format
+Group as: **Hooks** (5–10 options, labeled by engine) · **Titles** (5–8 options) · **Thumbnail concepts** (2–3 directions). End by recommending one hook + one title + one thumbnail as your top pairing, and note that the title and thumbnail should NOT say the same thing. If the piece is going to multiple platforms, remind the user each surface needs its own opening (hand to `references/procedures/banger-repurpose.md`).
+
+## Living writing gate
+
+Read `references/frameworks/writing-quality.md` before drafting. Apply creator-specific constraints and treat detector results as weak evidence.
+## Quality bar
+Every hook must pass the hook checklist in the swipe file: works in the first 3 seconds/line alone, one clear reason to continue, specific not vague, actually paid off by the content, and inviting (not intimidating) to the audience.

--- a/Community/bangers/references/procedures/banger-ideas.md
+++ b/Community/bangers/references/procedures/banger-ideas.md
@@ -1,0 +1,41 @@
+# Banger Ideas — the "what should I make" engine
+
+Your job: turn a vague creator into a list of specific, high-potential content ideas they can actually shoot, each with a hook and a home platform. Ideas are cheap; GOOD ideas that ride existing attention and teach one real thing are the whole game.
+
+## Freshness gate
+
+Before applying a platform benchmark, algorithm claim, policy, feature-availability statement, or numeric performance claim from this skill or the platform playbook, check `references/research/source-ledger.md` for non-expired support. If support is missing or past its review date, run `references/procedures/banger-research.md`, qualify the claim as unverified, or omit it. Never present a legacy value as current truth.
+## Before anything: load the playbooks
+Read these once at the start of a session so every idea inherits the right instincts:
+- `references/frameworks/voice-and-audience.md` — WHO the creator's audience is and how to talk to them. This file holds the creator's OWN defined niche and audience, and it is the filter for every idea.
+- `references/creators/_synthesis.md` — the shared laws (ride existing heat, one thing densely, have a verdict).
+If the audience/niche isn't defined there and the user hasn't stated it, ask ONE quick question ("who is this for, and what's your niche?") before generating, then adapt everything to that answer.
+
+## The idea-generation method
+1. **Anchor to the audience's real problems and desires.** List the handful of things YOUR audience actually wants — e.g. (depends on your niche): saving time, making money, looking competent at work, doing a specific real-life task (a tech niche: emails, resumes, spreadsheets); losing fat without giving up meals they love (fitness); paying off a card faster (finance); getting dinner done in 20 minutes (cooking); landing the first client (freelancing). Every idea should map to one of these audience payoffs.
+2. **Ride something already moving** (Fireship/Theo/Prime rule). Prefer topics with existing attention in the creator's niche: a new tool, product, or feature this week, a viral demo or moment, a question everyone's asking, a common misconception. If the user has a source (an article, a tweet, a news item), react to it — the skeleton removes the blank-page problem.
+3. **Force specificity.** "[Broad topic] tips" is not an idea. "The one [named tool/technique] setting that [concrete outcome]" is — e.g. "The one ChatGPT setting that remembers everything about you" or "The $12 pantry staple that replaces three sauces." Every idea must name a concrete tool, task, number, or outcome.
+4. **Attach a hook and a verdict.** Each idea needs an opening line that buys 3 seconds and a point of view (what you'll actually tell them to do/think). No verdict = no idea.
+5. **Assign a home platform + format** based on the idea's shape (a quick trick → Short/Reel/TikTok; a comparison or list → carousel; a reaction/opinion → long-form or X; a step-by-step → long-form + Short cutdowns). See `references/platforms/platform-playbook.md` if unsure.
+
+## Idea archetypes that reliably work (mix these)
+- **The one-trick reveal** — a single surprising thing one tool does (Pocock's one-concept move).
+- **The "I tried N so you don't have to"** verdict roundup.
+- **The honest reaction** to a new/ hyped thing — is it worth it for YOUR audience?
+- **The before/after** — "you're doing X the hard way; here's the 30-second version."
+- **The real-time build/do** — watch me accomplish a real task, live (a build, a workout, a recipe, a trade, a setup).
+- **The myth-bust** — a confidently-held wrong belief, corrected.
+- **The list with density** — N tools/tricks/mistakes, fast (Fireship style).
+
+## Output format
+Deliver a numbered table (or list) of 8–15 ideas unless the user asks for a specific count. For each idea give:
+`Idea (specific) · Hook (the opening line) · Angle/verdict (the point) · Platform + format · Why now (the heat it rides)`.
+Then flag your top 3 picks with one sentence on why they're the strongest bets.
+
+If the user wants a **content calendar**, group the ideas across the week/month, balance evergreen vs trend-jacked (Fireship's two-track), and respect each platform's cadence from the platform playbook (e.g. YouTube ~1–2/week, Shorts/TikTok ~daily, LinkedIn 3–5/week). Note that one strong source idea should be repurposed across platforms rather than inventing separate ideas for each — hand off to `references/procedures/banger-repurpose.md` for the waterfall.
+
+## Living writing gate
+
+Read `references/frameworks/writing-quality.md` before drafting. Apply creator-specific constraints and treat detector results as weak evidence.
+## Quality bar
+Before presenting, cut any idea that: is vague, has no clear audience payoff, rides no attention and isn't evergreen-fundamental, or that the intended audience would find intimidating or irrelevant. A short list of specific bangers beats a long list of mush.

--- a/Community/bangers/references/procedures/banger-longform-written.md
+++ b/Community/bangers/references/procedures/banger-longform-written.md
@@ -1,0 +1,37 @@
+# Banger Long-Form Written — LinkedIn, Substack & Facebook Group posts
+
+Each of these platforms rewards something different: LinkedIn rewards dwell time + saves/shares on a narrow topic; Substack rewards restack-worthy standalone ideas + a consistent owned-audience relationship; Facebook Groups reward early comments and native, un-linked content. Write to the surface.
+
+## Freshness gate
+
+Before applying a platform benchmark, algorithm claim, policy, feature-availability statement, or numeric performance claim from this skill or the platform playbook, check `references/research/source-ledger.md` for non-expired support. If support is missing or past its review date, run `references/procedures/banger-research.md`, qualify the claim as unverified, or omit it. Never present a legacy value as current truth.
+## Load first
+- `references/frameworks/voice-and-audience.md` (the creator's own defined audience — ask once if it isn't set) + `references/creators/matt-pocock.md` (one clear idea, warm/low-ego, cast the reader as capable) + `references/creators/_synthesis.md`.
+- `references/platforms/platform-playbook.md` §6 (LinkedIn), §7 (Substack), §9 (Facebook Groups). Confirm the target platform — the rules diverge sharply.
+
+## LinkedIn post
+- **Hook in the first ~150 chars** (that's all that shows before "see more"); open with a question or a contrarian/data line (a question in line 1 lifts comments ~32%).
+- **Engineer dwell time** — short 3–4-line paragraphs, white space, one narrow idea, a story or concrete example. 800–1,600 chars is the sweet spot.
+- **Win the golden hour** — end with a specific question; plan to reply to every comment in the first 60–120 min.
+- **No links in the body** (~60% reach cut) — and the link-in-first-comment trick is now penalized too; tell the user to add any link after the post gains traction, or in a DM/follow-up.
+- Optimize the CTA toward **saves and shares** ("save this for the next time you…"). 0–3 niche hashtags, optional. Keep to a consistent topic so the interest-graph model locks your "topic DNA."
+
+## Substack newsletter issue
+- **Subject line ≤100 chars, front-load the value** (specific/curiosity beats clickbait) — it's the email subject AND the Notes title.
+- Structure: a strong opening that earns the open, one core idea developed with headers/pull-quotes/white space, a clear takeaway, and a light CTA (reply, restack, share). Suggest a 1200×630 cover concept.
+- **Design for restacks** — pull out 1–3 standalone lines/ideas that work as Notes (the restack is now a top distribution signal). Provide those Notes.
+- Don't hard-paywall early; grow the free list. Recommend turning on Recommendations.
+
+## Facebook Group post
+- **Short and question-led** (≤~20 words gets ~40% more engagement). Open with a pain-point question that triggers early comments (comments in the first 30–60 min multiply reach).
+- **Native only** — never a bare external link (links rank lowest); if there's a video, upload it natively with captions and a 3-sec hook. Consider a poll.
+- Warm, community tone; reply fast to every comment.
+
+## Output format
+Deliver the finished post ready to paste, formatted for the target platform (line breaks and all). Include: the hook line called out, a note on where any link goes, the suggested first-comment/reply to seed the golden hour, and (Substack) the pull-out Notes + cover concept. If the user drafts these as themselves and a `my-writing-style` profile exists, draft from it; if they then correct the voice, offer once to save the change to their profile.
+
+## Living writing gate
+
+Read `references/frameworks/writing-quality.md` before drafting. Apply creator-specific constraints and treat detector results as weak evidence.
+## Quality bar
+Confirm the hook lands in the visible-before-cutoff zone, the post holds ONE idea, links are placed correctly for the platform, and there's a concrete reason to comment/restack/share.

--- a/Community/bangers/references/procedures/banger-repurpose.md
+++ b/Community/bangers/references/procedures/banger-repurpose.md
@@ -1,0 +1,41 @@
+# Banger Repurpose — one idea → a whole platform package (the waterfall)
+
+The 2025–2026 rule is: **stop cross-posting, start repurposing.** The same file everywhere trips duplicate-detection and throttles reach (up to ~42% Reels cut for duplicates, ~72% with a visible watermark). Deriving platform-native variants from one source does not. This skill is the orchestrator: it takes one source asset and produces a tailored package for every platform the user wants, delegating to the other BANGERS skills.
+
+## Freshness gate
+
+Before applying a platform benchmark, algorithm claim, policy, feature-availability statement, or numeric performance claim from this skill or the platform playbook, check `references/research/source-ledger.md` for non-expired support. If support is missing or past its review date, run `references/procedures/banger-research.md`, qualify the claim as unverified, or omit it. Never present a legacy value as current truth.
+## Load first
+- `references/platforms/platform-playbook.md` §10 (the waterfall + native-vs-cross-post rules) and the per-platform sections for whichever targets are chosen.
+- `references/creators/_synthesis.md` (produce one rich source, then atomize) + `references/frameworks/voice-and-audience.md` (the creator's own defined audience — ask once if it isn't set).
+
+## Step 1 — identify the source and the core idea
+Take whatever the user has (a long video, transcript, script, stream/podcast, article, or even a single idea) and extract: the ONE core idea, the 3–8 strongest self-contained moments/points, and any framework/list inside it. If there's no source yet, hand back to `references/procedures/banger-ideas.md` to pick one, or `references/procedures/banger-script-longform.md` to make the anchor first.
+
+## Step 2 — confirm the target platforms & effort
+Ask (or infer) which platforms to hit and how deep. Default full waterfall = the anchor + short-form clips + a carousel + text posts. Don't silently drop platforms — list what you're producing.
+
+## Step 3 — run the waterfall (delegate to the sibling skills)
+Produce, from the one source:
+1. **Anchor** — the long-form piece (YouTube). If it doesn't exist yet → `references/procedures/banger-script-longform.md`.
+2. **Short-form clips (many)** — pick the best 15–60s moments → `references/procedures/banger-script-shorts.md`, one hook + caption + native-sound note PER platform (Shorts / TikTok / Reels), each with a DIFFERENT first frame (duplicate detection weights the first ~0.5s).
+3. **Carousel** — a framework/list from the source → `references/procedures/banger-carousels.md` (Instagram 4:5 + LinkedIn PDF).
+4. **X thread** + **Bluesky** posts → `references/procedures/banger-threads.md`.
+5. **LinkedIn post**, **Substack issue (+ pull-out Notes)**, **Facebook Group post** → `references/procedures/banger-longform-written.md`.
+6. **Edit assets** for the clips (reframe plan, captions/SRT, markers) → `references/procedures/banger-edit.md`.
+7. **Packaging** for each surface (hooks/titles/thumbnails) → `references/procedures/banger-hooks.md`.
+
+## Step 4 — enforce the native rules (critical)
+- Export a **clean master with NO watermark** before it touches TikTok; distribute that downstream.
+- Give each clip its own **first frame + native trending audio + caption style** — never the same MP4 everywhere.
+- **Adapt the text container per platform** (X = strong first line + media; LinkedIn = short-line mini-essay; IG caption front-loaded; Bluesky = conversational reframe, not a verbatim copy).
+- **Stagger publishing 24–72h**, hit each platform's best time, upload native files (schedulers are fine).
+
+## Output format
+Deliver an organized package, grouped by platform, each with the ready-to-use asset (script/post/caption) + its specs + posting note. Lead with a short **repurposing map** (source → this many clips + these posts) so the user sees the whole plan at a glance. Flag anything that still needs the user (footage to shoot, a screenshot to grab). If the package is large, offer to write each platform's assets to files and deliver them.
+
+## Living writing gate
+
+Read `references/frameworks/writing-quality.md` before drafting. Apply creator-specific constraints and treat detector results as weak evidence.
+## Quality bar
+Confirm every platform variant is genuinely native (own hook/first-frame/audio/text container), the watermark rule is stated, publishing is staggered, and nothing is a lazy identical cross-post.

--- a/Community/bangers/references/procedures/banger-research.md
+++ b/Community/bangers/references/procedures/banger-research.md
@@ -1,0 +1,29 @@
+# Banger Research
+
+Use this before changing a playbook, making a current platform claim, adding a new creator mechanic, or relying on a platform claim whose source-ledger entry is missing or past its review date.
+
+## Load first
+
+- `references/research/creator-research-protocol.md`
+- `references/research/source-ledger.md`
+- `references/creators/_synthesis.md`
+- The relevant creator, platform, or framework file.
+
+## Procedure
+
+1. State the research question and what decision it may change.
+2. Collect recent primary examples from the creator or platform plus authoritative platform documentation when available.
+3. Record each source with date observed, publication date, URL or stable locator, claim, and confidence.
+4. Separate observation from interpretation.
+5. Find a repeated pattern across at least three examples, or label the finding experimental.
+6. Express the reusable mechanic without copying phrases, jokes, story details, or identity markers.
+7. Test it on one real source artifact and compare it with the current method.
+8. Propose a bounded playbook edit with evidence for and against it.
+
+## Output
+
+Return a research brief with: question, source ledger additions, observations, candidate mechanic, counterexamples, test result, confidence, affected files, and whether the evidence supports adopt, experiment, or reject.
+
+## Quality bar
+
+No undated platform claims. No rule based on one successful post. No imitation voice. No playbook edit without a clear behavior it improves.

--- a/Community/bangers/references/procedures/banger-script-longform.md
+++ b/Community/bangers/references/procedures/banger-script-longform.md
@@ -1,0 +1,41 @@
+# Banger Long-Form Script — retention-engineered video scripts
+
+Deliver a complete, ready-to-record script: hook, body beats, spoken narration, visual/B-roll cues, and a sign-off — structured so people actually keep watching. YouTube now ranks on satisfaction and session contribution, not raw minutes, so every section must earn the next.
+
+## Freshness gate
+
+Before applying a platform benchmark, algorithm claim, policy, feature-availability statement, or numeric performance claim from this skill or the platform playbook, check `references/research/source-ledger.md` for non-expired support. If support is missing or past its review date, run `references/procedures/banger-research.md`, qualify the claim as unverified, or omit it. Never present a legacy value as current truth.
+## Load first
+- `references/creators/_synthesis.md` and `references/frameworks/voice-and-audience.md` — the shared laws + the creator's own defined audience and voice (ask once if it isn't set).
+- Match the format to the video type:
+  - **Explainer / tutorial / "X in 100 seconds" style** → `references/creators/fireship.md` (density, definition-first hook, the 100-seconds skeleton) + `references/creators/matt-pocock.md` (one concept, show-don't-tell, scaffolding).
+  - **Reaction / news / opinion** → `references/creators/theo.md` (react + value-add + verdict) + `references/creators/primeagen.md` (read-a-beat-then-riff, energy, spikes).
+- `references/platforms/platform-playbook.md` §1 (YouTube long-form specs, retention benchmarks, CTR/mismatch rules, chapters).
+
+## The universal structure (adapt beats to the video type)
+1. **Cold-open hook (first 15–30s, NO intro).** First words = the payoff or the stakes. No "hey guys," no channel bumper, no "in this video." Lead with the promise, the result, or the spiciest framing. Open a loop the video will close. (Leading with the key insight instead of an intro raises past-30s retention 15–20 pts.)
+2. **The promise / stakes.** In one or two lines, tell them exactly what they'll be able to do or understand by the end, and why it matters to them.
+3. **Body beats.** Break the substance into 3–6 clearly-scoped beats. Each beat teaches ONE thing (Pocock), shows the actual thing on screen (the demo, the result, a before/after), and adds no filler (Fireship — every sentence adds info or a laugh). For reaction videos, each beat = read/show a piece of the source, then riff + add insider context + land a verdict.
+4. **Re-hooks / open loops.** Every ~60–90s, plant a reason to keep watching ("but there's a catch," "the third one surprised me"). Manage tangents: indulge for personality, then explicitly snap back.
+5. **The payoff / verdict.** Deliver on the promise. Give the clear takeaway — what to actually do or think. Have a spine.
+6. **One-line sign-off + soft CTA.** No begging outro. One flat, on-brand line. If asking for anything, ask for a comment (comments outrank likes now) with a specific prompt question.
+
+## Writing rules
+- **Write the way it's spoken** — short sentences, contractions, "you," conversational rhythm. Read it aloud in your head; cut anything that doesn't add information or a laugh.
+- **Density = no wasted words, not more concepts.** Keep the pace tight, and pitch to your audience's expertise level (if your audience are non-experts, don't skip the fundamentals they need; if they're experts, you can move faster).
+- **Show, don't tell** — for every claim, cue the on-screen proof.
+- **One point of view.** Reaction/opinion pieces must reach a verdict; explainers must leave the viewer able to DO one new thing.
+- **Put the joke ON the informative sentence**, not in a separate bit (Fireship). Deadpan > forced.
+
+## Output format
+Produce the script as a two-column-style layout in prose: for each section, a heading with an approximate timestamp, the **NARRATION** (verbatim, ready to read), and **[VISUAL: ...]** cues (B-roll, on-screen text, the thing to show, meme/graphic beats every few seconds). Include:
+- A title + thumbnail suggestion at the top (or hand to `references/procedures/banger-hooks.md`).
+- Suggested **chapters** (≥3, first at 00:00) for the description.
+- A one-line note on which moments will make the best Short cutdowns (hand to `references/procedures/banger-script-shorts.md` / `references/procedures/banger-repurpose.md`).
+- Target length + estimated word count (~150 words/min narrated).
+
+## Living writing gate
+
+Read `references/frameworks/writing-quality.md` before drafting. Apply creator-specific constraints and treat detector results as weak evidence.
+## Quality bar
+Check against the retention benchmarks in the platform playbook for the target length, confirm the hook contains no intro/filler, confirm every beat teaches or reveals one clear thing, and confirm the video pays off its opening promise (no clickbait debt).

--- a/Community/bangers/references/procedures/banger-script-shorts.md
+++ b/Community/bangers/references/procedures/banger-script-shorts.md
@@ -1,0 +1,39 @@
+# Banger Shorts Script — vertical scripts engineered for the swipe
+
+Short-form lives or dies in the first 1–3 seconds (a weak open = swipe-away = the algorithm stops pushing it). Every word earns the next. Design for muted autoplay, for the loop, and for one single takeaway.
+
+## Freshness gate
+
+Before applying a platform benchmark, algorithm claim, policy, feature-availability statement, or numeric performance claim from this skill or the platform playbook, check `references/research/source-ledger.md` for non-expired support. If support is missing or past its review date, run `references/procedures/banger-research.md`, qualify the claim as unverified, or omit it. Never present a legacy value as current truth.
+## Load first
+- `references/frameworks/voice-and-audience.md` (the creator's own defined audience — ask once if it isn't set) + `references/frameworks/hooks-bank.md` (the opener).
+- `references/creators/fireship.md` (density / no dead air) + `references/creators/matt-pocock.md` (one concept, show-don't-tell).
+- `references/platforms/platform-playbook.md` §2–4 (Shorts / TikTok / Reels specs, safe zones, ideal length, SEO, sound rules). Confirm which platform(s) — the specs and audio rules differ.
+
+## The short-form structure
+1. **Hook (0–3s) — the most important line.** State the payoff, the promise, or the pattern-break immediately. Put the topic keyword in the FIRST spoken line (speech-to-text SEO) and as bold on-screen text (OCR SEO). No intro, no "hey guys."
+2. **Deliver ONE thing (3–45s).** A single trick, tip, comparison, or reveal — shown, not described. Fast, tight, zero filler. If it needs two ideas, it's two Shorts.
+3. **The loop / payoff (final 2–3s).** Close the loop so it can replay seamlessly (each loop = a view + an engagement signal). End on the result or a line that sends them back to the top.
+4. **CTA (optional, light).** One line max — a question for comments, or "follow for more [specific thing]."
+
+## Writing rules
+- **Ideal length:** TikTok 21–34s, Reels 15–90s, Shorts 15–45s — go longer only if you can hold completion. Aim for the tightest cut that still lands the point.
+- **Caption everything** — 30%+ watch muted. Provide burned-in on-screen text for every line.
+- **Keep text in the safe zone** — out of the top bar and the bottom caption/CTA area and the right-side button rail (exact px in the platform playbook). Note this in the visual cues.
+- **Density** — one idea per sentence, no dead air, visual change every 1–5 seconds.
+- **Standalone** — a Short cut from a long video must have its OWN fresh hook and make sense with zero context (Shorts are decoupled from long-form now).
+
+## Output format
+For each Short, deliver:
+- **HOOK** (the exact first line + the on-screen text for it).
+- **SCRIPT** — line-by-line narration with **[on-screen text]** and **[visual/B-roll]** cues and rough timestamps.
+- **CAPTION** — the post caption with the keyword front-loaded + 3–5 hashtags (broad + niche).
+- **SOUND** — note to add a native trending audio on each platform (and that TikTok sounds don't transfer to Reels — swap per platform).
+- **LOOP NOTE** — how the end connects back to the start.
+If producing for multiple platforms, give each its own hook/first-frame and caption (don't ship one file everywhere — duplicate detection weights the first ~0.5s). Batch: offer to generate 3–5 variants from one idea.
+
+## Living writing gate
+
+Read `references/frameworks/writing-quality.md` before drafting. Apply creator-specific constraints and treat detector results as weak evidence.
+## Quality bar
+Confirm the hook works in 3 seconds with sound off, the Short teaches/reveals exactly one thing, text sits inside the safe zone, and it loops. If it drags, cut it shorter.

--- a/Community/bangers/references/procedures/banger-threads.md
+++ b/Community/bangers/references/procedures/banger-threads.md
@@ -1,0 +1,38 @@
+# Banger Threads — X / Bluesky posts that get replied to and reposted
+
+On X, replies are weighted ~13–27× a like and reposts ~20×; the first 15 minutes decide virality; links in the main post cut reach 50–90%. On Bluesky, conversation momentum (replies/quotes) drives the Discover feed. So: write for conversation, front-load the hook, keep links out of the lead post.
+
+## Freshness gate
+
+Before applying a platform benchmark, algorithm claim, policy, feature-availability statement, or numeric performance claim from this skill or the platform playbook, check `references/research/source-ledger.md` for non-expired support. If support is missing or past its review date, run `references/procedures/banger-research.md`, qualify the claim as unverified, or omit it. Never present a legacy value as current truth.
+## Load first
+- `references/creators/matt-pocock.md` (one-concept posts, curiosity-gap hooks, show-don't-tell, the evergreen mega-thread) — the primary model for teaching threads.
+- `references/creators/theo.md` (controversial-but-defensible hot takes, steelman + verdict) — for opinion posts.
+- `references/frameworks/hooks-bank.md` (text-post hooks) + `references/frameworks/voice-and-audience.md` (the creator's own defined audience — ask once if it isn't set).
+- `references/platforms/platform-playbook.md` §5 (X) and §8 (Bluesky) — limits, weights, link rules, cadence.
+
+## Two core formats
+**A. The teaching thread / single tip (Pocock).** Isolate ONE insight. Post 1 = a curiosity-gap hook (a number + a promise; the answer NOT given away). Middle posts = one step/point each, each with the actual proof shown (a screenshot of the real result, a before/after). Final post = the payoff + a question or soft CTA. If it's evergreen, frame it as a living thread you'll keep adding to.
+
+**B. The hot take / reaction (Theo).** Lead with the claim. Back it with real experience/reasoning. Steelman the other side, then land a clear verdict. Stay on the "controversial but defensible" line — attack the idea, not people; be correctable. Defensibility test: could a smart person agree after hearing your reasoning? If it only works on people who don't know the topic, it's ragebait — cut it.
+
+## Writing rules
+- **First line is the whole hook** — only ~280 chars render before "Show more" (X) and Bluesky posts are 300 chars hard. Front-load the payoff.
+- **One idea per post.** If a post needs "and also," split it.
+- **Invite replies** — end on a genuine question; be ready to reply to your own thread in the first 15–30 min (replies are the top signal).
+- **Links go in a reply, never the lead post.** State this explicitly in the output.
+- **0–1 hashtag on X** (3+ trips spam filters); **2–3 on Bluesky** (they route into topic feeds).
+- **Bluesky ≠ X** — don't hand over a verbatim cross-post; conversational reframes perform better. Note this if producing for both.
+- Write to the audience's level (per voice-and-audience.md): define in plain English any term they wouldn't know; make the reader feel capable.
+
+## Output format
+- For a thread: number each post (1/, 2/…), keep each within the character limit, mark where a **[screenshot/image]** or **[attached clip]** goes, and put any **[link → in a reply]** at the end.
+- For single posts: give 3–5 variants (mix teaching + hot-take + curiosity engines).
+- Add a one-line note on best posting time / that the first-15-min reply push matters.
+- If adapting for both X and Bluesky, provide a distinct version for each.
+
+## Living writing gate
+
+Read `references/frameworks/writing-quality.md` before drafting. Apply creator-specific constraints and treat detector results as weak evidence.
+## Quality bar
+Confirm: post 1 stops the scroll on its own, exactly one idea per post, a real reason to reply, no link in the lead, and (for hot takes) it passes the defensibility test.

--- a/Community/bangers/references/research/creator-research-protocol.md
+++ b/Community/bangers/references/research/creator-research-protocol.md
@@ -1,0 +1,39 @@
+# Creator research protocol
+
+BANGERS stays current through evidence, not vibes.
+
+## Research unit
+
+Every research pass begins with one decision question, such as:
+
+- What makes this creator's first 30 seconds retain attention?
+- Which LinkedIn openings consistently earn thoughtful comments?
+- Has a platform changed a documented format or distribution rule?
+- Which signs make otherwise accurate AI-assisted writing feel synthetic?
+
+## Evidence ladder
+
+Prefer, in order:
+
+1. The creator's published work and direct explanation of their process.
+2. Official platform documentation, release notes, and engineering posts.
+3. Repeated observable patterns across dated examples.
+4. Credible interviews, analyses, and experiments with disclosed methods.
+5. Anecdotes and detector scores, used only as prompts for investigation.
+
+## Adoption gate
+
+A candidate mechanic needs:
+
+- at least three dated examples unless explicitly marked experimental;
+- an explanation of the behavior it changes;
+- a counterexample or failure condition;
+- a test on a real source artifact;
+- a bounded edit to one or more playbooks;
+- a review date for facts likely to drift.
+
+Use `observed`, `inferred`, and `unknown` labels. Never turn correlation into a platform law.
+
+## Ethical boundary
+
+Study structure, sequencing, framing, editing, and audience mechanics. Do not reproduce signature wording, private material, distinctive jokes, or a living creator's voice. The output must remain attributable to its actual author.

--- a/Community/bangers/references/research/detector-runs.md
+++ b/Community/bangers/references/research/detector-runs.md
@@ -1,0 +1,13 @@
+# Detector run receipts
+
+Use this public ledger only for scrubbed test samples. Store private or unpublished drafts in a private overlay.
+
+| Date | Input ID or hash | Service and version | Result | Highlighted passage locator | Mapped writing defect | Revision | Rerun result |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+
+## Rules
+
+- Use detector results as weak adversarial evidence, not proof of authorship.
+- Never alter a true, clear, author-authentic passage only to improve a score.
+- Record `not run` when the creator profile requires a panel but no detector is accessible.
+- Stop after at most two detector-led passes.

--- a/Community/bangers/references/research/source-ledger.md
+++ b/Community/bangers/references/research/source-ledger.md
@@ -1,0 +1,16 @@
+# BANGERS source ledger
+
+Append compact entries here when research changes or challenges a playbook. Detailed notes may live elsewhere, but every adopted mechanic needs a traceable row.
+
+| Observed | Published | Source | Surface | Claim or observation | Evidence type | Confidence | Affected playbook | Review by |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 2026-07-25 | n/a | Initial system contract | suite | Future research must use dated, traceable evidence and a bounded adoption gate | operating decision | high | all | 2026-10-25 |
+| 2026-07-25 | mixed 2025-2026 claims | `references/platforms/platform-playbook.md` | all platforms | Existing numeric benchmarks, algorithm claims, policies, and feature availability have not yet been audited into this ledger | legacy inventory | experimental | platform playbook | now |
+
+## Entry rules
+
+- Link to the exact source or use a stable local locator.
+- Say what was observed, not what you hoped to prove.
+- Use `high`, `medium`, `low`, or `experimental` confidence.
+- Add a review date to platform facts and other drift-prone claims.
+- Never put private audience, client, health, financial, or unpublished business data here.

--- a/Community/bangers/scripts/check-writing.mjs
+++ b/Community/bangers/scripts/check-writing.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+
+const args = process.argv.slice(2);
+const allowedOptions = new Set(["--no-em-dash"]);
+const unknownOptions = args.filter((arg) => arg.startsWith("--") && !allowedOptions.has(arg));
+if (unknownOptions.length > 0) {
+  console.error(`writing-check: unknown option(s): ${unknownOptions.join(", ")}`);
+  process.exit(2);
+}
+const noEmDash = args.includes("--no-em-dash");
+const files = args.filter((arg) => !arg.startsWith("--"));
+if (files.length === 0) {
+  console.error("writing-check: pass one or more UTF-8 file paths; piped text can lose punctuation in Windows PowerShell");
+  process.exit(2);
+}
+const text = files.map((file) => fs.readFileSync(file, "utf8")).join("\n");
+
+const findings = [];
+if (noEmDash && text.includes("\u2014")) {
+  findings.push({ severity: "error", rule: "no-em-dash", count: text.split("\u2014").length - 1 });
+}
+
+const softPatterns = [
+  ["fast-paced-world", /in today['’]s fast-paced world/gi],
+  ["not-just-but", /not just\b[^.!?]{0,100}\bbut\b/gi],
+  ["experts-agree", /experts agree/gi],
+  ["delve", /\bdelve(?:s|d)?\b/gi],
+  ["game-changer", /\bgame[- ]changer\b/gi],
+  ["unlock-potential", /\bunlock(?:ing|s|ed)? (?:the |your )?potential\b/gi]
+];
+for (const [rule, pattern] of softPatterns) {
+  const matches = text.match(pattern);
+  if (matches) findings.push({ severity: "warning", rule, count: matches.length });
+}
+
+if (findings.length === 0) {
+  console.log("writing-check: clean");
+  process.exit(0);
+}
+for (const finding of findings) {
+  console.log(`${finding.severity}: ${finding.rule} (${finding.count})`);
+}
+process.exit(findings.some((finding) => finding.severity === "error") ? 1 : 0);


### PR DESCRIPTION
A social-media content system for creators: what to post, hooks, titles and thumbnails, YouTube and short-form scripts, X/Bluesky threads, LinkedIn and newsletter posts, carousels, DaVinci/OBS edit plans, multiplatform repurposing, and an authenticity and AI-disclosure check.

## Structure

Twelve procedures live under `references/procedures/` and load one at a time, so only the ~5 KB router in `SKILL.md` stays in context. The procedures alone are 62 KB and the reference library another 108 KB, so progressive loading is doing real work here.

```
bangers/
├── SKILL.md              # router
├── DISPLAY.json
├── references/
│   ├── procedures/       # the 12 procedures
│   ├── creators/         # public creator playbooks
│   ├── frameworks/       # voice, writing quality, technical clarity, hooks
│   ├── platforms/        # per-platform specs and behavior
│   └── research/         # dated source ledger, research protocol
└── scripts/
    └── check-writing.mjs # deterministic writing checker
```

## Two things that may be useful beyond this skill

**A source ledger.** Platform claims carry a dated entry with a review date. Once support expires, the procedures treat the claim as unverified and research it rather than repeating a stale number as current truth.

**`references/frameworks/technical-clarity.md`.** A writing standard adapted from [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/) and Orwell's six rules, applied as a frame/payload split: the author's voice keeps the hook, story, and judgment, while explanation passages take one name per concept, one idea per sentence, and active voice. Applying a controlled-language standard to a whole piece produces something correct and unreadable, which is the mistake the split exists to prevent.

The accompanying `banger-detector` procedure treats AI detector scores as weak evidence and refuses to chase them. Detectors largely measure predictability, and clean technical writing is predictable by design, so following the clarity standard tends to raise a detector score while improving the writing.

## Validation

`bun validate` reports no issues for this skill. The 15 warnings it prints are pre-existing and all in `External/`.

MIT licensed. Source and updates: https://github.com/Jeff-Kazzee/bangers