### PR TITLE
Add HOL Guard runtime safety skill

### DIFF
--- a/Community/hol-guard/DISPLAY.json
+++ b/Community/hol-guard/DISPLAY.json
@@ -1,0 +1,5 @@
+{
+  "specVersion": "0.2.0",
+  "icon": "shield-check",
+  "tags": ["security", "developer-tools", "ai-agents"]
+}

--- a/Community/hol-guard/SKILL.md
+++ b/Community/hol-guard/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: hol-guard
+description: Protect supported local coding-agent runtimes with HOL Guard before mutation-bearing tool work.
+compatibility: Created for Zo Computer
+metadata:
+  author: Hashgraph Online
+  category: Community
+---
+
+# HOL Guard Runtime Safety
+
+Use HOL Guard as a local safety boundary before a supported coding agent performs mutation-bearing tool work. Keep repository review, provider permissions, sandboxing, and remote service controls authoritative.
+
+## Set up the reviewed runtime
+
+Check whether HOL Guard is already available:
+
+```bash
+hol-guard --version
+```
+
+If it is unavailable and installing tools is authorized, install the reviewed stable release used by this skill:
+
+```bash
+uv tool install "hol-guard[cisco]==2.2.128"
+hol-guard --version
+```
+
+Require the version check to report `2.2.128`. Do not silently replace the pin with `latest`, a branch URL, or an unversioned package. If `uv` is unavailable or installation is not authorized, stop and report the missing prerequisite instead of continuing unprotected.
+
+## Detect a supported harness
+
+Ask HOL Guard for the exact harness identifier:
+
+```bash
+hol-guard detect --json
+```
+
+Use only a supported identifier returned by `detect`. Do not maintain a separate alias list or assume that an arbitrary agent runtime is covered.
+
+## Protect the harness
+
+Run the HOL Guard-owned setup and verification flow:
+
+```bash
+hol-guard bootstrap
+hol-guard install <detected-harness>
+hol-guard run <detected-harness> --dry-run
+hol-guard doctor <detected-harness> --json
+hol-guard status --json
+```
+
+Before real mutation-bearing work, launch the supported harness through Guard rather than directly:
+
+```bash
+hol-guard run <detected-harness>
+```
+
+Treat an unprotected fallback as failure. If installation, dry-run, doctor, or status cannot prove the expected protection state, stop mutation-bearing tool work and report the failing command.
+
+## Review Guard decisions
+
+When Guard blocks or queues work, inspect the actual request and evidence before deciding what to do:
+
+```bash
+hol-guard approvals
+hol-guard approvals open
+hol-guard receipts
+hol-guard events
+```
+
+Approve or deny only through Guard-owned commands after reviewing the risk reason and requested scope. Do not bypass a Guard decision by editing the protected harness configuration manually.
+
+## Boundary
+
+HOL Guard protects supported local agent runtimes. It does not replace repository policy, code review, operating-system isolation, application authorization, provider-side access controls, or remote services' own safety checks.

--- a/Community/hol-guard/SKILL.md
+++ b/Community/hol-guard/SKILL.md
@@ -64,12 +64,12 @@ When Guard blocks or queues work, inspect the actual request and evidence before
 
 ```bash
 hol-guard approvals
-hol-guard approvals open
+hol-guard approvals open <request-id>
 hol-guard receipts
 hol-guard events
 ```
 
-Approve or deny only through Guard-owned commands after reviewing the risk reason and requested scope. Do not bypass a Guard decision by editing the protected harness configuration manually.
+Use the pending request ID returned by `hol-guard approvals` when opening a specific approval. Approve or deny only through Guard-owned commands after reviewing the risk reason and requested scope. Do not bypass a Guard decision by editing the protected harness configuration manually.
 
 ## Boundary
 


### PR DESCRIPTION
Adds a Community `hol-guard` skill for installing and using the actual HOL Guard runtime before mutation-bearing work in supported local coding-agent harnesses.

The skill uses the reviewed stable pin `hol-guard[cisco]==2.2.128`, resolves harness support through `hol-guard detect --json`, uses Guard-owned install/dry-run/doctor/status flows, and explicitly fails closed rather than suggesting an unprotected fallback. `DISPLAY.json` follows the repository's 0.2.0 presentation schema.

I could not run the repository's Bun validator locally from this automation environment because outbound DNS is unavailable there; the repository's `Validate Skills` pull-request workflow runs the same `bun validate` contract on this PR. I will address any actionable validator/review failure without claiming a local test I could not perform.